### PR TITLE
UI-01: Login

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ the board is where an item's status changes as it moves.
 
 | Use case | Status | Issue |
 | --- | --- | --- |
-| UI-01: Login | ⬜ | [#1](https://github.com/artur-rios/heimdall-ui/issues/1) |
+| UI-01: Login | ✅ | [#1](https://github.com/artur-rios/heimdall-ui/issues/1) |
 | UI-02: Complete two-factor challenge at login | ⬜ | [#2](https://github.com/artur-rios/heimdall-ui/issues/2) |
 | UI-03: Request password recovery | ⬜ | [#3](https://github.com/artur-rios/heimdall-ui/issues/3) |
 | UI-04: Reset password | ⬜ | [#4](https://github.com/artur-rios/heimdall-ui/issues/4) |

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -25,7 +25,8 @@ const Set<String> publicRoutes = <String>{
 /// Pure on purpose: the whole guard is then testable without a widget tree,
 /// which is where its edge cases actually live.
 String? redirectFor({required SessionState session, required String location}) {
-  final path = Uri.parse(location).path;
+  final uri = Uri.parse(location);
+  final path = uri.path;
   final isPublic = publicRoutes.contains(path);
 
   return switch (session) {
@@ -35,9 +36,27 @@ String? redirectFor({required SessionState session, required String location}) {
     Challenged() => path == '/login/two-factor' ? null : '/login/two-factor',
     Unauthenticated() when isPublic => null,
     Unauthenticated() => '/login?from=${Uri.encodeComponent(location)}',
-    Authenticated() when path == '/login' || path == '/login/two-factor' => '/',
+    Authenticated() when path == '/login' || path == '/login/two-factor' =>
+      _returnTo(uri.queryParameters['from']),
     Authenticated() => null,
   };
+}
+
+/// Where a freshly signed-in caller belongs: the screen they originally asked
+/// for, or the home screen.
+///
+/// Only a path within this application is honoured. A value that is absolute,
+/// protocol-relative, or a login route itself would either send the user off
+/// the application or straight back into the sign-in loop, so both fall back
+/// home rather than being followed.
+String _returnTo(String? from) {
+  if (from == null || !from.startsWith('/') || from.startsWith('//')) {
+    return '/';
+  }
+
+  final path = Uri.parse(from).path;
+
+  return (path == '/login' || path == '/login/two-factor') ? '/' : from;
 }
 
 final Provider<GoRouter> routerProvider = Provider<GoRouter>((ref) {

--- a/lib/features/auth/presentation/login_screen.dart
+++ b/lib/features/auth/presentation/login_screen.dart
@@ -1,14 +1,27 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/network/dio_client.dart';
 import '../../../core/result/result.dart';
 import 'session_controller.dart';
 
-/// The sign-in screen.
+/// What activating the Google sign-in control does.
 ///
-/// Deliberately minimal: UI-01 completes it with the Google control, the
-/// recovery link, and the rest of its alternative flows. What is here is what
-/// the shell needs to be reachable at all.
+/// UI-01 owns the control's placement and whether it is offered at all; the
+/// exchange behind it belongs to UI-06, which overrides this. Until then the
+/// control says so rather than failing silently.
+typedef GoogleSignInAction = Future<void> Function(BuildContext context);
+
+final Provider<GoogleSignInAction> googleSignInActionProvider =
+    Provider<GoogleSignInAction>(
+      (ref) => (context) async {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Google sign-in is not available yet.')),
+        );
+      },
+    );
+
+/// The sign-in screen.
 class LoginScreen extends ConsumerStatefulWidget {
   const LoginScreen({super.key});
 
@@ -53,8 +66,10 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
       _submitting = false;
       _failure = result.failureOrNull;
 
-      if (_failure != null) {
-        // Keep the address, drop the secret.
+      if (_failure case final Failure failure
+          when failure.kind != FailureKind.network) {
+        // AF-01a: keep the address, drop the secret. A transport failure is
+        // not a rejection, so the input survives it and Retry can resend.
         _password.clear();
       }
     });
@@ -84,8 +99,13 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                       style: theme.textTheme.bodyMedium,
                     ),
                     const SizedBox(height: 24),
-                    if (_failure != null) ...<Widget>[
-                      _ErrorBanner(failure: _failure!),
+                    if (_failure case final Failure failure) ...<Widget>[
+                      if (failure.kind == FailureKind.network)
+                        // AF-01d: nothing was rejected, so the only useful
+                        // action is to try the same submission again.
+                        _RetryBanner(onRetry: _submitting ? null : _submit)
+                      else
+                        _ErrorBanner(failure: failure),
                       const SizedBox(height: 16),
                     ],
                     TextFormField(
@@ -125,12 +145,64 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                             )
                           : const Text('Sign in'),
                     ),
+                    // AF-01e: the control the login screen offers alongside the
+                    // credentials form. AF-06a hides it entirely when the build
+                    // carries no Google client id.
+                    if (ref
+                        .watch(appConfigProvider)
+                        .isGoogleSignInConfigured) ...<Widget>[
+                      const SizedBox(height: 16),
+                      OutlinedButton.icon(
+                        onPressed: _submitting
+                            ? null
+                            : () =>
+                                  ref.read(googleSignInActionProvider)(context),
+                        icon: const Icon(Icons.account_circle_outlined),
+                        label: const Text('Continue with Google'),
+                      ),
+                    ],
                   ],
                 ),
               ),
             ),
           ),
         ),
+      ),
+    );
+  }
+}
+
+/// Says that the API could not be reached, and offers the only action that
+/// helps. The API returns no errors for a transport failure, so there is
+/// nothing of its own to render here.
+class _RetryBanner extends StatelessWidget {
+  const _RetryBanner({required this.onRetry});
+
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: scheme.errorContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(
+            'Could not reach the API. Check your connection and try again.',
+            style: TextStyle(color: scheme.onErrorContainer),
+          ),
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: TextButton(onPressed: onRetry, child: const Text('Retry')),
+          ),
+        ],
       ),
     );
   }

--- a/test/app/heimdall_app_test.dart
+++ b/test/app/heimdall_app_test.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:heimdall_ui/app/heimdall_app.dart';
+import 'package:heimdall_ui/core/config/app_config.dart';
+import 'package:heimdall_ui/core/network/dio_client.dart';
 import 'package:heimdall_ui/core/result/result.dart';
 import 'package:heimdall_ui/core/storage/token_store.dart';
 import 'package:heimdall_ui/features/auth/domain/auth_repository.dart';
@@ -30,6 +32,11 @@ void main() {
   Future<void> pumpApp(WidgetTester tester) async {
     final container = ProviderContainer(
       overrides: <Override>[
+        // The sign-in screen asks the configuration whether to offer the
+        // Google control, so the whole app needs one to render.
+        appConfigProvider.overrideWithValue(
+          const AppConfig(apiBaseUrl: 'http://localhost:5000'),
+        ),
         tokenStoreProvider.overrideWithValue(store),
         authRepositoryProvider.overrideWithValue(repository),
       ],

--- a/test/app/router_test.dart
+++ b/test/app/router_test.dart
@@ -91,6 +91,39 @@ void main() {
     expect(redirect, '/');
   });
 
+  test('GivenAuthenticated_WhenLoginCarriesAFrom_ThenRedirectsToIt', () {
+    // Given / When
+    final redirect = redirectFor(
+      session: authenticated,
+      location: '/login?from=%2Fscopes%2Fabc',
+    );
+
+    // Then
+    expect(redirect, '/scopes/abc');
+  });
+
+  test('GivenAuthenticated_WhenFromPointsAtLogin_ThenRedirectsHome', () {
+    // Given / When
+    final redirect = redirectFor(
+      session: authenticated,
+      location: '/login?from=%2Flogin%2Ftwo-factor',
+    );
+
+    // Then
+    expect(redirect, '/');
+  });
+
+  test('GivenAuthenticated_WhenFromIsAbsolute_ThenRedirectsHome', () {
+    // Given / When
+    final redirect = redirectFor(
+      session: authenticated,
+      location: '/login?from=https%3A%2F%2Felsewhere.example.com%2Fsteal',
+    );
+
+    // Then
+    expect(redirect, '/');
+  });
+
   test('GivenAuthenticated_WhenVisitingPrivateRoute_ThenNoRedirect', () {
     // Given / When
     final redirect = redirectFor(session: authenticated, location: '/scopes');

--- a/test/features/auth/data/auth_repository_impl_test.dart
+++ b/test/features/auth/data/auth_repository_impl_test.dart
@@ -1,0 +1,210 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdall_api_client/export.dart';
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/features/auth/data/auth_repository_impl.dart';
+import 'package:heimdall_ui/features/auth/domain/auth_repository.dart';
+
+void main() {
+  late Dio dio;
+  late ApiAuthRepository repository;
+
+  ApiAuthRepository repositoryAnswering(_Answer answer) {
+    dio.httpClientAdapter = _StubAdapter(answer);
+
+    return ApiAuthRepository(AuthClient(dio));
+  }
+
+  setUp(() {
+    dio = Dio(BaseOptions(baseUrl: 'https://example.invalid'));
+  });
+
+  test('GivenTokenResponse_WhenLoggingIn_ThenLoggedInIsReturned', () async {
+    // Given
+    repository = repositoryAnswering(
+      _Answer(
+        status: 200,
+        body: <String, dynamic>{
+          'success': true,
+          'errors': <String>[],
+          'data': <String, dynamic>{
+            'token': 'jwt',
+            'expiresAt': '2030-01-01T00:00:00Z',
+            'requiresTwoFactor': false,
+          },
+        },
+      ),
+    );
+
+    // When
+    final result = await repository.login(email: 'a@b.c', password: 'secret');
+
+    // Then
+    expect(result.valueOrNull, isA<LoggedIn>());
+    expect((result.valueOrNull! as LoggedIn).token.value, 'jwt');
+  });
+
+  // AF-01c — the API answers with a challenge instead of a token.
+  test(
+    'GivenTwoFactorResponse_WhenLoggingIn_ThenTwoFactorRequiredIsReturned',
+    () async {
+      // Given
+      repository = repositoryAnswering(
+        _Answer(
+          status: 200,
+          body: <String, dynamic>{
+            'success': true,
+            'errors': <String>[],
+            'data': <String, dynamic>{
+              'requiresTwoFactor': true,
+              'challengeToken': 'challenge',
+              'availableMethods': <String>['Totp', 'Email'],
+            },
+          },
+        ),
+      );
+
+      // When
+      final result = await repository.login(email: 'a@b.c', password: 'secret');
+
+      // Then
+      final outcome = result.valueOrNull;
+      expect(outcome, isA<TwoFactorRequired>());
+      expect((outcome! as TwoFactorRequired).challengeToken, 'challenge');
+      expect((outcome as TwoFactorRequired).availableMethods, <String>[
+        'Totp',
+        'Email',
+      ]);
+    },
+  );
+
+  // AF-01a — an unsuccessful envelope carries the reason in `errors`.
+  test(
+    'GivenRejectedEnvelope_WhenLoggingIn_ThenApiErrorsAreReturned',
+    () async {
+      // Given
+      repository = repositoryAnswering(
+        _Answer(
+          status: 200,
+          body: <String, dynamic>{
+            'success': false,
+            'errors': <String>['Invalid email or password.'],
+            'data': null,
+          },
+        ),
+      );
+
+      // When
+      final result = await repository.login(email: 'a@b.c', password: 'wrong');
+
+      // Then
+      expect(result.failureOrNull?.errors, <String>[
+        'Invalid email or password.',
+      ]);
+    },
+  );
+
+  // AF-01a — the API answers 401 for every rejection, body and all.
+  test(
+    'GivenUnauthorizedStatus_WhenLoggingIn_ThenApiErrorsAreReturned',
+    () async {
+      // Given
+      repository = repositoryAnswering(
+        _Answer(
+          status: 401,
+          body: <String, dynamic>{
+            'success': false,
+            'errors': <String>['Invalid credentials.'],
+          },
+        ),
+      );
+
+      // When
+      final result = await repository.login(email: 'a@b.c', password: 'wrong');
+
+      // Then
+      expect(result.failureOrNull?.kind, FailureKind.unauthorized);
+      expect(result.failureOrNull?.errors, <String>['Invalid credentials.']);
+    },
+  );
+
+  // AF-01d — the API could not be reached at all.
+  test(
+    'GivenTransportFailure_WhenLoggingIn_ThenNetworkFailureIsReturned',
+    () async {
+      // Given
+      repository = repositoryAnswering(const _Answer(status: 0));
+
+      // When
+      final result = await repository.login(email: 'a@b.c', password: 'secret');
+
+      // Then
+      expect(result.failureOrNull?.kind, FailureKind.network);
+    },
+  );
+
+  // A successful envelope that carries neither a token nor a challenge.
+  test('GivenIncompleteEnvelope_WhenLoggingIn_ThenFailureIsReturned', () async {
+    // Given
+    repository = repositoryAnswering(
+      _Answer(
+        status: 200,
+        body: <String, dynamic>{
+          'success': true,
+          'errors': <String>[],
+          'data': <String, dynamic>{'requiresTwoFactor': false},
+        },
+      ),
+    );
+
+    // When
+    final result = await repository.login(email: 'a@b.c', password: 'secret');
+
+    // Then
+    expect(result.failureOrNull, isNotNull);
+  });
+}
+
+/// What the stub answers with. A [status] of zero stands for a connection that
+/// never got as far as a response.
+class _Answer {
+  const _Answer({required this.status, this.body});
+
+  final int status;
+  final Map<String, dynamic>? body;
+}
+
+/// Answers from memory, so no test reaches the network.
+class _StubAdapter implements HttpClientAdapter {
+  _StubAdapter(this._answer);
+
+  final _Answer _answer;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    if (_answer.status == 0) {
+      throw DioException.connectionError(
+        requestOptions: options,
+        reason: 'No route to host',
+      );
+    }
+
+    return ResponseBody.fromString(
+      jsonEncode(_answer.body),
+      _answer.status,
+      headers: <String, List<String>>{
+        Headers.contentTypeHeader: <String>[Headers.jsonContentType],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}

--- a/test/features/auth/data/auth_repository_impl_test.dart
+++ b/test/features/auth/data/auth_repository_impl_test.dart
@@ -25,7 +25,7 @@ void main() {
   test('GivenTokenResponse_WhenLoggingIn_ThenLoggedInIsReturned', () async {
     // Given
     repository = repositoryAnswering(
-      _Answer(
+      const _Answer(
         status: 200,
         body: <String, dynamic>{
           'success': true,
@@ -53,7 +53,7 @@ void main() {
     () async {
       // Given
       repository = repositoryAnswering(
-        _Answer(
+        const _Answer(
           status: 200,
           body: <String, dynamic>{
             'success': true,
@@ -87,7 +87,7 @@ void main() {
     () async {
       // Given
       repository = repositoryAnswering(
-        _Answer(
+        const _Answer(
           status: 200,
           body: <String, dynamic>{
             'success': false,
@@ -113,7 +113,7 @@ void main() {
     () async {
       // Given
       repository = repositoryAnswering(
-        _Answer(
+        const _Answer(
           status: 401,
           body: <String, dynamic>{
             'success': false,
@@ -150,7 +150,7 @@ void main() {
   test('GivenIncompleteEnvelope_WhenLoggingIn_ThenFailureIsReturned', () async {
     // Given
     repository = repositoryAnswering(
-      _Answer(
+      const _Answer(
         status: 200,
         body: <String, dynamic>{
           'success': true,

--- a/test/features/auth/presentation/login_screen_test.dart
+++ b/test/features/auth/presentation/login_screen_test.dart
@@ -1,0 +1,286 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdall_ui/app/theme.dart';
+import 'package:heimdall_ui/core/config/app_config.dart';
+import 'package:heimdall_ui/core/network/dio_client.dart';
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/core/storage/token_store.dart';
+import 'package:heimdall_ui/features/auth/domain/auth_repository.dart';
+import 'package:heimdall_ui/features/auth/presentation/login_screen.dart';
+import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockAuthRepository extends Mock implements AuthRepository {}
+
+/// A token whose payload names a User, which is all the screen's flows need.
+const String _jwt =
+    'header.'
+    'eyJzdWIiOiJpZCIsImVtYWlsIjoiYUBiLmMiLCJyb2xlIjozfQ.'
+    'signature';
+
+void main() {
+  late _MockAuthRepository repository;
+  late InMemoryTokenStore store;
+
+  const withoutGoogle = AppConfig(apiBaseUrl: 'http://localhost:5000');
+  const withGoogle = AppConfig(
+    apiBaseUrl: 'http://localhost:5000',
+    googleClientId: 'client-id.apps.googleusercontent.com',
+  );
+
+  Future<void> pump(
+    WidgetTester tester, {
+    Size size = const Size(400, 900),
+    ThemeData? theme,
+    AppConfig config = withoutGoogle,
+  }) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          appConfigProvider.overrideWithValue(config),
+          authRepositoryProvider.overrideWithValue(repository),
+          tokenStoreProvider.overrideWithValue(store),
+        ],
+        child: MaterialApp(
+          theme: theme ?? buildLightTheme(),
+          home: const LoginScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> fillAndSubmit(
+    WidgetTester tester, {
+    String email = 'a@b.c',
+    String password = 'secret',
+  }) async {
+    await tester.enterText(find.byType(TextFormField).first, email);
+    await tester.enterText(find.byType(TextFormField).last, password);
+    await tester.tap(find.widgetWithText(FilledButton, 'Sign in'));
+    await tester.pumpAndSettle();
+  }
+
+  setUp(() {
+    repository = _MockAuthRepository();
+    store = InMemoryTokenStore();
+  });
+
+  testWidgets(
+    'GivenLoginScreen_WhenSubmittedWithValidInput_ThenControllerIsCalled',
+    (tester) async {
+      // Given
+      when(
+        () => repository.login(email: 'a@b.c', password: 'secret'),
+      ).thenAnswer(
+        (_) async => Success<LoginOutcome>(
+          LoggedIn(AuthToken(value: _jwt, expiresAt: DateTime.utc(2030))),
+        ),
+      );
+      await pump(tester);
+
+      // When
+      await fillAndSubmit(tester);
+
+      // Then
+      verify(
+        () => repository.login(email: 'a@b.c', password: 'secret'),
+      ).called(1);
+    },
+  );
+
+  // AF-01a — invalid credentials.
+  testWidgets('GivenRejectedLogin_WhenRendered_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    when(() => repository.login(email: 'a@b.c', password: 'secret')).thenAnswer(
+      (_) async => const FailureResult<LoginOutcome>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['Invalid email or password.'],
+        ),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await fillAndSubmit(tester);
+
+    // Then
+    expect(find.text('Invalid email or password.'), findsOneWidget);
+  });
+
+  // AF-01a — the address survives a rejection, the secret does not.
+  testWidgets('GivenRejectedLogin_WhenRendered_ThenEmailKeptAndPasswordClear', (
+    tester,
+  ) async {
+    // Given
+    when(() => repository.login(email: 'a@b.c', password: 'secret')).thenAnswer(
+      (_) async => const FailureResult<LoginOutcome>(
+        Failure(kind: FailureKind.validation, errors: <String>['Rejected.']),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await fillAndSubmit(tester);
+
+    // Then
+    final fields = tester.widgetList<TextField>(find.byType(TextField));
+    expect(fields.first.controller?.text, 'a@b.c');
+    expect(fields.last.controller?.text, isEmpty);
+  });
+
+  // AF-01b — client-side validation.
+  testWidgets('GivenEmptyPassword_WhenSubmitted_ThenNoRequestIsMade', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+
+    // When
+    await fillAndSubmit(tester, password: '');
+
+    // Then
+    verifyNever(
+      () => repository.login(
+        email: any(named: 'email'),
+        password: any(named: 'password'),
+      ),
+    );
+    expect(find.text('Enter your password.'), findsOneWidget);
+  });
+
+  // AF-01b — a malformed address is refused before a request is made.
+  testWidgets('GivenMalformedEmail_WhenSubmitted_ThenNoRequestIsMade', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+
+    // When
+    await fillAndSubmit(tester, email: 'not-an-address');
+
+    // Then
+    verifyNever(
+      () => repository.login(
+        email: any(named: 'email'),
+        password: any(named: 'password'),
+      ),
+    );
+    expect(find.text('Enter a valid email address.'), findsOneWidget);
+  });
+
+  // AF-01d — API unreachable.
+  testWidgets('GivenTransportFailure_WhenSubmitted_ThenRetryBannerIsShown', (
+    tester,
+  ) async {
+    // Given
+    when(() => repository.login(email: 'a@b.c', password: 'secret')).thenAnswer(
+      (_) async => const FailureResult<LoginOutcome>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await fillAndSubmit(tester);
+
+    // Then
+    expect(find.widgetWithText(TextButton, 'Retry'), findsOneWidget);
+  });
+
+  // AF-01d — the retry sends the same submission again.
+  testWidgets('GivenRetryBanner_WhenRetryTapped_ThenLoginIsAttemptedAgain', (
+    tester,
+  ) async {
+    // Given
+    when(() => repository.login(email: 'a@b.c', password: 'secret')).thenAnswer(
+      (_) async => const FailureResult<LoginOutcome>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
+    await pump(tester);
+    await fillAndSubmit(tester);
+
+    // When
+    await tester.tap(find.widgetWithText(TextButton, 'Retry'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => repository.login(email: 'a@b.c', password: 'secret'),
+    ).called(2);
+  });
+
+  // AF-01e — the Google control, offered only when the build configures it.
+  testWidgets('GivenGoogleClientId_WhenRendered_ThenGoogleControlIsOffered', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, config: withGoogle);
+
+    // Then
+    expect(find.text('Continue with Google'), findsOneWidget);
+  });
+
+  // AF-06a — no client id, no control at all.
+  testWidgets('GivenNoGoogleClientId_WhenRendered_ThenGoogleControlIsHidden', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Continue with Google'), findsNothing);
+  });
+
+  testWidgets('GivenCompactWidth_WhenRendered_ThenTheFormIsShown', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, size: const Size(400, 900));
+
+    // Then
+    expect(find.byType(TextFormField), findsNWidgets(2));
+    expect(find.widgetWithText(FilledButton, 'Sign in'), findsOneWidget);
+  });
+
+  testWidgets('GivenMediumWidth_WhenRendered_ThenTheFormIsShown', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, size: const Size(800, 900));
+
+    // Then
+    expect(find.byType(TextFormField), findsNWidgets(2));
+    expect(find.widgetWithText(FilledButton, 'Sign in'), findsOneWidget);
+  });
+
+  testWidgets('GivenExpandedWidth_WhenRendered_ThenTheFormIsShown', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, size: const Size(1400, 900));
+
+    // Then
+    expect(find.byType(TextFormField), findsNWidgets(2));
+    expect(find.widgetWithText(FilledButton, 'Sign in'), findsOneWidget);
+  });
+
+  testWidgets('GivenDarkTheme_WhenRendered_ThenTheFormIsShown', (tester) async {
+    // Given / When
+    await pump(tester, theme: buildDarkTheme(), config: withGoogle);
+
+    // Then
+    expect(find.text('Heimdall'), findsOneWidget);
+    expect(find.text('Continue with Google'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/test/features/auth/presentation/session_controller_test.dart
+++ b/test/features/auth/presentation/session_controller_test.dart
@@ -89,6 +89,32 @@ void main() {
     expect(await store.read(), isNull);
   });
 
+  // AF-01d — the API could not be reached; nothing about the session changes.
+  test(
+    'GivenTransportFailure_WhenSignedIn_ThenNetworkFailureIsReturned',
+    () async {
+      // Given
+      when(
+        () => repository.login(email: 'a@b.c', password: 'secret'),
+      ).thenAnswer(
+        (_) async => const FailureResult<LoginOutcome>(
+          Failure(kind: FailureKind.network, errors: <String>[]),
+        ),
+      );
+      final container = containerWith();
+
+      // When
+      final result = await container
+          .read(sessionControllerProvider.notifier)
+          .signIn(email: 'a@b.c', password: 'secret');
+
+      // Then
+      expect(result.failureOrNull?.kind, FailureKind.network);
+      expect(container.read(sessionControllerProvider), isA<Unauthenticated>());
+      expect(await store.read(), isNull);
+    },
+  );
+
   test(
     'GivenChallengedSession_WhenCodeAccepted_ThenSessionIsAuthenticated',
     () async {


### PR DESCRIPTION
Completes **UI-01: Login** — the main flow and every alternative flow.

Closes #1

## Flows implemented

| Flow | Behavior |
| --- | --- |
| Main | Credentials are submitted to `POST /api/auth/login`; the token is stored, the session established, and the caller returned to the screen they originally asked for — the `?from=` the guard itself writes — or home. |
| AF-01a | A rejection renders the API's `errors` array as returned, keeps the email, and clears the password. |
| AF-01b | An empty or malformed email, or an empty password, marks the field and makes no request. |
| AF-01c | `requiresTwoFactor` moves the session to `Challenged` and routes to `/login/two-factor` instead of establishing a session. |
| AF-01d | A transport failure shows a retryable banner and leaves the session untouched. The input survives, so *Retry* resends the same submission. |
| AF-01e | The Google sign-in control is offered alongside the credentials form, and hidden entirely when the build carries no client id (AF-06a). |

## Notable changes

- `redirectFor` now honours `?from=`. Only a path within the application is followed — an absolute or protocol-relative value, or a login route itself, falls back home rather than sending the user off the application or back into the sign-in loop.
- The password is no longer cleared on a transport failure. Clearing it made *Retry* silently fail validation, and FR-UX-07 requires input to be preserved when a request fails for transport reasons. AF-01a still clears it on a rejection.
- `googleSignInActionProvider` is the seam UI-06 (#6) overrides with the real exchange. Until then, activating the control says the feature is not available yet.
- `test/app/heimdall_app_test.dart` overrides `appConfigProvider`, which the sign-in screen now reads.

## Verification

```
dart format --set-exit-if-changed .   →  Formatted 265 files (0 changed)
flutter analyze                        →  No issues found!
flutter test                           →  88 tests, all passed
```

New tests: widget coverage for the screen (main flow, AF-01a, AF-01b, AF-01d, AF-01e, all three breakpoints, dark theme), repository coverage for the login envelope over a local `HttpClientAdapter`, and unit coverage for the transport-failure and return-path cases. No test reaches the network.

## Out of scope

`/login/two-factor` remains the "not available yet" screen until UI-02 (#2), and the Google exchange arrives with UI-06 (#6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)