### PR TITLE
UI-03: Request password recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ app.*.map.json
 # Generated package build output (the generated sources themselves are committed)
 /packages/*/.dart_tool/
 /packages/*/build/
+
+# Claude Code local settings
+.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ the board is where an item's status changes as it moves.
 | --- | --- | --- |
 | UI-01: Login | ✅ | [#1](https://github.com/artur-rios/heimdall-ui/issues/1) |
 | UI-02: Complete two-factor challenge at login | ✅ | [#2](https://github.com/artur-rios/heimdall-ui/issues/2) |
-| UI-03: Request password recovery | ⬜ | [#3](https://github.com/artur-rios/heimdall-ui/issues/3) |
+| UI-03: Request password recovery | ✅ | [#3](https://github.com/artur-rios/heimdall-ui/issues/3) |
 | UI-04: Reset password | ⬜ | [#4](https://github.com/artur-rios/heimdall-ui/issues/4) |
 | UI-05: Verify email and resend verification | ⬜ | [#5](https://github.com/artur-rios/heimdall-ui/issues/5) |
 | UI-06: Sign in and sign out with Google | ⬜ | [#6](https://github.com/artur-rios/heimdall-ui/issues/6) |

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import '../features/auth/domain/session.dart';
 import '../features/auth/presentation/login_screen.dart';
+import '../features/auth/presentation/password_recovery_screen.dart';
 import '../features/auth/presentation/session_controller.dart';
 import '../features/auth/presentation/two_factor_screen.dart';
 import '../features/home/presentation/home_screen.dart';
@@ -80,6 +81,10 @@ final Provider<GoRouter> routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/login/two-factor',
         builder: (context, state) => const TwoFactorScreen(),
+      ),
+      GoRoute(
+        path: '/password-recovery',
+        builder: (context, state) => const PasswordRecoveryScreen(),
       ),
     ],
     // Every screen beyond these two arrives with its own use case. Until then

--- a/lib/features/auth/data/auth_repository_impl.dart
+++ b/lib/features/auth/data/auth_repository_impl.dart
@@ -71,6 +71,31 @@ class ApiAuthRepository implements AuthRepository {
     }
   }
 
+  @override
+  Future<Result<void>> requestPasswordRecovery({required String email}) async {
+    try {
+      final response = await _client.authPasswordRecovery(
+        body: PasswordRecoveryCommand(email: email),
+      );
+
+      if (response.success != true) {
+        return FailureResult<void>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: response.errors ?? const <String>[],
+          ),
+        );
+      }
+
+      // Nothing from the response is read beyond its success. The API answers
+      // an unknown address exactly as it answers a known one, and reading any
+      // further would only invite the interface to tell them apart.
+      return const Success<void>(null);
+    } on DioException catch (error) {
+      return FailureResult<void>(failureFromDioException(error));
+    }
+  }
+
   /// Reads a login response, which answers one of two ways: a usable token, or
   /// a challenge that must be answered before a session exists.
   Result<LoginOutcome> _outcomeFrom(LoginCommandOutputDataOutput response) {

--- a/lib/features/auth/domain/auth_repository.dart
+++ b/lib/features/auth/domain/auth_repository.dart
@@ -43,4 +43,11 @@ abstract interface class AuthRepository {
     required String code,
     bool isRecoveryCode,
   });
+
+  /// Asks the API to mail a password reset link.
+  ///
+  /// Carries no result beyond success, deliberately: the API answers the same
+  /// way whether or not the address belongs to anyone, so there is nothing here
+  /// that could tell a caller which it was.
+  Future<Result<void>> requestPasswordRecovery({required String email});
 }

--- a/lib/features/auth/presentation/login_screen.dart
+++ b/lib/features/auth/presentation/login_screen.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../../core/network/dio_client.dart';
 import '../../../core/result/result.dart';
+import '../../../shared/widgets/failure_banner.dart';
 import 'session_controller.dart';
 
 /// What activating the Google sign-in control does.
@@ -103,9 +105,9 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                       if (failure.kind == FailureKind.network)
                         // AF-01d: nothing was rejected, so the only useful
                         // action is to try the same submission again.
-                        _RetryBanner(onRetry: _submitting ? null : _submit)
+                        RetryBanner(onRetry: _submitting ? null : _submit)
                       else
-                        _ErrorBanner(failure: failure),
+                        ErrorBanner(failure: failure),
                       const SizedBox(height: 16),
                     ],
                     TextFormField(
@@ -145,6 +147,15 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                             )
                           : const Text('Sign in'),
                     ),
+                    const SizedBox(height: 8),
+                    // UI-03 step 1: the recovery screen is reached from here,
+                    // which is the only place someone who cannot sign in is.
+                    TextButton(
+                      onPressed: _submitting
+                          ? null
+                          : () => context.go('/password-recovery'),
+                      child: const Text('Forgot your password?'),
+                    ),
                     // AF-01e: the control the login screen offers alongside the
                     // credentials form. AF-06a hides it entirely when the build
                     // carries no Google client id.
@@ -167,72 +178,6 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
             ),
           ),
         ),
-      ),
-    );
-  }
-}
-
-/// Says that the API could not be reached, and offers the only action that
-/// helps. The API returns no errors for a transport failure, so there is
-/// nothing of its own to render here.
-class _RetryBanner extends StatelessWidget {
-  const _RetryBanner({required this.onRetry});
-
-  final VoidCallback? onRetry;
-
-  @override
-  Widget build(BuildContext context) {
-    final scheme = Theme.of(context).colorScheme;
-
-    return Container(
-      padding: const EdgeInsets.all(12),
-      decoration: BoxDecoration(
-        color: scheme.errorContainer,
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Text(
-            'Could not reach the API. Check your connection and try again.',
-            style: TextStyle(color: scheme.onErrorContainer),
-          ),
-          const SizedBox(height: 8),
-          Align(
-            alignment: Alignment.centerRight,
-            child: TextButton(onPressed: onRetry, child: const Text('Retry')),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-/// Shows the API's own error strings, unaltered.
-class _ErrorBanner extends StatelessWidget {
-  const _ErrorBanner({required this.failure});
-
-  final Failure failure;
-
-  @override
-  Widget build(BuildContext context) {
-    final scheme = Theme.of(context).colorScheme;
-    final messages = failure.errors.isNotEmpty
-        ? failure.errors
-        : <String>[failure.displayMessage];
-
-    return Container(
-      padding: const EdgeInsets.all(12),
-      decoration: BoxDecoration(
-        color: scheme.errorContainer,
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          for (final message in messages)
-            Text(message, style: TextStyle(color: scheme.onErrorContainer)),
-        ],
       ),
     );
   }

--- a/lib/features/auth/presentation/password_recovery_controller.dart
+++ b/lib/features/auth/presentation/password_recovery_controller.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/result/result.dart';
+import 'session_controller.dart';
+
+/// How far a password recovery request has got.
+sealed class PasswordRecoveryState {
+  const PasswordRecoveryState();
+}
+
+/// Nothing has been asked for yet.
+final class RecoveryIdle extends PasswordRecoveryState {
+  const RecoveryIdle();
+}
+
+/// A request is in flight. AF-03c: the screen refuses a second submission while
+/// the session is in this state, so a double tap cannot send twice.
+final class RecoverySending extends PasswordRecoveryState {
+  const RecoverySending();
+}
+
+/// The API accepted the request. This says nothing about whether the address is
+/// registered, and is shown identically either way.
+final class RecoverySent extends PasswordRecoveryState {
+  const RecoverySent();
+}
+
+/// The request did not reach the API, or the API refused it.
+final class RecoveryFailed extends PasswordRecoveryState {
+  const RecoveryFailed(this.failure);
+
+  final Failure failure;
+}
+
+final NotifierProvider<PasswordRecoveryController, PasswordRecoveryState>
+passwordRecoveryControllerProvider =
+    NotifierProvider<PasswordRecoveryController, PasswordRecoveryState>(
+      PasswordRecoveryController.new,
+    );
+
+/// Owns one password recovery request from asked to answered.
+class PasswordRecoveryController extends Notifier<PasswordRecoveryState> {
+  @override
+  PasswordRecoveryState build() => const RecoveryIdle();
+
+  /// Asks for a reset link for [email].
+  ///
+  /// AF-03c: a request already in flight is not joined by a second one. The
+  /// guard lives here rather than only in the screen, so it holds however the
+  /// submission was triggered.
+  Future<void> request(String email) async {
+    if (state is RecoverySending) {
+      return;
+    }
+
+    state = const RecoverySending();
+
+    final result = await ref
+        .read(authRepositoryProvider)
+        .requestPasswordRecovery(email: email);
+
+    state = result.fold(
+      onSuccess: (_) => const RecoverySent(),
+      // AF-03b: nothing was sent, so the confirmation would be a lie. The
+      // failure is kept as it came back and the screen decides how to say it.
+      onFailure: RecoveryFailed.new,
+    );
+  }
+
+  /// Returns the screen to its starting state, so a failed attempt can be made
+  /// again against a corrected address.
+  void reset() {
+    state = const RecoveryIdle();
+  }
+}

--- a/lib/features/auth/presentation/password_recovery_screen.dart
+++ b/lib/features/auth/presentation/password_recovery_screen.dart
@@ -1,0 +1,186 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../core/result/result.dart';
+import '../../../shared/widgets/failure_banner.dart';
+import 'password_recovery_controller.dart';
+
+/// The password recovery screen.
+///
+/// Everything it can say is deliberately the same for an address that exists
+/// and one that does not: the confirmation is the only success, and it names
+/// nobody.
+class PasswordRecoveryScreen extends ConsumerStatefulWidget {
+  const PasswordRecoveryScreen({super.key});
+
+  @override
+  ConsumerState<PasswordRecoveryScreen> createState() =>
+      _PasswordRecoveryScreenState();
+}
+
+class _PasswordRecoveryScreenState
+    extends ConsumerState<PasswordRecoveryScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _email = TextEditingController();
+
+  @override
+  void dispose() {
+    _email.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    // AF-03a: an empty or malformed address never reaches the API.
+    if (!(_formKey.currentState?.validate() ?? false)) {
+      return;
+    }
+
+    // AF-03c: the control is already disabled while a request is in flight;
+    // this makes a submission from the keyboard obey the same rule.
+    if (ref.read(passwordRecoveryControllerProvider) is RecoverySending) {
+      return;
+    }
+
+    await ref
+        .read(passwordRecoveryControllerProvider.notifier)
+        .request(_email.text.trim());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final state = ref.watch(passwordRecoveryControllerProvider);
+    final sending = state is RecoverySending;
+
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.go('/login'),
+        ),
+        title: const Text('Reset your password'),
+      ),
+      body: SafeArea(
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 420),
+              child: state is RecoverySent
+                  ? _Confirmation(onBackToSignIn: () => context.go('/login'))
+                  : Form(
+                      key: _formKey,
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: <Widget>[
+                          Text(
+                            'Forgot your password?',
+                            style: theme.textTheme.headlineMedium,
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            'Enter your email address and we will send you a '
+                            'link to set a new password.',
+                            style: theme.textTheme.bodyMedium,
+                          ),
+                          const SizedBox(height: 24),
+                          if (state is RecoveryFailed) ...<Widget>[
+                            if (state.failure.kind == FailureKind.network)
+                              // AF-03b: nothing was sent, so the same
+                              // submission is worth making again.
+                              RetryBanner(onRetry: sending ? null : _submit)
+                            else
+                              ErrorBanner(failure: state.failure),
+                            const SizedBox(height: 16),
+                          ],
+                          TextFormField(
+                            controller: _email,
+                            autofillHints: const <String>[AutofillHints.email],
+                            keyboardType: TextInputType.emailAddress,
+                            decoration: const InputDecoration(
+                              labelText: 'Email',
+                            ),
+                            onFieldSubmitted: (_) => _submit(),
+                            validator: (value) {
+                              final email = value?.trim() ?? '';
+
+                              if (email.isEmpty) {
+                                return 'Enter your email address.';
+                              }
+
+                              return email.contains('@')
+                                  ? null
+                                  : 'Enter a valid email address.';
+                            },
+                          ),
+                          const SizedBox(height: 24),
+                          FilledButton(
+                            onPressed: sending ? null : _submit,
+                            child: sending
+                                ? const SizedBox.square(
+                                    dimension: 20,
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: 2,
+                                    ),
+                                  )
+                                : const Text('Send reset link'),
+                          ),
+                          const SizedBox(height: 8),
+                          TextButton(
+                            onPressed: sending
+                                ? null
+                                : () => context.go('/login'),
+                            child: const Text('Back to sign in'),
+                          ),
+                        ],
+                      ),
+                    ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The one thing a successful request ever says.
+///
+/// It does not repeat the address back, and it is worded so that it reads the
+/// same whether or not anyone is registered under it — which is the point.
+class _Confirmation extends StatelessWidget {
+  const _Confirmation({required this.onBackToSignIn});
+
+  final VoidCallback onBackToSignIn;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        Icon(
+          Icons.mark_email_read_outlined,
+          size: 48,
+          color: theme.colorScheme.primary,
+        ),
+        const SizedBox(height: 16),
+        Text('Check your inbox', style: theme.textTheme.headlineMedium),
+        const SizedBox(height: 8),
+        Text(
+          'If that address belongs to an account, a link to set a new password '
+          'is on its way. It expires shortly, so use it soon.',
+          style: theme.textTheme.bodyMedium,
+        ),
+        const SizedBox(height: 24),
+        FilledButton(
+          onPressed: onBackToSignIn,
+          child: const Text('Back to sign in'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/auth/presentation/two_factor_screen.dart
+++ b/lib/features/auth/presentation/two_factor_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/result/result.dart';
+import '../../../shared/widgets/failure_banner.dart';
 import '../domain/session.dart';
 import 'session_controller.dart';
 
@@ -150,9 +151,9 @@ class _TwoFactorScreenState extends ConsumerState<TwoFactorScreen> {
                       const SizedBox(height: 24),
                       if (_failure case final Failure failure) ...<Widget>[
                         if (failure.kind == FailureKind.network)
-                          _RetryBanner(onRetry: _submitting ? null : _submit)
+                          RetryBanner(onRetry: _submitting ? null : _submit)
                         else
-                          _ErrorBanner(failure: failure),
+                          ErrorBanner(failure: failure),
                         const SizedBox(height: 16),
                       ],
                       // AF-02c: only worth showing when there is a choice to
@@ -267,68 +268,3 @@ String _promptFor(String? method) => switch (method?.toLowerCase()) {
   null => 'Enter your verification code.',
   _ => 'Enter your verification code for $method.',
 };
-
-/// Says that the API could not be reached, and offers the only action that
-/// helps. The challenge is untouched, so the same code can simply be sent again.
-class _RetryBanner extends StatelessWidget {
-  const _RetryBanner({required this.onRetry});
-
-  final VoidCallback? onRetry;
-
-  @override
-  Widget build(BuildContext context) {
-    final scheme = Theme.of(context).colorScheme;
-
-    return Container(
-      padding: const EdgeInsets.all(12),
-      decoration: BoxDecoration(
-        color: scheme.errorContainer,
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Text(
-            'Could not reach the API. Check your connection and try again.',
-            style: TextStyle(color: scheme.onErrorContainer),
-          ),
-          const SizedBox(height: 8),
-          Align(
-            alignment: Alignment.centerRight,
-            child: TextButton(onPressed: onRetry, child: const Text('Retry')),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-/// Shows the API's own error strings, unaltered.
-class _ErrorBanner extends StatelessWidget {
-  const _ErrorBanner({required this.failure});
-
-  final Failure failure;
-
-  @override
-  Widget build(BuildContext context) {
-    final scheme = Theme.of(context).colorScheme;
-    final messages = failure.errors.isNotEmpty
-        ? failure.errors
-        : <String>[failure.displayMessage];
-
-    return Container(
-      padding: const EdgeInsets.all(12),
-      decoration: BoxDecoration(
-        color: scheme.errorContainer,
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          for (final message in messages)
-            Text(message, style: TextStyle(color: scheme.onErrorContainer)),
-        ],
-      ),
-    );
-  }
-}

--- a/lib/shared/widgets/failure_banner.dart
+++ b/lib/shared/widgets/failure_banner.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+
+import '../../core/result/result.dart';
+
+/// Says that the API could not be reached, and offers the only action that
+/// helps. A transport failure carries no errors of the API's own, so there is
+/// nothing of its to render here.
+class RetryBanner extends StatelessWidget {
+  const RetryBanner({required this.onRetry, super.key});
+
+  /// `null` while a retry is already in flight, which disables the control.
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: scheme.errorContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(
+            'Could not reach the API. Check your connection and try again.',
+            style: TextStyle(color: scheme.onErrorContainer),
+          ),
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: TextButton(onPressed: onRetry, child: const Text('Retry')),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Shows the API's own error strings, unaltered, so what a user reads matches
+/// what an operator finds in the API's logs.
+class ErrorBanner extends StatelessWidget {
+  const ErrorBanner({required this.failure, super.key});
+
+  final Failure failure;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final messages = failure.errors.isNotEmpty
+        ? failure.errors
+        : <String>[failure.displayMessage];
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: scheme.errorContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          for (final message in messages)
+            Text(message, style: TextStyle(color: scheme.onErrorContainer)),
+        ],
+      ),
+    );
+  }
+}

--- a/test/app/router_test.dart
+++ b/test/app/router_test.dart
@@ -52,6 +52,22 @@ void main() {
     expect(redirect, isNull);
   });
 
+  // UI-03 — the recovery screen is reached by someone who, by definition,
+  // cannot sign in, so the guard must let them through.
+  test('GivenUnauthenticated_WhenVisitingRecovery_ThenNoRedirect', () {
+    // Given
+    const session = Unauthenticated();
+
+    // When
+    final redirect = redirectFor(
+      session: session,
+      location: '/password-recovery',
+    );
+
+    // Then
+    expect(redirect, isNull);
+  });
+
   test('GivenChallenged_WhenVisitingAnyRoute_ThenRedirectsToTheChallenge', () {
     // Given
     const session = Challenged(

--- a/test/features/auth/data/auth_repository_impl_test.dart
+++ b/test/features/auth/data/auth_repository_impl_test.dart
@@ -299,6 +299,118 @@ void main() {
       expect(result.failureOrNull?.kind, FailureKind.network);
     },
   );
+
+  test(
+    'GivenAcceptedEnvelope_WhenRequestingRecovery_ThenSuccessIsReturned',
+    () async {
+      // Given
+      repository = repositoryAnswering(
+        const _Answer(
+          status: 200,
+          body: <String, dynamic>{
+            'success': true,
+            'errors': <String>[],
+            'data': null,
+          },
+        ),
+      );
+
+      // When
+      final result = await repository.requestPasswordRecovery(email: 'a@b.c');
+
+      // Then
+      expect(result.isSuccess, isTrue);
+    },
+  );
+
+  test(
+    'GivenAnAddress_WhenRequestingRecovery_ThenItIsSentAsTheEmail',
+    () async {
+      // Given
+      repository = repositoryAnswering(
+        const _Answer(
+          status: 200,
+          body: <String, dynamic>{
+            'success': true,
+            'errors': <String>[],
+            'data': null,
+          },
+        ),
+      );
+
+      // When
+      await repository.requestPasswordRecovery(email: 'a@b.c');
+
+      // Then
+      expect(adapter.requests.single['email'], 'a@b.c');
+    },
+  );
+
+  // The neutral confirmation: the API answers an unknown address the same way,
+  // and nothing here reads any further into it.
+  test(
+    'GivenUnknownAddress_WhenRequestingRecovery_ThenSuccessIsReturned',
+    () async {
+      // Given
+      repository = repositoryAnswering(
+        const _Answer(
+          status: 200,
+          body: <String, dynamic>{
+            'success': true,
+            'errors': <String>[],
+            'data': null,
+          },
+        ),
+      );
+
+      // When
+      final result = await repository.requestPasswordRecovery(
+        email: 'nobody@nowhere.invalid',
+      );
+
+      // Then
+      expect(result.isSuccess, isTrue);
+    },
+  );
+
+  test(
+    'GivenRejectedEnvelope_WhenRequestingRecovery_ThenApiErrorsAreReturned',
+    () async {
+      // Given
+      repository = repositoryAnswering(
+        const _Answer(
+          status: 400,
+          body: <String, dynamic>{
+            'success': false,
+            'errors': <String>['Email is not in a valid format.'],
+          },
+        ),
+      );
+
+      // When
+      final result = await repository.requestPasswordRecovery(email: 'nope');
+
+      // Then
+      expect(result.failureOrNull?.errors, <String>[
+        'Email is not in a valid format.',
+      ]);
+    },
+  );
+
+  // AF-03b — the API could not be reached at all.
+  test(
+    'GivenTransportFailure_WhenRequestingRecovery_ThenNetworkFailureIsReturned',
+    () async {
+      // Given
+      repository = repositoryAnswering(const _Answer(status: 0));
+
+      // When
+      final result = await repository.requestPasswordRecovery(email: 'a@b.c');
+
+      // Then
+      expect(result.failureOrNull?.kind, FailureKind.network);
+    },
+  );
 }
 
 /// What the stub answers with. A [status] of zero stands for a connection that

--- a/test/features/auth/presentation/password_recovery_controller_test.dart
+++ b/test/features/auth/presentation/password_recovery_controller_test.dart
@@ -1,0 +1,177 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/features/auth/domain/auth_repository.dart';
+import 'package:heimdall_ui/features/auth/presentation/password_recovery_controller.dart';
+import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockAuthRepository extends Mock implements AuthRepository {}
+
+void main() {
+  late _MockAuthRepository repository;
+  late ProviderContainer container;
+
+  PasswordRecoveryController controllerUnderTest() {
+    container = ProviderContainer(
+      overrides: <Override>[
+        authRepositoryProvider.overrideWithValue(repository),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    return container.read(passwordRecoveryControllerProvider.notifier);
+  }
+
+  void answerWith(Result<void> result) {
+    when(
+      () => repository.requestPasswordRecovery(email: any(named: 'email')),
+    ).thenAnswer((_) async => result);
+  }
+
+  setUp(() {
+    repository = _MockAuthRepository();
+  });
+
+  test('GivenAcceptedRequest_WhenRecoveryRequested_ThenStateIsSent', () async {
+    // Given
+    answerWith(const Success<void>(null));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.request('a@b.c');
+
+    // Then
+    expect(
+      container.read(passwordRecoveryControllerProvider),
+      isA<RecoverySent>(),
+    );
+  });
+
+  test(
+    'GivenAnyAddress_WhenRecoveryRequested_ThenTheAddressIsSentAsTyped',
+    () async {
+      // Given
+      answerWith(const Success<void>(null));
+      final controller = controllerUnderTest();
+
+      // When
+      await controller.request('a@b.c');
+
+      // Then
+      verify(
+        () => repository.requestPasswordRecovery(email: 'a@b.c'),
+      ).called(1);
+    },
+  );
+
+  // The neutral confirmation: an unregistered address is answered by the API
+  // exactly as a registered one is, and reaches the same state here.
+  test('GivenUnknownAddress_WhenRecoveryRequested_ThenStateIsSent', () async {
+    // Given
+    answerWith(const Success<void>(null));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.request('nobody@nowhere.invalid');
+
+    // Then
+    expect(
+      container.read(passwordRecoveryControllerProvider),
+      isA<RecoverySent>(),
+    );
+  });
+
+  // AF-03b — a transport failure never becomes a confirmation.
+  test(
+    'GivenTransportFailure_WhenRecoveryRequested_ThenStateIsFailed',
+    () async {
+      // Given
+      answerWith(
+        const FailureResult<void>(
+          Failure(kind: FailureKind.network, errors: <String>[]),
+        ),
+      );
+      final controller = controllerUnderTest();
+
+      // When
+      await controller.request('a@b.c');
+
+      // Then
+      final state = container.read(passwordRecoveryControllerProvider);
+      expect(state, isA<RecoveryFailed>());
+      expect((state as RecoveryFailed).failure.kind, FailureKind.network);
+    },
+  );
+
+  test(
+    'GivenRejectedRequest_WhenRecoveryRequested_ThenApiErrorsAreKept',
+    () async {
+      // Given
+      answerWith(
+        const FailureResult<void>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: <String>['Email is required.'],
+          ),
+        ),
+      );
+      final controller = controllerUnderTest();
+
+      // When
+      await controller.request('not-an-address');
+
+      // Then
+      final state = container.read(passwordRecoveryControllerProvider);
+      expect((state as RecoveryFailed).failure.errors, <String>[
+        'Email is required.',
+      ]);
+    },
+  );
+
+  // AF-03c — a second request while the first is in flight is not sent.
+  test(
+    'GivenRequestInFlight_WhenRequestedAgain_ThenOnlyOneRequestIsSent',
+    () async {
+      // Given
+      final pending = Completer<Result<void>>();
+      when(
+        () => repository.requestPasswordRecovery(email: any(named: 'email')),
+      ).thenAnswer((_) => pending.future);
+      final controller = controllerUnderTest();
+
+      // When
+      final first = controller.request('a@b.c');
+      final second = controller.request('a@b.c');
+      pending.complete(const Success<void>(null));
+      await Future.wait<void>(<Future<void>>[first, second]);
+
+      // Then
+      verify(
+        () => repository.requestPasswordRecovery(email: 'a@b.c'),
+      ).called(1);
+    },
+  );
+
+  test('GivenFailedRequest_WhenReset_ThenStateIsIdle', () async {
+    // Given
+    answerWith(
+      const FailureResult<void>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
+    final controller = controllerUnderTest();
+    await controller.request('a@b.c');
+
+    // When
+    controller.reset();
+
+    // Then
+    expect(
+      container.read(passwordRecoveryControllerProvider),
+      isA<RecoveryIdle>(),
+    );
+  });
+}

--- a/test/features/auth/presentation/password_recovery_screen_test.dart
+++ b/test/features/auth/presentation/password_recovery_screen_test.dart
@@ -1,0 +1,308 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdall_ui/app/theme.dart';
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/features/auth/domain/auth_repository.dart';
+import 'package:heimdall_ui/features/auth/presentation/password_recovery_screen.dart';
+import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockAuthRepository extends Mock implements AuthRepository {}
+
+void main() {
+  late _MockAuthRepository repository;
+  late ProviderContainer container;
+
+  Future<void> pump(
+    WidgetTester tester, {
+    Size size = const Size(400, 900),
+    ThemeData? theme,
+  }) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    container = ProviderContainer(
+      overrides: <Override>[
+        authRepositoryProvider.overrideWithValue(repository),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          theme: theme ?? buildLightTheme(),
+          home: const PasswordRecoveryScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  void answerWith(Result<void> result) {
+    when(
+      () => repository.requestPasswordRecovery(email: any(named: 'email')),
+    ).thenAnswer((_) async => result);
+  }
+
+  Future<void> submit(WidgetTester tester, String email) async {
+    await tester.enterText(find.byType(TextFormField), email);
+    await tester.tap(find.widgetWithText(FilledButton, 'Send reset link'));
+    await tester.pumpAndSettle();
+  }
+
+  setUp(() {
+    repository = _MockAuthRepository();
+  });
+
+  testWidgets('GivenRecoveryScreen_WhenSubmitted_ThenTheAddressIsSent', (
+    tester,
+  ) async {
+    // Given
+    answerWith(const Success<void>(null));
+    await pump(tester);
+
+    // When
+    await submit(tester, 'a@b.c');
+
+    // Then
+    verify(() => repository.requestPasswordRecovery(email: 'a@b.c')).called(1);
+  });
+
+  testWidgets('GivenAcceptedRequest_WhenSubmitted_ThenConfirmationIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(const Success<void>(null));
+    await pump(tester);
+
+    // When
+    await submit(tester, 'a@b.c');
+
+    // Then
+    expect(find.text('Check your inbox'), findsOneWidget);
+  });
+
+  // The confirmation must not repeat the address back, since doing so on a
+  // shared screen would be one more place it could be read.
+  testWidgets('GivenAcceptedRequest_WhenConfirmed_ThenTheAddressIsNotEchoed', (
+    tester,
+  ) async {
+    // Given
+    answerWith(const Success<void>(null));
+    await pump(tester);
+
+    // When
+    await submit(tester, 'a@b.c');
+
+    // Then
+    expect(find.textContaining('a@b.c'), findsNothing);
+  });
+
+  // The neutral confirmation: an address nobody holds is answered identically.
+  testWidgets(
+    'GivenUnknownAddress_WhenSubmitted_ThenTheSameConfirmationIsShown',
+    (tester) async {
+      // Given
+      answerWith(const Success<void>(null));
+      await pump(tester);
+
+      // When
+      await submit(tester, 'nobody@nowhere.invalid');
+
+      // Then
+      expect(find.text('Check your inbox'), findsOneWidget);
+    },
+  );
+
+  // AF-03a — an empty address never reaches the API.
+  testWidgets('GivenEmptyAddress_WhenSubmitted_ThenNoRequestIsMade', (
+    tester,
+  ) async {
+    // Given
+    answerWith(const Success<void>(null));
+    await pump(tester);
+
+    // When
+    await submit(tester, '');
+
+    // Then
+    verifyNever(
+      () => repository.requestPasswordRecovery(email: any(named: 'email')),
+    );
+  });
+
+  // AF-03a — and neither does a malformed one.
+  testWidgets('GivenMalformedAddress_WhenSubmitted_ThenTheFieldIsMarked', (
+    tester,
+  ) async {
+    // Given
+    answerWith(const Success<void>(null));
+    await pump(tester);
+
+    // When
+    await submit(tester, 'not-an-address');
+
+    // Then
+    expect(find.text('Enter a valid email address.'), findsOneWidget);
+  });
+
+  // AF-03b — a transport failure offers a retry and withholds the confirmation.
+  testWidgets('GivenTransportFailure_WhenSubmitted_ThenRetryIsOffered', (
+    tester,
+  ) async {
+    // Given
+    answerWith(
+      const FailureResult<void>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await submit(tester, 'a@b.c');
+
+    // Then
+    expect(find.widgetWithText(TextButton, 'Retry'), findsOneWidget);
+  });
+
+  testWidgets('GivenTransportFailure_WhenSubmitted_ThenNoConfirmationIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(
+      const FailureResult<void>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await submit(tester, 'a@b.c');
+
+    // Then
+    expect(find.text('Check your inbox'), findsNothing);
+  });
+
+  testWidgets('GivenRejectedRequest_WhenSubmitted_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(
+      const FailureResult<void>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['Email is not in a valid format.'],
+        ),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await submit(tester, 'a@b.c');
+
+    // Then
+    expect(find.text('Email is not in a valid format.'), findsOneWidget);
+  });
+
+  // AF-03c — the control is disabled while the request is in flight.
+  testWidgets('GivenRequestInFlight_WhenRendered_ThenSubmitIsDisabled', (
+    tester,
+  ) async {
+    // Given
+    final pending = Completer<Result<void>>();
+    when(
+      () => repository.requestPasswordRecovery(email: any(named: 'email')),
+    ).thenAnswer((_) => pending.future);
+    await pump(tester);
+
+    // When
+    await tester.enterText(find.byType(TextFormField), 'a@b.c');
+    await tester.tap(find.byType(FilledButton));
+    await tester.pump();
+
+    // Then
+    expect(
+      tester.widget<FilledButton>(find.byType(FilledButton)).onPressed,
+      isNull,
+    );
+    pending.complete(const Success<void>(null));
+    await tester.pumpAndSettle();
+  });
+
+  // AF-03c — and a second tap while it is in flight sends nothing.
+  testWidgets('GivenRequestInFlight_WhenTappedAgain_ThenOnlyOneRequestIsSent', (
+    tester,
+  ) async {
+    // Given
+    final pending = Completer<Result<void>>();
+    when(
+      () => repository.requestPasswordRecovery(email: any(named: 'email')),
+    ).thenAnswer((_) => pending.future);
+    await pump(tester);
+
+    // When
+    await tester.enterText(find.byType(TextFormField), 'a@b.c');
+    await tester.tap(find.byType(FilledButton));
+    await tester.pump();
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pump();
+
+    // Then
+    verify(() => repository.requestPasswordRecovery(email: 'a@b.c')).called(1);
+    pending.complete(const Success<void>(null));
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('GivenCompactWidth_WhenRendered_ThenTheFormIsShown', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, size: const Size(400, 900));
+
+    // Then
+    expect(
+      find.widgetWithText(FilledButton, 'Send reset link'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('GivenMediumWidth_WhenRendered_ThenTheFormIsShown', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, size: const Size(800, 900));
+
+    // Then
+    expect(
+      find.widgetWithText(FilledButton, 'Send reset link'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('GivenExpandedWidth_WhenRendered_ThenTheFormIsShown', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, size: const Size(1400, 900));
+
+    // Then
+    expect(
+      find.widgetWithText(FilledButton, 'Send reset link'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('GivenDarkTheme_WhenRendered_ThenTheFormIsShown', (tester) async {
+    // Given / When
+    await pump(tester, theme: buildDarkTheme());
+
+    // Then
+    expect(find.text('Forgot your password?'), findsOneWidget);
+  });
+}

--- a/test/shared/widgets/failure_banner_test.dart
+++ b/test/shared/widgets/failure_banner_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdall_ui/app/theme.dart';
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/shared/widgets/failure_banner.dart';
+
+void main() {
+  Future<void> pump(
+    WidgetTester tester,
+    Widget banner, {
+    ThemeData? theme,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme ?? buildLightTheme(),
+        home: Scaffold(body: banner),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('GivenApiErrors_WhenRendered_ThenEachOneIsShown', (tester) async {
+    // Given
+    const failure = Failure(
+      kind: FailureKind.validation,
+      errors: <String>['First problem.', 'Second problem.'],
+    );
+
+    // When
+    await pump(tester, const ErrorBanner(failure: failure));
+
+    // Then
+    expect(find.text('First problem.'), findsOneWidget);
+    expect(find.text('Second problem.'), findsOneWidget);
+  });
+
+  testWidgets('GivenNoApiErrors_WhenRendered_ThenTheFallbackIsShown', (
+    tester,
+  ) async {
+    // Given
+    const failure = Failure(kind: FailureKind.unknown, errors: <String>[]);
+
+    // When
+    await pump(tester, const ErrorBanner(failure: failure));
+
+    // Then
+    expect(find.text('Something went wrong.'), findsOneWidget);
+  });
+
+  testWidgets('GivenARetryHandler_WhenTapped_ThenItIsCalled', (tester) async {
+    // Given
+    var retried = 0;
+
+    // When
+    await pump(tester, RetryBanner(onRetry: () => retried++));
+    await tester.tap(find.widgetWithText(TextButton, 'Retry'));
+
+    // Then
+    expect(retried, 1);
+  });
+
+  testWidgets('GivenNoRetryHandler_WhenRendered_ThenRetryIsDisabled', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, const RetryBanner(onRetry: null));
+
+    // Then
+    expect(
+      tester.widget<TextButton>(find.byType(TextButton)).onPressed,
+      isNull,
+    );
+  });
+
+  testWidgets('GivenDarkTheme_WhenRendered_ThenTheMessageIsShown', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(
+      tester,
+      const RetryBanner(onRetry: null),
+      theme: buildDarkTheme(),
+    );
+
+    // Then
+    expect(
+      find.text(
+        'Could not reach the API. Check your connection and try again.',
+      ),
+      findsOneWidget,
+    );
+  });
+}


### PR DESCRIPTION
Implements UI-03 from the [Use Case Specification Document](docs/requirements/Use%20Case%20Specification%20Document.md), delivering FR-AU-10.

## Flows implemented

| Flow | What it does |
| --- | --- |
| **Main** | The recovery screen is opened from the sign-in screen, takes an email address, calls `POST /api/auth/password-recovery`, and shows a neutral confirmation. |
| **AF-03a** | An empty or malformed address is stopped by the field's validator; no request is made. |
| **AF-03b** | A transport failure shows the retry banner and withholds the confirmation, since nothing was sent. |
| **AF-03c** | The submit control is disabled while a request is in flight, and the controller refuses a second request in that state. |

The confirmation is the only success the screen can show. Nothing beyond the envelope's `success` flag is read, and the address is not echoed back, so a registered address and an unregistered one are indistinguishable from the interface.

## Also here

The retry and error banners that the sign-in and challenge screens each carried a private copy of are now one pair in `lib/shared/widgets/failure_banner.dart`, used by all three screens.

## Verification

```
dart format --set-exit-if-changed . && flutter analyze && flutter test
```

All three pass; **153 tests**, none skipped. Coverage added:

- `password_recovery_controller_test.dart` — the main flow, the neutral answer for an unknown address, AF-03b, AF-03c, and that the API's errors are kept.
- `password_recovery_screen_test.dart` — the main flow, the confirmation and that it does not echo the address, AF-03a (empty and malformed), AF-03b, AF-03c (disabled control and a second submission), the API error path, all three breakpoints, and the dark theme.
- `auth_repository_impl_test.dart` — the request body, the accepted envelope, a rejected envelope's errors, and the transport failure.
- `failure_banner_test.dart` — the shared banners.
- `router_test.dart` — `/password-recovery` is reachable without a session.

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
