### PR TITLE
UI-05: Verify email and resend verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ the board is where an item's status changes as it moves.
 | UI-02: Complete two-factor challenge at login | ✅ | [#2](https://github.com/artur-rios/heimdall-ui/issues/2) |
 | UI-03: Request password recovery | ✅ | [#3](https://github.com/artur-rios/heimdall-ui/issues/3) |
 | UI-04: Reset password | ✅ | [#4](https://github.com/artur-rios/heimdall-ui/issues/4) |
-| UI-05: Verify email and resend verification | ⬜ | [#5](https://github.com/artur-rios/heimdall-ui/issues/5) |
+| UI-05: Verify email and resend verification | ✅ | [#5](https://github.com/artur-rios/heimdall-ui/issues/5) |
 | UI-06: Sign in and sign out with Google | ⬜ | [#6](https://github.com/artur-rios/heimdall-ui/issues/6) |
 | UI-07: Guard routes by session and role | ⬜ | [#7](https://github.com/artur-rios/heimdall-ui/issues/7) |
 

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -8,6 +8,7 @@ import '../features/auth/presentation/password_recovery_screen.dart';
 import '../features/auth/presentation/password_reset_screen.dart';
 import '../features/auth/presentation/session_controller.dart';
 import '../features/auth/presentation/two_factor_screen.dart';
+import '../features/auth/presentation/verify_email_screen.dart';
 import '../features/home/presentation/home_screen.dart';
 
 /// Routes an unauthenticated caller may reach.
@@ -93,6 +94,13 @@ final Provider<GoRouter> routerProvider = Provider<GoRouter>((ref) {
         // what is wrong. Refusing to route would only show "not found".
         builder: (context, state) =>
             PasswordResetScreen(token: state.uri.queryParameters['token']),
+      ),
+      GoRoute(
+        path: '/verify-email',
+        // AF-05a: as with the reset link, a link without `token` still reaches
+        // the screen, which explains and offers the resend.
+        builder: (context, state) =>
+            VerifyEmailScreen(token: state.uri.queryParameters['token']),
       ),
     ],
     // Every screen beyond these two arrives with its own use case. Until then

--- a/lib/features/auth/data/auth_repository_impl.dart
+++ b/lib/features/auth/data/auth_repository_impl.dart
@@ -121,6 +121,51 @@ class ApiAuthRepository implements AuthRepository {
     }
   }
 
+  @override
+  Future<Result<List<String>>> verifyEmail({required String token}) async {
+    try {
+      final response = await _client.authVerifyEmail(
+        body: VerifyEmailCommand(token: token),
+      );
+
+      if (response.success != true) {
+        return FailureResult<List<String>>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: response.errors ?? const <String>[],
+          ),
+        );
+      }
+
+      // AF-05d: an address that was already verified answers successfully, so
+      // the messages are carried up rather than flattened away — they are what
+      // lets the screen say which of the two happened.
+      return Success<List<String>>(response.messages ?? const <String>[]);
+    } on DioException catch (error) {
+      return FailureResult<List<String>>(failureFromDioException(error));
+    }
+  }
+
+  @override
+  Future<Result<void>> resendVerificationEmail() async {
+    try {
+      final response = await _client.authResendVerification();
+
+      if (response.success != true) {
+        return FailureResult<void>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: response.errors ?? const <String>[],
+          ),
+        );
+      }
+
+      return const Success<void>(null);
+    } on DioException catch (error) {
+      return FailureResult<void>(failureFromDioException(error));
+    }
+  }
+
   /// Reads a login response, which answers one of two ways: a usable token, or
   /// a challenge that must be answered before a session exists.
   Result<LoginOutcome> _outcomeFrom(LoginCommandOutputDataOutput response) {

--- a/lib/features/auth/domain/auth_repository.dart
+++ b/lib/features/auth/domain/auth_repository.dart
@@ -59,4 +59,18 @@ abstract interface class AuthRepository {
     required String token,
     required String newPassword,
   });
+
+  /// Confirms an email address from the token in a verification link.
+  ///
+  /// Returns the envelope's `messages`, because an address that was already
+  /// verified answers successfully too (AF-05d) and the wording is the only
+  /// thing that tells the two apart.
+  Future<Result<List<String>>> verifyEmail({required String token});
+
+  /// Asks for a fresh verification email.
+  ///
+  /// Takes no argument: the API reads the person from the bearer token, so a
+  /// caller can only ever ask for their own — and an anonymous caller cannot
+  /// ask at all.
+  Future<Result<void>> resendVerificationEmail();
 }

--- a/lib/features/auth/domain/session.dart
+++ b/lib/features/auth/domain/session.dart
@@ -26,11 +26,20 @@ class Principal {
     required this.role,
     this.scopeId,
     this.ownedScopeIds = const <String>[],
+    this.emailVerified = true,
   });
 
   final String id;
   final String email;
   final Role role;
+
+  /// Whether the API considers this address verified.
+  ///
+  /// AF-05e reads it to decide whether to prompt. It defaults to `true` — a
+  /// token that says nothing about verification is not evidence of an
+  /// unverified address, and nagging on absent data is worse than staying
+  /// quiet.
+  final bool emailVerified;
 
   /// The scope a User belongs to; `null` for the other roles.
   final String? scopeId;

--- a/lib/features/auth/presentation/email_verification_controller.dart
+++ b/lib/features/auth/presentation/email_verification_controller.dart
@@ -1,0 +1,145 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/result/result.dart';
+import 'session_controller.dart';
+
+/// How far the verification of a token has got.
+sealed class VerifyStatus {
+  const VerifyStatus();
+}
+
+/// Nothing is being verified — normally because the link carried no token
+/// (AF-05a), which is a state rather than an error.
+final class VerifyIdle extends VerifyStatus {
+  const VerifyIdle();
+}
+
+/// The token is being checked. UI-05 verifies on open, so this is what the
+/// screen shows first.
+final class Verifying extends VerifyStatus {
+  const Verifying();
+}
+
+/// The address is verified.
+///
+/// [messages] is the envelope's own wording, which is the only thing that
+/// distinguishes a freshly verified address from one that already was
+/// (AF-05d). Both are successes, and both land here.
+final class Verified extends VerifyStatus {
+  const Verified(this.messages);
+
+  final List<String> messages;
+}
+
+/// AF-05b — the API refused the token.
+final class VerifyRejected extends VerifyStatus {
+  const VerifyRejected(this.failure);
+
+  final Failure failure;
+}
+
+/// How far a request for a fresh verification email has got.
+sealed class ResendStatus {
+  const ResendStatus();
+}
+
+final class ResendIdle extends ResendStatus {
+  const ResendIdle();
+}
+
+final class Resending extends ResendStatus {
+  const Resending();
+}
+
+/// AF-05c — the API accepted the request. Neutral by design: it says an email
+/// is on its way, not who it went to.
+final class ResendSent extends ResendStatus {
+  const ResendSent();
+}
+
+final class ResendRejected extends ResendStatus {
+  const ResendRejected(this.failure);
+
+  final Failure failure;
+}
+
+/// The two halves of UI-05, which run independently: a resend can follow a
+/// rejected verification, and the banner resends with nothing to verify.
+class EmailVerificationState {
+  const EmailVerificationState({
+    this.verification = const VerifyIdle(),
+    this.resend = const ResendIdle(),
+  });
+
+  final VerifyStatus verification;
+  final ResendStatus resend;
+
+  EmailVerificationState copyWith({
+    VerifyStatus? verification,
+    ResendStatus? resend,
+  }) => EmailVerificationState(
+    verification: verification ?? this.verification,
+    resend: resend ?? this.resend,
+  );
+}
+
+final NotifierProvider<EmailVerificationController, EmailVerificationState>
+emailVerificationControllerProvider =
+    NotifierProvider<EmailVerificationController, EmailVerificationState>(
+      EmailVerificationController.new,
+    );
+
+/// Owns email verification and the resend that backs it up.
+class EmailVerificationController extends Notifier<EmailVerificationState> {
+  @override
+  EmailVerificationState build() => const EmailVerificationState();
+
+  /// Verifies [token], which the screen calls as soon as it opens.
+  ///
+  /// AF-05a: a link with no token leaves the state idle and sends nothing —
+  /// there is no request that could succeed.
+  Future<void> verify(String? token) async {
+    if (token == null || token.isEmpty) {
+      state = state.copyWith(verification: const VerifyIdle());
+
+      return;
+    }
+
+    if (state.verification is Verifying) {
+      return;
+    }
+
+    state = state.copyWith(verification: const Verifying());
+
+    final result = await ref
+        .read(authRepositoryProvider)
+        .verifyEmail(token: token);
+
+    state = state.copyWith(
+      verification: result.fold(
+        onSuccess: Verified.new,
+        onFailure: VerifyRejected.new,
+      ),
+    );
+  }
+
+  /// AF-05c — asks the API to send a fresh verification email.
+  Future<void> resend() async {
+    if (state.resend is Resending) {
+      return;
+    }
+
+    state = state.copyWith(resend: const Resending());
+
+    final result = await ref
+        .read(authRepositoryProvider)
+        .resendVerificationEmail();
+
+    state = state.copyWith(
+      resend: result.fold(
+        onSuccess: (_) => const ResendSent(),
+        onFailure: ResendRejected.new,
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/session_controller.dart
+++ b/lib/features/auth/presentation/session_controller.dart
@@ -67,6 +67,13 @@ Principal principalFromToken(AuthToken token) {
         (payload['ownedScopeIds'] as List<dynamic>? ?? const <dynamic>[])
             .map((id) => id.toString())
             .toList(growable: false),
+    // AF-05e: read like every other claim here. Absent means "say nothing",
+    // not "unverified", so only an explicit false raises the prompt.
+    emailVerified: switch (payload['emailVerified']) {
+      final bool value => value,
+      final String value => value.toLowerCase() != 'false',
+      _ => true,
+    },
   );
 }
 

--- a/lib/features/auth/presentation/verification_banner.dart
+++ b/lib/features/auth/presentation/verification_banner.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../domain/session.dart';
+import 'email_verification_controller.dart';
+import 'session_controller.dart';
+
+/// Whether the prompt has been dismissed for this session.
+///
+/// AF-05e calls the banner dismissible, and a dismissal that a rebuild undoes
+/// is not one. It lives here rather than in the widget so navigating away and
+/// back does not bring the banner straight back.
+final NotifierProvider<VerificationBannerDismissal, bool>
+verificationBannerDismissedProvider =
+    NotifierProvider<VerificationBannerDismissal, bool>(
+      VerificationBannerDismissal.new,
+    );
+
+class VerificationBannerDismissal extends Notifier<bool> {
+  @override
+  bool build() => false;
+
+  void dismiss() {
+    state = true;
+  }
+}
+
+/// AF-05e — the prompt an authenticated user with an unverified address sees.
+///
+/// Renders nothing at all when there is nothing to say, so the caller can place
+/// it unconditionally.
+class VerificationBanner extends ConsumerWidget {
+  const VerificationBanner({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final session = ref.watch(sessionControllerProvider);
+
+    if (session is! Authenticated || session.principal.emailVerified) {
+      return const SizedBox.shrink();
+    }
+
+    if (ref.watch(verificationBannerDismissedProvider)) {
+      return const SizedBox.shrink();
+    }
+
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final resend = ref.watch(emailVerificationControllerProvider).resend;
+
+    return Material(
+      color: scheme.secondaryContainer,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 12, 8, 12),
+        child: Row(
+          children: <Widget>[
+            Icon(
+              Icons.mark_email_unread_outlined,
+              color: scheme.onSecondaryContainer,
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: switch (resend) {
+                ResendSent() => Text(
+                  'A new verification email is on its way.',
+                  style: TextStyle(color: scheme.onSecondaryContainer),
+                ),
+                ResendRejected(:final failure) => Text(
+                  failure.displayMessage,
+                  style: TextStyle(color: scheme.onSecondaryContainer),
+                ),
+                _ => Text(
+                  'Your email address is not verified yet.',
+                  style: TextStyle(color: scheme.onSecondaryContainer),
+                ),
+              },
+            ),
+            if (resend is! ResendSent)
+              TextButton(
+                onPressed: resend is Resending
+                    ? null
+                    : () => ref
+                          .read(emailVerificationControllerProvider.notifier)
+                          .resend(),
+                child: const Text('Resend'),
+              ),
+            IconButton(
+              tooltip: 'Dismiss',
+              icon: const Icon(Icons.close),
+              onPressed: () => ref
+                  .read(verificationBannerDismissedProvider.notifier)
+                  .dismiss(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/verify_email_screen.dart
+++ b/lib/features/auth/presentation/verify_email_screen.dart
@@ -1,0 +1,226 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../core/result/result.dart';
+import '../../../shared/widgets/failure_banner.dart';
+import '../domain/session.dart';
+import 'email_verification_controller.dart';
+import 'session_controller.dart';
+
+/// The email verification screen, opened by the link mailed at person creation.
+///
+/// It verifies on open rather than waiting for a tap: the user already acted by
+/// following the link, and asking them to confirm it twice adds nothing.
+class VerifyEmailScreen extends ConsumerStatefulWidget {
+  const VerifyEmailScreen({required this.token, super.key});
+
+  /// The token from `?token=…`, or `null` when the link carried none.
+  final String? token;
+
+  @override
+  ConsumerState<VerifyEmailScreen> createState() => _VerifyEmailScreenState();
+}
+
+class _VerifyEmailScreenState extends ConsumerState<VerifyEmailScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        ref
+            .read(emailVerificationControllerProvider.notifier)
+            .verify(widget.token);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final state = ref.watch(emailVerificationControllerProvider);
+    final authenticated = ref.watch(sessionControllerProvider) is Authenticated;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Verify your email')),
+      body: SafeArea(
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 420),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  ...switch (state.verification) {
+                    Verifying() => <Widget>[
+                      const Center(child: CircularProgressIndicator()),
+                      const SizedBox(height: 16),
+                      Text(
+                        'Checking your link…',
+                        style: theme.textTheme.bodyMedium,
+                        textAlign: TextAlign.center,
+                      ),
+                    ],
+                    Verified(:final messages) => _verified(
+                      context,
+                      theme,
+                      messages,
+                      authenticated: authenticated,
+                    ),
+                    // AF-05b: the token is no good and cannot be corrected
+                    // here, so the resend below is the way on.
+                    VerifyRejected(:final failure) => <Widget>[
+                      Text(
+                        'That link did not work',
+                        style: theme.textTheme.headlineMedium,
+                      ),
+                      const SizedBox(height: 16),
+                      if (failure.kind == FailureKind.network)
+                        RetryBanner(
+                          onRetry: () => ref
+                              .read(
+                                emailVerificationControllerProvider.notifier,
+                              )
+                              .verify(widget.token),
+                        )
+                      else
+                        ErrorBanner(failure: failure),
+                    ],
+                    // AF-05a: no token, so nothing was ever sent.
+                    VerifyIdle() => <Widget>[
+                      Text(
+                        'This link is incomplete',
+                        style: theme.textTheme.headlineMedium,
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        'It carries no verification token, so there is nothing '
+                        'to confirm. Ask for a fresh email below.',
+                        style: theme.textTheme.bodyMedium,
+                      ),
+                    ],
+                  },
+                  // AF-05a and AF-05b both end here: the resend is what makes
+                  // either recoverable.
+                  if (state.verification is! Verified) ...<Widget>[
+                    const SizedBox(height: 24),
+                    _ResendSection(authenticated: authenticated),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// The success state, which AF-05d shares with the main flow.
+  ///
+  /// The API's own `messages` are shown when it sent any, because "already
+  /// verified" and "now verified" are both successes and only its wording
+  /// separates them.
+  List<Widget> _verified(
+    BuildContext context,
+    ThemeData theme,
+    List<String> messages, {
+    required bool authenticated,
+  }) => <Widget>[
+    Icon(
+      Icons.mark_email_read_outlined,
+      size: 48,
+      color: theme.colorScheme.primary,
+    ),
+    const SizedBox(height: 16),
+    Text('Your email is verified', style: theme.textTheme.headlineMedium),
+    const SizedBox(height: 8),
+    for (final message in messages)
+      Text(message, style: theme.textTheme.bodyMedium),
+    if (messages.isEmpty)
+      Text(
+        'Your address is confirmed. Nothing else is needed.',
+        style: theme.textTheme.bodyMedium,
+      ),
+    const SizedBox(height: 24),
+    // Onward to the home screen when a session exists, and to sign-in
+    // otherwise — someone following a link from their mail client usually
+    // holds neither.
+    FilledButton(
+      onPressed: () => context.go(authenticated ? '/' : '/login'),
+      child: Text(authenticated ? 'Continue' : 'Sign in'),
+    ),
+  ];
+}
+
+/// AF-05c — the resend action, and what to do when it is not available.
+///
+/// The API reads the person from the bearer token, so only a signed-in caller
+/// can ask for a fresh email. An anonymous one is sent to sign in rather than
+/// offered a control that could only answer 401.
+class _ResendSection extends ConsumerWidget {
+  const _ResendSection({required this.authenticated});
+
+  final bool authenticated;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final resend = ref.watch(emailVerificationControllerProvider).resend;
+
+    if (!authenticated) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Text(
+            'Sign in to ask for a new verification email — we send it to the '
+            'address on your account, so we need to know whose it is.',
+            style: theme.textTheme.bodyMedium,
+          ),
+          const SizedBox(height: 16),
+          FilledButton(
+            onPressed: () => context.go('/login'),
+            child: const Text('Sign in'),
+          ),
+        ],
+      );
+    }
+
+    return switch (resend) {
+      ResendSent() => Text(
+        'A new verification email is on its way. Check your inbox.',
+        style: theme.textTheme.bodyMedium,
+      ),
+      _ => Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          if (resend case ResendRejected(:final failure)) ...<Widget>[
+            if (failure.kind == FailureKind.network)
+              RetryBanner(
+                onRetry: () => ref
+                    .read(emailVerificationControllerProvider.notifier)
+                    .resend(),
+              )
+            else
+              ErrorBanner(failure: failure),
+            const SizedBox(height: 16),
+          ],
+          FilledButton(
+            onPressed: resend is Resending
+                ? null
+                : () => ref
+                      .read(emailVerificationControllerProvider.notifier)
+                      .resend(),
+            child: resend is Resending
+                ? const SizedBox.square(
+                    dimension: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Text('Send a new email'),
+          ),
+        ],
+      ),
+    };
+  }
+}

--- a/lib/features/home/presentation/home_screen.dart
+++ b/lib/features/home/presentation/home_screen.dart
@@ -6,6 +6,7 @@ import '../../../app/theme_mode_controller.dart';
 import '../../../shared/layout/adaptive_scaffold.dart';
 import '../../auth/domain/session.dart';
 import '../../auth/presentation/session_controller.dart';
+import '../../auth/presentation/verification_banner.dart';
 import 'destinations.dart';
 
 /// The screen behind `/`, and the shell every administrative screen will be
@@ -40,21 +41,30 @@ class HomeScreen extends ConsumerWidget {
               ref.read(sessionControllerProvider.notifier).signOut(),
         ),
       ],
-      body: Center(
-        child: Padding(
-          padding: const EdgeInsets.all(24),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
-              Text(
-                'Signed in as ${principal.email}',
-                style: Theme.of(context).textTheme.titleMedium,
+      body: Column(
+        children: <Widget>[
+          // AF-05e: renders nothing when the address is verified or the prompt
+          // was dismissed, so it sits here unconditionally.
+          const VerificationBanner(),
+          Expanded(
+            child: Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: <Widget>[
+                    Text(
+                      'Signed in as ${principal.email}',
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                    const SizedBox(height: 8),
+                    Text(_roleLabel(principal.role)),
+                  ],
+                ),
               ),
-              const SizedBox(height: 8),
-              Text(_roleLabel(principal.role)),
-            ],
+            ),
           ),
-        ),
+        ],
       ),
     );
   }

--- a/test/features/auth/data/auth_repository_impl_test.dart
+++ b/test/features/auth/data/auth_repository_impl_test.dart
@@ -529,6 +529,143 @@ void main() {
       expect(result.failureOrNull?.kind, FailureKind.network);
     },
   );
+
+  test('GivenAVerificationToken_WhenVerifying_ThenTheTokenIsSent', () async {
+    // Given
+    repository = repositoryAnswering(
+      const _Answer(
+        status: 200,
+        body: <String, dynamic>{
+          'success': true,
+          'messages': <String>[],
+          'errors': <String>[],
+          'data': null,
+        },
+      ),
+    );
+
+    // When
+    await repository.verifyEmail(token: 'verification-token');
+
+    // Then
+    expect(adapter.requests.single['token'], 'verification-token');
+  });
+
+  // AF-05d — an address already verified answers successfully, and only the
+  // envelope's messages say which of the two happened.
+  test('GivenAcceptedEnvelope_WhenVerifying_ThenMessagesAreReturned', () async {
+    // Given
+    repository = repositoryAnswering(
+      const _Answer(
+        status: 200,
+        body: <String, dynamic>{
+          'success': true,
+          'messages': <String>['This address was already verified.'],
+          'errors': <String>[],
+          'data': null,
+        },
+      ),
+    );
+
+    // When
+    final result = await repository.verifyEmail(token: 'spent-token');
+
+    // Then
+    expect(result.valueOrNull, <String>['This address was already verified.']);
+  });
+
+  // AF-05b — an unknown, expired, or spent token answers 400 by name.
+  test('GivenRejectedToken_WhenVerifying_ThenApiErrorsAreReturned', () async {
+    // Given
+    repository = repositoryAnswering(
+      const _Answer(
+        status: 400,
+        body: <String, dynamic>{
+          'success': false,
+          'errors': <String>['The verification token has expired.'],
+        },
+      ),
+    );
+
+    // When
+    final result = await repository.verifyEmail(token: 'stale');
+
+    // Then
+    expect(result.failureOrNull?.errors, <String>[
+      'The verification token has expired.',
+    ]);
+  });
+
+  test(
+    'GivenTransportFailure_WhenVerifying_ThenNetworkFailureIsReturned',
+    () async {
+      // Given
+      repository = repositoryAnswering(const _Answer(status: 0));
+
+      // When
+      final result = await repository.verifyEmail(token: 'verification-token');
+
+      // Then
+      expect(result.failureOrNull?.kind, FailureKind.network);
+    },
+  );
+
+  // AF-05c — the resend takes no body; the person comes from the token.
+  test('GivenASession_WhenResending_ThenNoBodyIsSent', () async {
+    // Given
+    repository = repositoryAnswering(
+      const _Answer(
+        status: 200,
+        body: <String, dynamic>{
+          'success': true,
+          'errors': <String>[],
+          'data': null,
+        },
+      ),
+    );
+
+    // When
+    final result = await repository.resendVerificationEmail();
+
+    // Then
+    expect(result.isSuccess, isTrue);
+    expect(adapter.requests, isEmpty);
+  });
+
+  test('GivenRejectedResend_WhenResending_ThenApiErrorsAreReturned', () async {
+    // Given
+    repository = repositoryAnswering(
+      const _Answer(
+        status: 400,
+        body: <String, dynamic>{
+          'success': false,
+          'errors': <String>['This address is already verified.'],
+        },
+      ),
+    );
+
+    // When
+    final result = await repository.resendVerificationEmail();
+
+    // Then
+    expect(result.failureOrNull?.errors, <String>[
+      'This address is already verified.',
+    ]);
+  });
+
+  test(
+    'GivenTransportFailure_WhenResending_ThenNetworkFailureIsReturned',
+    () async {
+      // Given
+      repository = repositoryAnswering(const _Answer(status: 0));
+
+      // When
+      final result = await repository.resendVerificationEmail();
+
+      // Then
+      expect(result.failureOrNull?.kind, FailureKind.network);
+    },
+  );
 }
 
 /// What the stub answers with. A [status] of zero stands for a connection that

--- a/test/features/auth/presentation/email_verification_controller_test.dart
+++ b/test/features/auth/presentation/email_verification_controller_test.dart
@@ -1,0 +1,233 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/features/auth/domain/auth_repository.dart';
+import 'package:heimdall_ui/features/auth/presentation/email_verification_controller.dart';
+import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockAuthRepository extends Mock implements AuthRepository {}
+
+void main() {
+  late _MockAuthRepository repository;
+  late ProviderContainer container;
+
+  EmailVerificationController controllerUnderTest() {
+    container = ProviderContainer(
+      overrides: <Override>[
+        authRepositoryProvider.overrideWithValue(repository),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    return container.read(emailVerificationControllerProvider.notifier);
+  }
+
+  EmailVerificationState currentState() =>
+      container.read(emailVerificationControllerProvider);
+
+  void answerVerifyWith(Result<List<String>> result) {
+    when(
+      () => repository.verifyEmail(token: any(named: 'token')),
+    ).thenAnswer((_) async => result);
+  }
+
+  void answerResendWith(Result<void> result) {
+    when(
+      () => repository.resendVerificationEmail(),
+    ).thenAnswer((_) async => result);
+  }
+
+  setUp(() {
+    repository = _MockAuthRepository();
+  });
+
+  test('GivenAValidToken_WhenVerified_ThenStateIsVerified', () async {
+    // Given
+    answerVerifyWith(const Success<List<String>>(<String>['Email verified.']));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.verify('verification-token');
+
+    // Then
+    expect(currentState().verification, isA<Verified>());
+  });
+
+  test('GivenAValidToken_WhenVerified_ThenTheTokenIsSent', () async {
+    // Given
+    answerVerifyWith(const Success<List<String>>(<String>[]));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.verify('verification-token');
+
+    // Then
+    verify(() => repository.verifyEmail(token: 'verification-token')).called(1);
+  });
+
+  // AF-05d — an address that was already verified answers successfully, and
+  // the API's own wording is what says so.
+  test('GivenAlreadyVerified_WhenVerified_ThenTheApiMessagesAreKept', () async {
+    // Given
+    answerVerifyWith(
+      const Success<List<String>>(<String>[
+        'This address was already verified.',
+      ]),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.verify('spent-token');
+
+    // Then
+    expect((currentState().verification as Verified).messages, <String>[
+      'This address was already verified.',
+    ]);
+  });
+
+  // AF-05a — no token means no request.
+  test('GivenNoToken_WhenVerified_ThenNoRequestIsMade', () async {
+    // Given
+    answerVerifyWith(const Success<List<String>>(<String>[]));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.verify(null);
+
+    // Then
+    verifyNever(() => repository.verifyEmail(token: any(named: 'token')));
+  });
+
+  test('GivenAnEmptyToken_WhenVerified_ThenStateStaysIdle', () async {
+    // Given
+    answerVerifyWith(const Success<List<String>>(<String>[]));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.verify('');
+
+    // Then
+    expect(currentState().verification, isA<VerifyIdle>());
+  });
+
+  // AF-05b — the API refuses the token.
+  test('GivenRejectedToken_WhenVerified_ThenApiErrorsAreKept', () async {
+    // Given
+    answerVerifyWith(
+      const FailureResult<List<String>>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['The verification token has expired.'],
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.verify('stale');
+
+    // Then
+    expect(
+      (currentState().verification as VerifyRejected).failure.errors,
+      <String>['The verification token has expired.'],
+    );
+  });
+
+  test('GivenTransportFailure_WhenVerified_ThenStateIsRejected', () async {
+    // Given
+    answerVerifyWith(
+      const FailureResult<List<String>>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.verify('verification-token');
+
+    // Then
+    expect(
+      (currentState().verification as VerifyRejected).failure.kind,
+      FailureKind.network,
+    );
+  });
+
+  // AF-05c — the resend.
+  test('GivenAResendRequest_WhenSent_ThenStateIsSent', () async {
+    // Given
+    answerResendWith(const Success<void>(null));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.resend();
+
+    // Then
+    expect(currentState().resend, isA<ResendSent>());
+  });
+
+  test('GivenRejectedResend_WhenSent_ThenApiErrorsAreKept', () async {
+    // Given
+    answerResendWith(
+      const FailureResult<void>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['This address is already verified.'],
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.resend();
+
+    // Then
+    expect((currentState().resend as ResendRejected).failure.errors, <String>[
+      'This address is already verified.',
+    ]);
+  });
+
+  test(
+    'GivenResendInFlight_WhenRequestedAgain_ThenOnlyOneRequestIsSent',
+    () async {
+      // Given
+      final pending = Completer<Result<void>>();
+      when(
+        () => repository.resendVerificationEmail(),
+      ).thenAnswer((_) => pending.future);
+      final controller = controllerUnderTest();
+
+      // When
+      final first = controller.resend();
+      final second = controller.resend();
+      pending.complete(const Success<void>(null));
+      await Future.wait<void>(<Future<void>>[first, second]);
+
+      // Then
+      verify(() => repository.resendVerificationEmail()).called(1);
+    },
+  );
+
+  // The two halves are independent: a resend after a refused token must not
+  // overwrite what the verification said.
+  test('GivenRejectedToken_WhenResent_ThenTheRejectionIsKept', () async {
+    // Given
+    answerVerifyWith(
+      const FailureResult<List<String>>(
+        Failure(kind: FailureKind.validation, errors: <String>['No good.']),
+      ),
+    );
+    answerResendWith(const Success<void>(null));
+    final controller = controllerUnderTest();
+    await controller.verify('stale');
+
+    // When
+    await controller.resend();
+
+    // Then
+    expect(currentState().verification, isA<VerifyRejected>());
+    expect(currentState().resend, isA<ResendSent>());
+  });
+}

--- a/test/features/auth/presentation/session_controller_test.dart
+++ b/test/features/auth/presentation/session_controller_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:heimdall_ui/core/result/result.dart';
@@ -429,4 +431,47 @@ void main() {
     expect(principal.role, Role.user);
     expect(principal.id, isEmpty);
   });
+
+  // AF-05e — the claim the unverified-address prompt is decided by.
+  test('GivenUnverifiedClaim_WhenPrincipalRead_ThenEmailIsUnverified', () {
+    // Given
+    final token = AuthToken(
+      value: _jwtWith(<String, dynamic>{'emailVerified': false}),
+      expiresAt: DateTime.utc(2030),
+    );
+
+    // When
+    final principal = principalFromToken(token);
+
+    // Then
+    expect(principal.emailVerified, isFalse);
+  });
+
+  // Absent is not the same as false: a token that says nothing about
+  // verification must not raise the prompt.
+  test('GivenNoVerificationClaim_WhenPrincipalRead_ThenEmailIsVerified', () {
+    // Given
+    final token = AuthToken(
+      value: _jwtWith(<String, dynamic>{}),
+      expiresAt: DateTime.utc(2030),
+    );
+
+    // When
+    final principal = principalFromToken(token);
+
+    // Then
+    expect(principal.emailVerified, isTrue);
+  });
+}
+
+/// Builds a JWT whose payload is the standard User claims plus [extra].
+String _jwtWith(Map<String, dynamic> extra) {
+  final claims = <String, dynamic>{
+    'sub': 'id',
+    'email': 'a@b.c',
+    'role': 3,
+    ...extra,
+  };
+
+  return 'header.${base64Url.encode(utf8.encode(jsonEncode(claims)))}.signature';
 }

--- a/test/features/auth/presentation/verification_banner_test.dart
+++ b/test/features/auth/presentation/verification_banner_test.dart
@@ -1,0 +1,193 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdall_ui/app/theme.dart';
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/core/storage/token_store.dart';
+import 'package:heimdall_ui/features/auth/domain/auth_repository.dart';
+import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
+import 'package:heimdall_ui/features/auth/presentation/verification_banner.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockAuthRepository extends Mock implements AuthRepository {}
+
+/// A token naming a User, with [verified] deciding the claim AF-05e reads.
+/// Pass `null` to leave the claim out entirely.
+String jwtWith({bool? verified}) {
+  final claims = <String, dynamic>{'sub': 'id', 'email': 'a@b.c', 'role': 3};
+
+  if (verified != null) {
+    claims['emailVerified'] = verified;
+  }
+
+  return 'header.${base64Url.encode(utf8.encode(jsonEncode(claims)))}.signature';
+}
+
+void main() {
+  late _MockAuthRepository repository;
+  late InMemoryTokenStore store;
+  late ProviderContainer container;
+
+  Future<void> pump(
+    WidgetTester tester, {
+    String? jwt,
+    ThemeData? theme,
+  }) async {
+    if (jwt != null) {
+      await store.write(AuthToken(value: jwt, expiresAt: DateTime.utc(2030)));
+    }
+
+    container = ProviderContainer(
+      overrides: <Override>[
+        authRepositoryProvider.overrideWithValue(repository),
+        tokenStoreProvider.overrideWithValue(store),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(sessionControllerProvider.notifier).restore();
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          theme: theme ?? buildLightTheme(),
+          home: const Scaffold(body: VerificationBanner()),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  setUp(() {
+    repository = _MockAuthRepository();
+    store = InMemoryTokenStore();
+    when(
+      () => repository.resendVerificationEmail(),
+    ).thenAnswer((_) async => const Success<void>(null));
+  });
+
+  // AF-05e — the prompt an unverified authenticated user sees.
+  testWidgets('GivenUnverifiedSession_WhenRendered_ThenThePromptIsShown', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, jwt: jwtWith(verified: false));
+
+    // Then
+    expect(
+      find.text('Your email address is not verified yet.'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('GivenVerifiedSession_WhenRendered_ThenNothingIsShown', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, jwt: jwtWith(verified: true));
+
+    // Then
+    expect(find.text('Your email address is not verified yet.'), findsNothing);
+  });
+
+  testWidgets('GivenNoSession_WhenRendered_ThenNothingIsShown', (tester) async {
+    // Given / When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Your email address is not verified yet.'), findsNothing);
+  });
+
+  // An absent claim is not evidence of an unverified address, so it stays
+  // quiet rather than nagging on data it does not have.
+  testWidgets('GivenNoVerificationClaim_WhenRendered_ThenNothingIsShown', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, jwt: jwtWith());
+
+    // Then
+    expect(find.text('Your email address is not verified yet.'), findsNothing);
+  });
+
+  testWidgets('GivenThePrompt_WhenResendTapped_ThenTheApiIsCalled', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester, jwt: jwtWith(verified: false));
+
+    // When
+    await tester.tap(find.widgetWithText(TextButton, 'Resend'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(() => repository.resendVerificationEmail()).called(1);
+  });
+
+  testWidgets('GivenAcceptedResend_WhenSent_ThenConfirmationIsShown', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester, jwt: jwtWith(verified: false));
+
+    // When
+    await tester.tap(find.widgetWithText(TextButton, 'Resend'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(
+      find.text('A new verification email is on its way.'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('GivenRejectedResend_WhenSent_ThenTheApiErrorIsShown', (
+    tester,
+  ) async {
+    // Given
+    when(() => repository.resendVerificationEmail()).thenAnswer(
+      (_) async => const FailureResult<void>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['This address is already verified.'],
+        ),
+      ),
+    );
+    await pump(tester, jwt: jwtWith(verified: false));
+
+    // When
+    await tester.tap(find.widgetWithText(TextButton, 'Resend'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('This address is already verified.'), findsOneWidget);
+  });
+
+  // AF-05e — and it is dismissible.
+  testWidgets('GivenThePrompt_WhenDismissed_ThenItIsGone', (tester) async {
+    // Given
+    await pump(tester, jwt: jwtWith(verified: false));
+
+    // When
+    await tester.tap(find.byIcon(Icons.close));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('Your email address is not verified yet.'), findsNothing);
+  });
+
+  testWidgets('GivenDarkTheme_WhenRendered_ThenThePromptIsShown', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, jwt: jwtWith(verified: false), theme: buildDarkTheme());
+
+    // Then
+    expect(
+      find.text('Your email address is not verified yet.'),
+      findsOneWidget,
+    );
+  });
+}

--- a/test/features/auth/presentation/verify_email_screen_test.dart
+++ b/test/features/auth/presentation/verify_email_screen_test.dart
@@ -1,0 +1,406 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:heimdall_ui/app/theme.dart';
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/core/storage/token_store.dart';
+import 'package:heimdall_ui/features/auth/domain/auth_repository.dart';
+import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
+import 'package:heimdall_ui/features/auth/presentation/verify_email_screen.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockAuthRepository extends Mock implements AuthRepository {}
+
+/// A token whose payload names a verified User, which is all this screen needs
+/// to decide that a session exists.
+String _jwt() {
+  final payload = base64Url.encode(
+    utf8.encode(
+      jsonEncode(<String, dynamic>{
+        'sub': 'id',
+        'email': 'a@b.c',
+        'role': 3,
+        'emailVerified': true,
+      }),
+    ),
+  );
+
+  return 'header.$payload.signature';
+}
+
+void main() {
+  late _MockAuthRepository repository;
+  late InMemoryTokenStore store;
+  late ProviderContainer container;
+  late GoRouter router;
+
+  Future<void> pump(
+    WidgetTester tester, {
+    String? token = 'verification-token',
+    bool signedIn = false,
+    Size size = const Size(400, 900),
+    ThemeData? theme,
+  }) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    if (signedIn) {
+      await store.write(
+        AuthToken(value: _jwt(), expiresAt: DateTime.utc(2030)),
+      );
+    }
+
+    container = ProviderContainer(
+      overrides: <Override>[
+        authRepositoryProvider.overrideWithValue(repository),
+        tokenStoreProvider.overrideWithValue(store),
+      ],
+    );
+    addTearDown(container.dispose);
+    // Settle the start-up read before the screen asks about the session.
+    await container.read(sessionControllerProvider.notifier).restore();
+
+    router = GoRouter(
+      initialLocation: token == null
+          ? '/verify-email'
+          : '/verify-email?token=$token',
+      routes: <RouteBase>[
+        GoRoute(
+          path: '/verify-email',
+          builder: (context, state) =>
+              VerifyEmailScreen(token: state.uri.queryParameters['token']),
+        ),
+        GoRoute(
+          path: '/',
+          builder: (context, state) => const Scaffold(body: Text('home')),
+        ),
+        GoRoute(
+          path: '/login',
+          builder: (context, state) => const Scaffold(body: Text('login')),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(
+          theme: theme ?? buildLightTheme(),
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  void answerVerifyWith(Result<List<String>> result) {
+    when(
+      () => repository.verifyEmail(token: any(named: 'token')),
+    ).thenAnswer((_) async => result);
+  }
+
+  void answerResendWith(Result<void> result) {
+    when(
+      () => repository.resendVerificationEmail(),
+    ).thenAnswer((_) async => result);
+  }
+
+  setUp(() {
+    repository = _MockAuthRepository();
+    store = InMemoryTokenStore();
+  });
+
+  testWidgets('GivenAVerificationLink_WhenOpened_ThenTheTokenIsVerified', (
+    tester,
+  ) async {
+    // Given
+    answerVerifyWith(const Success<List<String>>(<String>[]));
+
+    // When
+    await pump(tester);
+
+    // Then
+    verify(() => repository.verifyEmail(token: 'verification-token')).called(1);
+  });
+
+  testWidgets('GivenAcceptedToken_WhenOpened_ThenSuccessIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerVerifyWith(const Success<List<String>>(<String>[]));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Your email is verified'), findsOneWidget);
+  });
+
+  // AF-05d — the API's own wording is what says it was already verified.
+  testWidgets('GivenAlreadyVerified_WhenOpened_ThenTheApiMessageIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerVerifyWith(
+      const Success<List<String>>(<String>[
+        'This address was already verified.',
+      ]),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('This address was already verified.'), findsOneWidget);
+  });
+
+  testWidgets('GivenNoSession_WhenVerified_ThenSignInIsOffered', (
+    tester,
+  ) async {
+    // Given
+    answerVerifyWith(const Success<List<String>>(<String>[]));
+    await pump(tester);
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Sign in'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('login'), findsOneWidget);
+  });
+
+  testWidgets('GivenASession_WhenVerified_ThenHomeIsOffered', (tester) async {
+    // Given
+    answerVerifyWith(const Success<List<String>>(<String>[]));
+    answerResendWith(const Success<void>(null));
+    await pump(tester, signedIn: true);
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Continue'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('home'), findsOneWidget);
+  });
+
+  // AF-05a — a link with no token verifies nothing and offers the resend.
+  testWidgets('GivenNoToken_WhenOpened_ThenNoRequestIsMade', (tester) async {
+    // Given
+    answerVerifyWith(const Success<List<String>>(<String>[]));
+
+    // When
+    await pump(tester, token: null);
+
+    // Then
+    verifyNever(() => repository.verifyEmail(token: any(named: 'token')));
+  });
+
+  testWidgets('GivenNoToken_WhenOpened_ThenTheLinkIsCalledIncomplete', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, token: null);
+
+    // Then
+    expect(find.text('This link is incomplete'), findsOneWidget);
+  });
+
+  testWidgets('GivenNoTokenAndASession_WhenOpened_ThenResendIsOffered', (
+    tester,
+  ) async {
+    // Given
+    answerResendWith(const Success<void>(null));
+
+    // When
+    await pump(tester, token: null, signedIn: true);
+
+    // Then
+    expect(
+      find.widgetWithText(FilledButton, 'Send a new email'),
+      findsOneWidget,
+    );
+  });
+
+  // The resend endpoint reads the person from the bearer token, so an
+  // anonymous caller is sent to sign in rather than offered a dead control.
+  testWidgets('GivenNoTokenAndNoSession_WhenOpened_ThenSignInIsOffered', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, token: null);
+
+    // Then
+    expect(find.widgetWithText(FilledButton, 'Sign in'), findsOneWidget);
+    expect(find.widgetWithText(FilledButton, 'Send a new email'), findsNothing);
+  });
+
+  // AF-05b — the API refuses the token, and the resend is the way on.
+  testWidgets('GivenRejectedToken_WhenOpened_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerVerifyWith(
+      const FailureResult<List<String>>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['The verification token has expired.'],
+        ),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('The verification token has expired.'), findsOneWidget);
+  });
+
+  testWidgets('GivenRejectedTokenAndASession_WhenOpened_ThenResendIsOffered', (
+    tester,
+  ) async {
+    // Given
+    answerVerifyWith(
+      const FailureResult<List<String>>(
+        Failure(kind: FailureKind.validation, errors: <String>['No good.']),
+      ),
+    );
+    answerResendWith(const Success<void>(null));
+
+    // When
+    await pump(tester, signedIn: true);
+
+    // Then
+    expect(
+      find.widgetWithText(FilledButton, 'Send a new email'),
+      findsOneWidget,
+    );
+  });
+
+  // AF-05c — the resend is sent and confirmed neutrally.
+  testWidgets('GivenASession_WhenResendRequested_ThenTheApiIsCalled', (
+    tester,
+  ) async {
+    // Given
+    answerVerifyWith(
+      const FailureResult<List<String>>(
+        Failure(kind: FailureKind.validation, errors: <String>['No good.']),
+      ),
+    );
+    answerResendWith(const Success<void>(null));
+    await pump(tester, signedIn: true);
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Send a new email'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(() => repository.resendVerificationEmail()).called(1);
+  });
+
+  testWidgets('GivenAcceptedResend_WhenRequested_ThenConfirmationIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerVerifyWith(
+      const FailureResult<List<String>>(
+        Failure(kind: FailureKind.validation, errors: <String>['No good.']),
+      ),
+    );
+    answerResendWith(const Success<void>(null));
+    await pump(tester, signedIn: true);
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Send a new email'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(
+      find.text('A new verification email is on its way. Check your inbox.'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('GivenRejectedResend_WhenRequested_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerVerifyWith(
+      const FailureResult<List<String>>(
+        Failure(kind: FailureKind.validation, errors: <String>['No good.']),
+      ),
+    );
+    answerResendWith(
+      const FailureResult<void>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['This address is already verified.'],
+        ),
+      ),
+    );
+    await pump(tester, signedIn: true);
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Send a new email'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('This address is already verified.'), findsOneWidget);
+  });
+
+  testWidgets('GivenCompactWidth_WhenRendered_ThenTheOutcomeIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerVerifyWith(const Success<List<String>>(<String>[]));
+
+    // When
+    await pump(tester, size: const Size(400, 900));
+
+    // Then
+    expect(find.text('Your email is verified'), findsOneWidget);
+  });
+
+  testWidgets('GivenMediumWidth_WhenRendered_ThenTheOutcomeIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerVerifyWith(const Success<List<String>>(<String>[]));
+
+    // When
+    await pump(tester, size: const Size(800, 900));
+
+    // Then
+    expect(find.text('Your email is verified'), findsOneWidget);
+  });
+
+  testWidgets('GivenExpandedWidth_WhenRendered_ThenTheOutcomeIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerVerifyWith(const Success<List<String>>(<String>[]));
+
+    // When
+    await pump(tester, size: const Size(1400, 900));
+
+    // Then
+    expect(find.text('Your email is verified'), findsOneWidget);
+  });
+
+  testWidgets('GivenDarkTheme_WhenRendered_ThenTheOutcomeIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerVerifyWith(const Success<List<String>>(<String>[]));
+
+    // When
+    await pump(tester, theme: buildDarkTheme());
+
+    // Then
+    expect(find.text('Your email is verified'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Implements UI-05 from the [Use Case Specification Document](docs/requirements/Use%20Case%20Specification%20Document.md), delivering FR-AU-12, FR-AU-13 and FR-AU-14.

## Flows implemented

| Flow | What it does |
| --- | --- |
| **Main** | `/verify-email?token=…` verifies on open — the user already acted by following the link — shows progress, then confirms and routes onward: home when a session exists, sign-in otherwise. |
| **AF-05a** | A link with no token sends nothing, says the link is incomplete, and offers the resend. |
| **AF-05b** | A token the API refuses shows the returned errors, with the resend as the way on. |
| **AF-05c** | The resend calls `POST /api/auth/resend-verification` and confirms neutrally. |
| **AF-05d** | An already-verified address is a success like any other; the API's own `messages` are carried up and shown, since its wording is the only thing separating the two. |
| **AF-05e** | An authenticated user with an unverified address sees a dismissible prompt on the home screen offering the resend. The dismissal lives in a provider, so a rebuild does not undo it. |

## Two constraints worth flagging

**The resend needs a session.** `POST /api/auth/resend-verification` reads the person from the bearer token — an anonymous caller cannot use it. Rather than offer a control that could only answer 401, AF-05a and AF-05b route an anonymous user to sign in and say why. Both flows still lead somewhere; the route just goes through sign-in when the API demands it.

**Where `emailVerified` comes from — an assumption to check.** Nothing in the login, 2FA or Google responses reports whether the signed-in person's address is verified; `emailVerified` appears only on `PersonOutput`, which is UI-08's read. So AF-05e reads an `emailVerified` claim from the token, exactly as the role, scope and owned-scope claims are already read in `principalFromToken`. **An absent claim reads as verified** — it is not evidence of the opposite, and nagging on data the client does not have is worse than staying quiet. If the API does not in fact put that claim in the token, AF-05e will never fire in production and the fix is either a claim on the API side or a person read once UI-08 lands. Worth a look.

## Verification

```
dart format --set-exit-if-changed . && flutter analyze && flutter test
```

All three pass; **228 tests**, none skipped. Coverage added:

- `email_verification_controller_test.dart` — the main flow, the request, AF-05a (no request, state stays idle), AF-05b, AF-05c, AF-05d, the transport failure, the in-flight guard, and that a resend does not overwrite a rejected verification.
- `verify_email_screen_test.dart` — verification on open, the success state and both onward routes, AF-05a, AF-05b, AF-05c (call, confirmation, rejection), AF-05d, the anonymous sign-in route, all three breakpoints, and the dark theme.
- `verification_banner_test.dart` — AF-05e shown, hidden when verified, hidden with no session, hidden when the claim is absent, the resend and its outcomes, dismissal, and the dark theme.
- `session_controller_test.dart` — the `emailVerified` claim, present-false and absent.
- `auth_repository_impl_test.dart` — verify's request body, the messages, a rejected token, resend's empty body, a rejected resend, and both transport failures.

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
