### PR TITLE
ci: install libsecret-1-dev for the Linux build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,10 @@ jobs:
       - name: Install desktop dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev
+          # libsecret-1-dev is not part of Flutter's generic desktop list: it is
+          # flutter_secure_storage_linux's own dependency, and the session token
+          # lives in libsecret, so it is not optional here.
+          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev libsecret-1-dev
       - run: flutter pub get
       - run: flutter build linux --release
       - uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ The design this repository was built from is at
   **and the C++ ATL component**. Without ATL the build fails on `atlstr.h`, which
   `flutter_secure_storage_windows` includes.
 - **Linux** — `clang`, `cmake`, `ninja-build`, `pkg-config`, `libgtk-3-dev`, `liblzma-dev`,
-  `libstdc++-12-dev`.
+  `libstdc++-12-dev`, and `libsecret-1-dev`. The last is `flutter_secure_storage_linux`'s own
+  dependency rather than part of Flutter's generic desktop list, and the build fails without it.
 - **Android** — the Android SDK including `cmdline-tools`, the API 37 platform
   (`sdkmanager --install "platforms;android-37.0"`), accepted SDK licences (`flutter doctor
   --android-licenses`), and JDK 17. The app sets `compileSdk = 37` because `flutter_secure_storage`

--- a/docs/requirements/Operations & Infrastructure Document.md
+++ b/docs/requirements/Operations & Infrastructure Document.md
@@ -61,7 +61,7 @@ flutter run --dart-define-from-file=config/local.json
 | All | Flutter 3.44.9 or newer on the stable channel |
 | Web | A Chromium-based browser for `flutter run -d chrome` |
 | Windows | Visual Studio (or Build Tools) with the *Desktop development with C++* workload **and the C++ ATL component** |
-| Linux | `clang`, `cmake`, `ninja-build`, `pkg-config`, `libgtk-3-dev`, `liblzma-dev`, `libstdc++-12-dev` |
+| Linux | `clang`, `cmake`, `ninja-build`, `pkg-config`, `libgtk-3-dev`, `liblzma-dev`, `libstdc++-12-dev`, `libsecret-1-dev` |
 | Android | The Android SDK including `cmdline-tools`, the **API 37 platform** (`platforms;android-37.0`), accepted SDK licences, and JDK 17 |
 
 > **The Windows ATL component is not optional.** `flutter_secure_storage_windows`, which holds the
@@ -85,7 +85,7 @@ flutter run --dart-define-from-file=config/local.json
 On Debian or Ubuntu:
 
 ```bash
-sudo apt-get update && sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev
+sudo apt-get update && sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev libsecret-1-dev
 ```
 
 Confirm the toolchain before building:
@@ -209,6 +209,7 @@ the default so that no deployment address is exposed in a public log.
 | The Google control never appears | No `HEIMDALL_GOOGLE_CLIENT_ID` was supplied at build time, or the scope has Google Sign-In switched off |
 | A deep link 404s in production but works locally | The static host is not falling back to `index.html` |
 | `flutter build linux` fails on a fresh machine | The apt packages in §3 are not installed |
+| `flutter build linux` fails with `required packages were not found: libsecret-1` | `libsecret-1-dev` is missing — it is a plugin dependency, not part of Flutter's generic desktop list |
 | `flutter build windows` fails with `Cannot open include file: 'atlstr.h'` | The C++ ATL component is missing from Visual Studio (see §3) |
 | `flutter build apk` fails after `flutter doctor` flags the Android toolchain | `cmdline-tools` is missing, or the SDK licences were never accepted (see §3) |
 | `flutter build apk` fails with `Failed to find target with hash string 'android-37'` | The API 37 platform is not installed — `sdkmanager --install "platforms;android-37.0"` |


### PR DESCRIPTION
Fixes the Linux job, which was the only one of the four to fail on `main` after #34.

## Root cause

```
The following required packages were not found:
 - libsecret-1>=0.18.4
Call Stack: flutter_secure_storage_linux/linux/CMakeLists.txt:15 (pkg_check_modules)
```

The Linux job installed Flutter's generic desktop dependency list — `clang`, `cmake`,
`ninja-build`, `pkg-config`, `libgtk-3-dev`, `liblzma-dev`, `libstdc++-12-dev` — which covers the
engine's own needs but not plugin-specific native dependencies. `flutter_secure_storage_linux`
declares `pkg_check_modules(LIBSECRET REQUIRED IMPORTED_TARGET libsecret-1>=0.18.4)`, and since
that plugin is what holds the session token, it is not optional.

The same omission was in the prerequisites list in the Operations document and the README, so
anyone setting up a Linux machine from the documentation would have hit it too. All three are
fixed, plus a troubleshooting row naming the exact CMake error.

This is the Linux counterpart of the Windows ATL problem — the same plugin, the same class of
missing native dependency. It was predictable from that one, and worth remembering the next time a
plugin is added.

## Verification

`Build` dispatched against this branch —
[run 31707977649](https://github.com/artur-rios/heimdall-ui/actions/runs/31707977649) — all four
targets green:

| Target | Result |
| --- | --- |
| Web | success |
| Linux | success |
| Windows | success |
| Android | success |

`libsecret-1-dev` resolves to 0.20.5 on Ubuntu, comfortably above the required 0.18.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)