### PR TITLE
docs: link the public delivery board

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,11 @@ the platform work that is not itself a use case. Each one ships on its own branc
 request — see the
 [Development Workflow Document](docs/requirements/Development%20Workflow%20Document.md).
 
+The same work is on the public board at
+[Heimdall UI Delivery](https://github.com/users/artur-rios/projects/11), which carries the
+`Todo → In Progress → Testing → Done` status of every issue. This table is the at-a-glance summary;
+the board is where an item's status changes as it moves.
+
 **Legend:** ✅ done and merged &nbsp;·&nbsp; 🚧 in progress &nbsp;·&nbsp; ⬜ not started
 
 ### Authentication & Session

--- a/docs/requirements/Development Workflow Document.md
+++ b/docs/requirements/Development Workflow Document.md
@@ -43,6 +43,10 @@ flowchart TD
 
 ## 3. Issue status lifecycle
 
+Each use case is tracked by its GitHub issue on the
+[Heimdall UI Delivery board](https://github.com/users/artur-rios/projects/11), whose `Status` field
+carries these values, in order:
+
 | Order | Status | Set when |
 | --- | --- | --- |
 | 1 | **Todo** | The use case has not been started (default). |


### PR DESCRIPTION
Points the README tracker and the Development Workflow Document's status lifecycle at the new public
project board, [Heimdall UI Delivery](https://github.com/users/artur-rios/projects/11).

The board is linked to this repository, carries all 33 issues, and its `Status` field was extended
from the default `Todo / In Progress / Done` to the four values the workflow document actually
defines — `Todo → In Progress → Testing → Done` — so the board and the document agree.

Documentation only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)