### PR TITLE
UI-04: Reset password

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ the board is where an item's status changes as it moves.
 | UI-01: Login | ✅ | [#1](https://github.com/artur-rios/heimdall-ui/issues/1) |
 | UI-02: Complete two-factor challenge at login | ✅ | [#2](https://github.com/artur-rios/heimdall-ui/issues/2) |
 | UI-03: Request password recovery | ✅ | [#3](https://github.com/artur-rios/heimdall-ui/issues/3) |
-| UI-04: Reset password | ⬜ | [#4](https://github.com/artur-rios/heimdall-ui/issues/4) |
+| UI-04: Reset password | ✅ | [#4](https://github.com/artur-rios/heimdall-ui/issues/4) |
 | UI-05: Verify email and resend verification | ⬜ | [#5](https://github.com/artur-rios/heimdall-ui/issues/5) |
 | UI-06: Sign in and sign out with Google | ⬜ | [#6](https://github.com/artur-rios/heimdall-ui/issues/6) |
 | UI-07: Guard routes by session and role | ⬜ | [#7](https://github.com/artur-rios/heimdall-ui/issues/7) |

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import '../features/auth/domain/session.dart';
 import '../features/auth/presentation/login_screen.dart';
 import '../features/auth/presentation/password_recovery_screen.dart';
+import '../features/auth/presentation/password_reset_screen.dart';
 import '../features/auth/presentation/session_controller.dart';
 import '../features/auth/presentation/two_factor_screen.dart';
 import '../features/home/presentation/home_screen.dart';
@@ -85,6 +86,13 @@ final Provider<GoRouter> routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/password-recovery',
         builder: (context, state) => const PasswordRecoveryScreen(),
+      ),
+      GoRoute(
+        path: '/password-reset',
+        // AF-04a: a link without `token` still reaches the screen, which says
+        // what is wrong. Refusing to route would only show "not found".
+        builder: (context, state) =>
+            PasswordResetScreen(token: state.uri.queryParameters['token']),
       ),
     ],
     // Every screen beyond these two arrives with its own use case. Until then

--- a/lib/features/auth/data/auth_repository_impl.dart
+++ b/lib/features/auth/data/auth_repository_impl.dart
@@ -96,6 +96,31 @@ class ApiAuthRepository implements AuthRepository {
     }
   }
 
+  @override
+  Future<Result<void>> resetPassword({
+    required String token,
+    required String newPassword,
+  }) async {
+    try {
+      final response = await _client.authResetPassword(
+        body: ResetPasswordCommand(token: token, newPassword: newPassword),
+      );
+
+      if (response.success != true) {
+        return FailureResult<void>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: response.errors ?? const <String>[],
+          ),
+        );
+      }
+
+      return const Success<void>(null);
+    } on DioException catch (error) {
+      return FailureResult<void>(failureFromDioException(error));
+    }
+  }
+
   /// Reads a login response, which answers one of two ways: a usable token, or
   /// a challenge that must be answered before a session exists.
   Result<LoginOutcome> _outcomeFrom(LoginCommandOutputDataOutput response) {

--- a/lib/features/auth/domain/auth_repository.dart
+++ b/lib/features/auth/domain/auth_repository.dart
@@ -50,4 +50,13 @@ abstract interface class AuthRepository {
   /// way whether or not the address belongs to anyone, so there is nothing here
   /// that could tell a caller which it was.
   Future<Result<void>> requestPasswordRecovery({required String email});
+
+  /// Sets a new password from the token in a recovery link.
+  ///
+  /// The token is the only credential someone who has lost their password can
+  /// present, so it travels in the body and is never stored.
+  Future<Result<void>> resetPassword({
+    required String token,
+    required String newPassword,
+  });
 }

--- a/lib/features/auth/presentation/password_reset_controller.dart
+++ b/lib/features/auth/presentation/password_reset_controller.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/result/result.dart';
+import 'session_controller.dart';
+
+/// How far a password reset has got.
+sealed class PasswordResetState {
+  const PasswordResetState();
+}
+
+/// The form is waiting to be filled in.
+final class ResetIdle extends PasswordResetState {
+  const ResetIdle();
+}
+
+/// A reset is in flight; the submit control is disabled meanwhile.
+final class ResetSubmitting extends PasswordResetState {
+  const ResetSubmitting();
+}
+
+/// The password was changed. The screen offers sign-in from here.
+final class ResetSucceeded extends PasswordResetState {
+  const ResetSucceeded();
+}
+
+/// The API refused, or could not be reached.
+///
+/// AF-04b and AF-04d arrive here alike: the envelope names the reason in
+/// `errors` but carries no code separating a spent token from a password the
+/// policy rejects, so the screen shows what came back and offers a fresh link
+/// rather than guessing which of the two it was.
+final class ResetFailed extends PasswordResetState {
+  const ResetFailed(this.failure);
+
+  final Failure failure;
+}
+
+final NotifierProvider<PasswordResetController, PasswordResetState>
+passwordResetControllerProvider =
+    NotifierProvider<PasswordResetController, PasswordResetState>(
+      PasswordResetController.new,
+    );
+
+/// Owns one password reset from submitted to answered.
+class PasswordResetController extends Notifier<PasswordResetState> {
+  @override
+  PasswordResetState build() => const ResetIdle();
+
+  /// Sets [newPassword] using the reset [token] from the link.
+  ///
+  /// A submission already in flight is not joined by a second one, so a double
+  /// tap cannot spend the token twice.
+  Future<void> submit({
+    required String token,
+    required String newPassword,
+  }) async {
+    if (state is ResetSubmitting) {
+      return;
+    }
+
+    state = const ResetSubmitting();
+
+    final result = await ref
+        .read(authRepositoryProvider)
+        .resetPassword(token: token, newPassword: newPassword);
+
+    state = result.fold(
+      onSuccess: (_) => const ResetSucceeded(),
+      onFailure: ResetFailed.new,
+    );
+  }
+}

--- a/lib/features/auth/presentation/password_reset_screen.dart
+++ b/lib/features/auth/presentation/password_reset_screen.dart
@@ -1,0 +1,241 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../core/result/result.dart';
+import '../../../shared/widgets/failure_banner.dart';
+import 'password_reset_controller.dart';
+
+/// The password reset screen, opened by the link mailed in UI-03.
+///
+/// The token is the whole credential here, so the screen has nothing to do
+/// without one — which is why AF-04a is a distinct state rather than a
+/// validation message on the form.
+class PasswordResetScreen extends ConsumerStatefulWidget {
+  const PasswordResetScreen({required this.token, super.key});
+
+  /// The token from `?token=…`, or `null` when the link carried none.
+  final String? token;
+
+  @override
+  ConsumerState<PasswordResetScreen> createState() =>
+      _PasswordResetScreenState();
+}
+
+class _PasswordResetScreenState extends ConsumerState<PasswordResetScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _password = TextEditingController();
+  final _confirmation = TextEditingController();
+
+  @override
+  void dispose() {
+    _password.dispose();
+    _confirmation.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    final token = widget.token;
+
+    if (token == null || token.isEmpty) {
+      return;
+    }
+
+    // AF-04c: the confirmation must match before anything is sent.
+    if (!(_formKey.currentState?.validate() ?? false)) {
+      return;
+    }
+
+    if (ref.read(passwordResetControllerProvider) is ResetSubmitting) {
+      return;
+    }
+
+    await ref
+        .read(passwordResetControllerProvider.notifier)
+        .submit(token: token, newPassword: _password.text);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final token = widget.token;
+    final state = ref.watch(passwordResetControllerProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Set a new password')),
+      body: SafeArea(
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 420),
+              child: switch (state) {
+                // AF-04a: no token, nothing to reset. The only useful action is
+                // to ask for a link that carries one.
+                _ when token == null || token.isEmpty =>
+                  const _IncompleteLink(),
+                ResetSucceeded() => const _Confirmation(),
+                _ => _buildForm(context, theme, state),
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildForm(
+    BuildContext context,
+    ThemeData theme,
+    PasswordResetState state,
+  ) {
+    final submitting = state is ResetSubmitting;
+    final failure = state is ResetFailed ? state.failure : null;
+    final rejected = failure != null && failure.kind != FailureKind.network;
+
+    return Form(
+      key: _formKey,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Text('Set a new password', style: theme.textTheme.headlineMedium),
+          const SizedBox(height: 8),
+          Text(
+            'Choose a new password for your account.',
+            style: theme.textTheme.bodyMedium,
+          ),
+          const SizedBox(height: 24),
+          if (failure != null) ...<Widget>[
+            if (failure.kind == FailureKind.network)
+              RetryBanner(onRetry: submitting ? null : _submit)
+            else
+              ErrorBanner(failure: failure),
+            const SizedBox(height: 16),
+          ],
+          TextFormField(
+            controller: _password,
+            obscureText: true,
+            autofillHints: const <String>[AutofillHints.newPassword],
+            decoration: InputDecoration(
+              labelText: 'New password',
+              // AF-04d: a password the policy refuses is the API's answer about
+              // this field, so it is marked as well as banner-ed.
+              errorText: rejected ? failure.displayMessage : null,
+            ),
+            validator: (value) =>
+                (value ?? '').isEmpty ? 'Enter a new password.' : null,
+          ),
+          const SizedBox(height: 16),
+          TextFormField(
+            controller: _confirmation,
+            obscureText: true,
+            autofillHints: const <String>[AutofillHints.newPassword],
+            decoration: const InputDecoration(labelText: 'Confirm password'),
+            onFieldSubmitted: (_) => _submit(),
+            // AF-04c: mismatched entries never reach the API.
+            validator: (value) =>
+                value == _password.text ? null : 'The passwords do not match.',
+          ),
+          const SizedBox(height: 24),
+          FilledButton(
+            onPressed: submitting ? null : _submit,
+            child: submitting
+                ? const SizedBox.square(
+                    dimension: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Text('Set password'),
+          ),
+          // AF-04b: a token the API will not accept cannot be corrected here,
+          // so the way forward is a new link rather than another attempt.
+          if (rejected) ...<Widget>[
+            const SizedBox(height: 8),
+            TextButton(
+              onPressed: submitting
+                  ? null
+                  : () => context.go('/password-recovery'),
+              child: const Text('Request a new link'),
+            ),
+          ],
+          const SizedBox(height: 8),
+          TextButton(
+            onPressed: submitting ? null : () => context.go('/login'),
+            child: const Text('Back to sign in'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// AF-04a — the link arrived without a token, so there is no form to show.
+class _IncompleteLink extends StatelessWidget {
+  const _IncompleteLink();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        Icon(Icons.link_off_outlined, size: 48, color: theme.colorScheme.error),
+        const SizedBox(height: 16),
+        Text('This link is incomplete', style: theme.textTheme.headlineMedium),
+        const SizedBox(height: 8),
+        Text(
+          'It carries no reset token, so there is nothing to set a password '
+          'against. Mail clients sometimes cut long links short — requesting a '
+          'new one is the quickest way through.',
+          style: theme.textTheme.bodyMedium,
+        ),
+        const SizedBox(height: 24),
+        FilledButton(
+          onPressed: () => context.go('/password-recovery'),
+          child: const Text('Request a new link'),
+        ),
+        const SizedBox(height: 8),
+        TextButton(
+          onPressed: () => context.go('/login'),
+          child: const Text('Back to sign in'),
+        ),
+      ],
+    );
+  }
+}
+
+/// The password was changed, and signing in is the only thing left to do.
+class _Confirmation extends StatelessWidget {
+  const _Confirmation();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        Icon(
+          Icons.lock_reset_outlined,
+          size: 48,
+          color: theme.colorScheme.primary,
+        ),
+        const SizedBox(height: 16),
+        Text('Your password is set', style: theme.textTheme.headlineMedium),
+        const SizedBox(height: 8),
+        Text(
+          'Sign in with your new password to continue.',
+          style: theme.textTheme.bodyMedium,
+        ),
+        const SizedBox(height: 24),
+        FilledButton(
+          onPressed: () => context.go('/login'),
+          child: const Text('Sign in'),
+        ),
+      ],
+    );
+  }
+}

--- a/test/features/auth/data/auth_repository_impl_test.dart
+++ b/test/features/auth/data/auth_repository_impl_test.dart
@@ -411,6 +411,124 @@ void main() {
       expect(result.failureOrNull?.kind, FailureKind.network);
     },
   );
+
+  test('GivenAcceptedEnvelope_WhenResetting_ThenSuccessIsReturned', () async {
+    // Given
+    repository = repositoryAnswering(
+      const _Answer(
+        status: 200,
+        body: <String, dynamic>{
+          'success': true,
+          'errors': <String>[],
+          'data': null,
+        },
+      ),
+    );
+
+    // When
+    final result = await repository.resetPassword(
+      token: 'reset-token',
+      newPassword: 'new-secret',
+    );
+
+    // Then
+    expect(result.isSuccess, isTrue);
+  });
+
+  test('GivenAResetToken_WhenResetting_ThenTokenAndPasswordAreSent', () async {
+    // Given
+    repository = repositoryAnswering(
+      const _Answer(
+        status: 200,
+        body: <String, dynamic>{
+          'success': true,
+          'errors': <String>[],
+          'data': null,
+        },
+      ),
+    );
+
+    // When
+    await repository.resetPassword(
+      token: 'reset-token',
+      newPassword: 'new-secret',
+    );
+
+    // Then
+    expect(adapter.requests.single['token'], 'reset-token');
+    expect(adapter.requests.single['newPassword'], 'new-secret');
+  });
+
+  // AF-04b — an unknown, expired, or spent token answers 400 by name.
+  test('GivenRejectedToken_WhenResetting_ThenApiErrorsAreReturned', () async {
+    // Given
+    repository = repositoryAnswering(
+      const _Answer(
+        status: 400,
+        body: <String, dynamic>{
+          'success': false,
+          'errors': <String>['The reset token has expired.'],
+        },
+      ),
+    );
+
+    // When
+    final result = await repository.resetPassword(
+      token: 'stale',
+      newPassword: 'new-secret',
+    );
+
+    // Then
+    expect(result.failureOrNull?.errors, <String>[
+      'The reset token has expired.',
+    ]);
+  });
+
+  // AF-04d — the envelope reports failure within a 200.
+  test(
+    'GivenRejectedPasswordEnvelope_WhenResetting_ThenApiErrorsAreReturned',
+    () async {
+      // Given
+      repository = repositoryAnswering(
+        const _Answer(
+          status: 200,
+          body: <String, dynamic>{
+            'success': false,
+            'errors': <String>['Password must be at least 8 characters.'],
+            'data': null,
+          },
+        ),
+      );
+
+      // When
+      final result = await repository.resetPassword(
+        token: 'reset-token',
+        newPassword: 'short',
+      );
+
+      // Then
+      expect(result.failureOrNull?.errors, <String>[
+        'Password must be at least 8 characters.',
+      ]);
+    },
+  );
+
+  test(
+    'GivenTransportFailure_WhenResetting_ThenNetworkFailureIsReturned',
+    () async {
+      // Given
+      repository = repositoryAnswering(const _Answer(status: 0));
+
+      // When
+      final result = await repository.resetPassword(
+        token: 'reset-token',
+        newPassword: 'new-secret',
+      );
+
+      // Then
+      expect(result.failureOrNull?.kind, FailureKind.network);
+    },
+  );
 }
 
 /// What the stub answers with. A [status] of zero stands for a connection that

--- a/test/features/auth/presentation/password_reset_controller_test.dart
+++ b/test/features/auth/presentation/password_reset_controller_test.dart
@@ -1,0 +1,172 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/features/auth/domain/auth_repository.dart';
+import 'package:heimdall_ui/features/auth/presentation/password_reset_controller.dart';
+import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockAuthRepository extends Mock implements AuthRepository {}
+
+void main() {
+  late _MockAuthRepository repository;
+  late ProviderContainer container;
+
+  PasswordResetController controllerUnderTest() {
+    container = ProviderContainer(
+      overrides: <Override>[
+        authRepositoryProvider.overrideWithValue(repository),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    return container.read(passwordResetControllerProvider.notifier);
+  }
+
+  void answerWith(Result<void> result) {
+    when(
+      () => repository.resetPassword(
+        token: any(named: 'token'),
+        newPassword: any(named: 'newPassword'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  setUp(() {
+    repository = _MockAuthRepository();
+  });
+
+  test('GivenAcceptedReset_WhenSubmitted_ThenStateIsSucceeded', () async {
+    // Given
+    answerWith(const Success<void>(null));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.submit(token: 'reset-token', newPassword: 'new-secret');
+
+    // Then
+    expect(
+      container.read(passwordResetControllerProvider),
+      isA<ResetSucceeded>(),
+    );
+  });
+
+  test('GivenAResetToken_WhenSubmitted_ThenTokenAndPasswordAreSent', () async {
+    // Given
+    answerWith(const Success<void>(null));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.submit(token: 'reset-token', newPassword: 'new-secret');
+
+    // Then
+    verify(
+      () => repository.resetPassword(
+        token: 'reset-token',
+        newPassword: 'new-secret',
+      ),
+    ).called(1);
+  });
+
+  // AF-04b — a token the API will not accept.
+  test('GivenRejectedToken_WhenSubmitted_ThenApiErrorsAreKept', () async {
+    // Given
+    answerWith(
+      const FailureResult<void>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['The reset token has expired.'],
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.submit(token: 'stale', newPassword: 'new-secret');
+
+    // Then
+    final state = container.read(passwordResetControllerProvider);
+    expect((state as ResetFailed).failure.errors, <String>[
+      'The reset token has expired.',
+    ]);
+  });
+
+  // AF-04d — a password the policy refuses.
+  test('GivenRejectedPassword_WhenSubmitted_ThenApiErrorsAreKept', () async {
+    // Given
+    answerWith(
+      const FailureResult<void>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['Password must be at least 8 characters.'],
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.submit(token: 'reset-token', newPassword: 'short');
+
+    // Then
+    final state = container.read(passwordResetControllerProvider);
+    expect((state as ResetFailed).failure.errors, <String>[
+      'Password must be at least 8 characters.',
+    ]);
+  });
+
+  test('GivenTransportFailure_WhenSubmitted_ThenStateIsFailed', () async {
+    // Given
+    answerWith(
+      const FailureResult<void>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.submit(token: 'reset-token', newPassword: 'new-secret');
+
+    // Then
+    final state = container.read(passwordResetControllerProvider);
+    expect((state as ResetFailed).failure.kind, FailureKind.network);
+  });
+
+  // A reset token is spent by using it, so a double submission must not send
+  // the same one twice.
+  test(
+    'GivenResetInFlight_WhenSubmittedAgain_ThenOnlyOneRequestIsSent',
+    () async {
+      // Given
+      final pending = Completer<Result<void>>();
+      when(
+        () => repository.resetPassword(
+          token: any(named: 'token'),
+          newPassword: any(named: 'newPassword'),
+        ),
+      ).thenAnswer((_) => pending.future);
+      final controller = controllerUnderTest();
+
+      // When
+      final first = controller.submit(
+        token: 'reset-token',
+        newPassword: 'new-secret',
+      );
+      final second = controller.submit(
+        token: 'reset-token',
+        newPassword: 'new-secret',
+      );
+      pending.complete(const Success<void>(null));
+      await Future.wait<void>(<Future<void>>[first, second]);
+
+      // Then
+      verify(
+        () => repository.resetPassword(
+          token: 'reset-token',
+          newPassword: 'new-secret',
+        ),
+      ).called(1);
+    },
+  );
+}

--- a/test/features/auth/presentation/password_reset_screen_test.dart
+++ b/test/features/auth/presentation/password_reset_screen_test.dart
@@ -1,0 +1,390 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:heimdall_ui/app/theme.dart';
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/features/auth/domain/auth_repository.dart';
+import 'package:heimdall_ui/features/auth/presentation/password_reset_screen.dart';
+import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockAuthRepository extends Mock implements AuthRepository {}
+
+void main() {
+  late _MockAuthRepository repository;
+  late ProviderContainer container;
+  late GoRouter router;
+
+  /// Pumps the screen behind a router, so the actions that leave it — request a
+  /// new link, sign in — can be followed rather than only rendered.
+  Future<void> pump(
+    WidgetTester tester, {
+    String? token = 'reset-token',
+    Size size = const Size(400, 900),
+    ThemeData? theme,
+  }) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    container = ProviderContainer(
+      overrides: <Override>[
+        authRepositoryProvider.overrideWithValue(repository),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    router = GoRouter(
+      initialLocation: token == null
+          ? '/password-reset'
+          : '/password-reset?token=$token',
+      routes: <RouteBase>[
+        GoRoute(
+          path: '/password-reset',
+          builder: (context, state) =>
+              PasswordResetScreen(token: state.uri.queryParameters['token']),
+        ),
+        GoRoute(
+          path: '/password-recovery',
+          builder: (context, state) =>
+              const Scaffold(body: Text('recovery screen')),
+        ),
+        GoRoute(
+          path: '/login',
+          builder: (context, state) => const Scaffold(body: Text('login')),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(
+          theme: theme ?? buildLightTheme(),
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  void answerWith(Result<void> result) {
+    when(
+      () => repository.resetPassword(
+        token: any(named: 'token'),
+        newPassword: any(named: 'newPassword'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  Future<void> submit(
+    WidgetTester tester,
+    String password,
+    String confirmation,
+  ) async {
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'New password'),
+      password,
+    );
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Confirm password'),
+      confirmation,
+    );
+    await tester.tap(find.widgetWithText(FilledButton, 'Set password'));
+    await tester.pumpAndSettle();
+  }
+
+  setUp(() {
+    repository = _MockAuthRepository();
+  });
+
+  testWidgets('GivenAResetLink_WhenSubmitted_ThenTokenAndPasswordAreSent', (
+    tester,
+  ) async {
+    // Given
+    answerWith(const Success<void>(null));
+    await pump(tester);
+
+    // When
+    await submit(tester, 'new-secret', 'new-secret');
+
+    // Then
+    verify(
+      () => repository.resetPassword(
+        token: 'reset-token',
+        newPassword: 'new-secret',
+      ),
+    ).called(1);
+  });
+
+  testWidgets('GivenAcceptedReset_WhenSubmitted_ThenSuccessIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(const Success<void>(null));
+    await pump(tester);
+
+    // When
+    await submit(tester, 'new-secret', 'new-secret');
+
+    // Then
+    expect(find.text('Your password is set'), findsOneWidget);
+  });
+
+  testWidgets('GivenAcceptedReset_WhenSigningIn_ThenLoginIsOpened', (
+    tester,
+  ) async {
+    // Given
+    answerWith(const Success<void>(null));
+    await pump(tester);
+    await submit(tester, 'new-secret', 'new-secret');
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Sign in'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('login'), findsOneWidget);
+  });
+
+  // AF-04a — the link carried no token.
+  testWidgets('GivenNoToken_WhenRendered_ThenTheLinkIsCalledIncomplete', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, token: null);
+
+    // Then
+    expect(find.text('This link is incomplete'), findsOneWidget);
+  });
+
+  testWidgets('GivenNoToken_WhenRendered_ThenNoFormIsShown', (tester) async {
+    // Given / When
+    await pump(tester, token: null);
+
+    // Then
+    expect(find.byType(TextFormField), findsNothing);
+  });
+
+  // AF-04a — and the way out of it is UI-03.
+  testWidgets('GivenNoToken_WhenANewLinkIsRequested_ThenRecoveryIsOpened', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester, token: null);
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Request a new link'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('recovery screen'), findsOneWidget);
+  });
+
+  // AF-04b — the API refuses the token.
+  testWidgets('GivenRejectedToken_WhenSubmitted_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(
+      const FailureResult<void>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['The reset token has expired.'],
+        ),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await submit(tester, 'new-secret', 'new-secret');
+
+    // Then
+    expect(find.text('The reset token has expired.'), findsWidgets);
+  });
+
+  testWidgets('GivenRejectedToken_WhenSubmitted_ThenANewLinkIsOffered', (
+    tester,
+  ) async {
+    // Given
+    answerWith(
+      const FailureResult<void>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['The reset token has expired.'],
+        ),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await submit(tester, 'new-secret', 'new-secret');
+    await tester.tap(find.widgetWithText(TextButton, 'Request a new link'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('recovery screen'), findsOneWidget);
+  });
+
+  // AF-04c — a mismatched confirmation never reaches the API.
+  testWidgets('GivenMismatchedPasswords_WhenSubmitted_ThenNoRequestIsMade', (
+    tester,
+  ) async {
+    // Given
+    answerWith(const Success<void>(null));
+    await pump(tester);
+
+    // When
+    await submit(tester, 'new-secret', 'different');
+
+    // Then
+    verifyNever(
+      () => repository.resetPassword(
+        token: any(named: 'token'),
+        newPassword: any(named: 'newPassword'),
+      ),
+    );
+  });
+
+  testWidgets(
+    'GivenMismatchedPasswords_WhenSubmitted_ThenTheConfirmationIsMarked',
+    (tester) async {
+      // Given
+      answerWith(const Success<void>(null));
+      await pump(tester);
+
+      // When
+      await submit(tester, 'new-secret', 'different');
+
+      // Then
+      expect(find.text('The passwords do not match.'), findsOneWidget);
+    },
+  );
+
+  // AF-04d — the policy refuses the password, and the field says so.
+  testWidgets('GivenRejectedPassword_WhenSubmitted_ThenTheFieldIsMarked', (
+    tester,
+  ) async {
+    // Given
+    answerWith(
+      const FailureResult<void>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['Password must be at least 8 characters.'],
+        ),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await submit(tester, 'short', 'short');
+
+    // Then
+    final field = tester.widget<TextField>(
+      find
+          .descendant(
+            of: find.widgetWithText(TextFormField, 'New password'),
+            matching: find.byType(TextField),
+          )
+          .first,
+    );
+    expect(
+      field.decoration?.errorText,
+      'Password must be at least 8 characters.',
+    );
+  });
+
+  testWidgets('GivenTransportFailure_WhenSubmitted_ThenRetryIsOffered', (
+    tester,
+  ) async {
+    // Given
+    answerWith(
+      const FailureResult<void>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await submit(tester, 'new-secret', 'new-secret');
+
+    // Then
+    expect(find.widgetWithText(TextButton, 'Retry'), findsOneWidget);
+  });
+
+  testWidgets('GivenResetInFlight_WhenRendered_ThenSubmitIsDisabled', (
+    tester,
+  ) async {
+    // Given
+    final pending = Completer<Result<void>>();
+    when(
+      () => repository.resetPassword(
+        token: any(named: 'token'),
+        newPassword: any(named: 'newPassword'),
+      ),
+    ).thenAnswer((_) => pending.future);
+    await pump(tester);
+
+    // When
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'New password'),
+      'new-secret',
+    );
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Confirm password'),
+      'new-secret',
+    );
+    await tester.tap(find.byType(FilledButton));
+    await tester.pump();
+
+    // Then
+    expect(
+      tester.widget<FilledButton>(find.byType(FilledButton)).onPressed,
+      isNull,
+    );
+    pending.complete(const Success<void>(null));
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('GivenCompactWidth_WhenRendered_ThenTheFormIsShown', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, size: const Size(400, 900));
+
+    // Then
+    expect(find.widgetWithText(FilledButton, 'Set password'), findsOneWidget);
+  });
+
+  testWidgets('GivenMediumWidth_WhenRendered_ThenTheFormIsShown', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, size: const Size(800, 900));
+
+    // Then
+    expect(find.widgetWithText(FilledButton, 'Set password'), findsOneWidget);
+  });
+
+  testWidgets('GivenExpandedWidth_WhenRendered_ThenTheFormIsShown', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, size: const Size(1400, 900));
+
+    // Then
+    expect(find.widgetWithText(FilledButton, 'Set password'), findsOneWidget);
+  });
+
+  testWidgets('GivenDarkTheme_WhenRendered_ThenTheFormIsShown', (tester) async {
+    // Given / When
+    await pump(tester, theme: buildDarkTheme());
+
+    // Then
+    expect(find.widgetWithText(FilledButton, 'Set password'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Implements UI-04 from the [Use Case Specification Document](docs/requirements/Use%20Case%20Specification%20Document.md), delivering FR-AU-11.

## Flows implemented

| Flow | What it does |
| --- | --- |
| **Main** | `/password-reset?token=…` opens the screen with the token from the link, takes a new password and its confirmation, calls `POST /api/auth/password-reset`, then confirms and offers sign-in. |
| **AF-04a** | A link with no token gets its own state, not a form: the screen says the link is incomplete and offers UI-03. |
| **AF-04b** | A token the API refuses shows the returned errors and offers a fresh link. |
| **AF-04c** | A confirmation that does not match is stopped by the field's validator; no request is made. |
| **AF-04d** | A password the policy refuses shows the returned errors in the banner and against the password field. |

### One decision worth flagging

The envelope carries no code separating **AF-04b** (bad token) from **AF-04d** (bad password) — both arrive as a failed envelope with strings in `errors`. Rather than guess which occurred, the screen does what serves either: shows the API's errors, marks the password field, and offers a new link. No classification the API does not provide is invented.

## Verification

```
dart format --set-exit-if-changed . && flutter analyze && flutter test
```

All three pass; **181 tests**, none skipped. Coverage added:

- `password_reset_controller_test.dart` — the main flow, the request body, AF-04b, AF-04d, the transport failure, and that a double submission cannot spend the token twice.
- `password_reset_screen_test.dart` — the main flow and its onward route to sign-in, AF-04a (message, no form, and the route to UI-03), AF-04b (errors and the route to UI-03), AF-04c (no request, confirmation marked), AF-04d (the field's `errorText`), the retry banner, the disabled control in flight, all three breakpoints, and the dark theme.
- `auth_repository_impl_test.dart` — the accepted envelope, the request body, a rejected token, a rejected password, and the transport failure.

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
