### PR TITLE
UI-06: Sign in and sign out with Google

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,26 @@ Configuration is supplied at build time. Nothing is read from a file at runtime.
 | --- | --- | --- |
 | `HEIMDALL_API_BASE_URL` | In any real deployment | `http://localhost:5000` |
 | `HEIMDALL_GOOGLE_CLIENT_ID` | Only for Google Sign-In | unset — the Google control is hidden |
+| `HEIMDALL_SCOPE_ID` | Only when no calling application supplies one | unset — see below |
+
+### The target scope
+
+Heimdall UI is opened by the applications that use Heimdall's services, and the scope being entered
+is theirs to name — there is no screen here that asks for it, and no endpoint an anonymous caller
+could list scopes from. On the web the calling application writes the scope's `PublicId` into
+**session storage** before sending the user here:
+
+```js
+sessionStorage.setItem('heimdall.scopeId', '<scope-public-id>');
+```
+
+Session storage rather than a cookie: it is scoped to the tab, so two tabs can act in two scopes; it
+is never attached to a request, so the scope cannot become a header the API did not ask for; and it
+dies with the tab, so a scope does not outlive the visit on a shared machine. It is read on every
+use, so a caller may change it between one attempt and the next.
+
+`HEIMDALL_SCOPE_ID` is the fallback for a build with no such caller — the desktop and Android
+targets, or a web build opened directly.
 
 ```bash
 flutter run --dart-define=HEIMDALL_API_BASE_URL=https://heimdall.example.com
@@ -222,7 +242,7 @@ the board is where an item's status changes as it moves.
 | UI-03: Request password recovery | ✅ | [#3](https://github.com/artur-rios/heimdall-ui/issues/3) |
 | UI-04: Reset password | ✅ | [#4](https://github.com/artur-rios/heimdall-ui/issues/4) |
 | UI-05: Verify email and resend verification | ✅ | [#5](https://github.com/artur-rios/heimdall-ui/issues/5) |
-| UI-06: Sign in and sign out with Google | ⬜ | [#6](https://github.com/artur-rios/heimdall-ui/issues/6) |
+| UI-06: Sign in and sign out with Google | ✅ | [#6](https://github.com/artur-rios/heimdall-ui/issues/6) |
 | UI-07: Guard routes by session and role | ⬜ | [#7](https://github.com/artur-rios/heimdall-ui/issues/7) |
 
 ### Profile & Security

--- a/docs/requirements/Operations & Infrastructure Document.md
+++ b/docs/requirements/Operations & Infrastructure Document.md
@@ -29,6 +29,37 @@ runtime, and no value is baked into source.
 | --- | --- | --- | --- |
 | `HEIMDALL_API_BASE_URL` | Yes, in any real deployment | `http://localhost:5000` | The API root. A trailing slash is trimmed. |
 | `HEIMDALL_GOOGLE_CLIENT_ID` | Only for Google Sign-In | unset | The Google client id for the target. When unset, the Google control is hidden rather than shown broken. |
+| `HEIMDALL_SCOPE_ID` | Only when no calling application supplies one | unset | The `PublicId` of the scope this build acts in. See §2.1 — on the web the calling application's value wins. |
+
+### 2.1 The target scope
+
+Heimdall UI is opened by the applications that use Heimdall's services, and **the scope being entered
+is theirs to name**. There is no screen here that asks for it, and no endpoint an anonymous caller
+could list scopes from, so it arrives from outside.
+
+On the **web**, the calling application writes the scope's `PublicId` into session storage before
+sending the user here:
+
+```js
+sessionStorage.setItem('heimdall.scopeId', '<scope-public-id>');
+```
+
+Session storage rather than a cookie, deliberately:
+
+- It is scoped to the tab, so two tabs can act in two scopes at once.
+- It is never attached to a request, so the scope cannot become a header the API did not ask for,
+  and cannot be replayed by a third party's form.
+- It dies with the tab, so a scope does not outlive the visit on a shared machine.
+
+The value is read on every use rather than captured at start-up, so a caller may change it between
+one attempt and the next.
+
+On **Windows, Linux, and Android** there is no calling web application, so `HEIMDALL_SCOPE_ID` is the
+whole answer. On the web it is the fallback used when the caller left nothing — a build opened
+directly rather than handed off to.
+
+When neither supplies a scope, the request is made without one and the API decides what that means.
+Nothing is invented on the client's side.
 
 Supply them per command:
 
@@ -41,7 +72,8 @@ Or keep them in a file that is **not committed** — `config/local.json` is git-
 ```json
 {
   "HEIMDALL_API_BASE_URL": "https://heimdall.example.com",
-  "HEIMDALL_GOOGLE_CLIENT_ID": "000000000000-example.apps.googleusercontent.com"
+  "HEIMDALL_GOOGLE_CLIENT_ID": "000000000000-example.apps.googleusercontent.com",
+  "HEIMDALL_SCOPE_ID": "00000000-0000-0000-0000-000000000001"
 }
 ```
 

--- a/lib/core/config/app_config.dart
+++ b/lib/core/config/app_config.dart
@@ -4,9 +4,13 @@
 /// literal beyond the local default, so a deployment address never reaches the
 /// repository.
 class AppConfig {
-  const AppConfig({required String apiBaseUrl, String? googleClientId})
-    : _rawApiBaseUrl = apiBaseUrl,
-      _rawGoogleClientId = googleClientId;
+  const AppConfig({
+    required String apiBaseUrl,
+    String? googleClientId,
+    String? scopeId,
+  }) : _rawApiBaseUrl = apiBaseUrl,
+       _rawGoogleClientId = googleClientId,
+       _rawScopeId = scopeId;
 
   /// Reads the configuration from the compile-time environment, falling back to
   /// a local API so the application runs with no flags at all.
@@ -16,10 +20,12 @@ class AppConfig {
       defaultValue: 'http://localhost:5000',
     ),
     googleClientId: String.fromEnvironment('HEIMDALL_GOOGLE_CLIENT_ID'),
+    scopeId: String.fromEnvironment('HEIMDALL_SCOPE_ID'),
   );
 
   final String _rawApiBaseUrl;
   final String? _rawGoogleClientId;
+  final String? _rawScopeId;
 
   /// The API root, without a trailing slash, so paths concatenate predictably.
   String get apiBaseUrl => _rawApiBaseUrl.endsWith('/')
@@ -37,4 +43,14 @@ class AppConfig {
 
   /// Whether the Google sign-in control should be offered at all.
   bool get isGoogleSignInConfigured => googleClientId != null;
+
+  /// The scope this build targets when no calling application named one.
+  ///
+  /// On the web the caller's value in session storage wins; this is what a
+  /// desktop or mobile build, which has no such caller, falls back to.
+  String? get scopeId {
+    final raw = _rawScopeId;
+
+    return (raw == null || raw.isEmpty) ? null : raw;
+  }
 }

--- a/lib/core/scope/scope_source.dart
+++ b/lib/core/scope/scope_source.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// The key a calling application writes the target scope under.
+///
+/// Heimdall UI is opened from the applications that use Heimdall's services,
+/// and the scope being entered is theirs to decide — there is no screen here
+/// that could ask for it, and no endpoint an anonymous caller could list them
+/// from.
+const String scopeStorageKey = 'heimdall.scopeId';
+
+/// Where the `PublicId` of the scope the caller is acting in comes from.
+///
+/// Read on demand rather than captured once: the calling application may
+/// rewrite it between one attempt and the next, and a value cached at start-up
+/// would then be the wrong one.
+abstract interface class ScopeSource {
+  String? read();
+}
+
+/// A scope fixed for the lifetime of the process.
+///
+/// Backs the non-web targets, where there is no calling web application to
+/// write anything and a build targets one deployment.
+class FixedScopeSource implements ScopeSource {
+  const FixedScopeSource(this._scopeId);
+
+  final String? _scopeId;
+
+  @override
+  String? read() {
+    final scopeId = _scopeId;
+
+    return (scopeId == null || scopeId.isEmpty) ? null : scopeId;
+  }
+}
+
+/// Overridden at start-up with the platform's source, and in tests with a fake.
+final Provider<ScopeSource> scopeSourceProvider = Provider<ScopeSource>(
+  (ref) => throw UnimplementedError('scopeSourceProvider must be overridden'),
+);

--- a/lib/core/scope/session_scope_source.dart
+++ b/lib/core/scope/session_scope_source.dart
@@ -1,0 +1,9 @@
+/// The platform's [ScopeSource], chosen at compile time.
+///
+/// On the web the calling application writes the scope into session storage
+/// before sending the user here; on every other target there is no such caller,
+/// so the build-time value is all there is.
+library;
+
+export 'session_scope_source_io.dart'
+    if (dart.library.js_interop) 'session_scope_source_web.dart';

--- a/lib/core/scope/session_scope_source_io.dart
+++ b/lib/core/scope/session_scope_source_io.dart
@@ -1,0 +1,6 @@
+import 'scope_source.dart';
+
+/// The non-web targets have no calling application to read a scope from, so the
+/// build-time value is the whole answer.
+ScopeSource sessionScopeSource({String? fallback}) =>
+    FixedScopeSource(fallback);

--- a/lib/core/scope/session_scope_source_web.dart
+++ b/lib/core/scope/session_scope_source_web.dart
@@ -1,0 +1,31 @@
+import 'package:web/web.dart' as web;
+
+import 'scope_source.dart';
+
+/// Reads the scope the calling application left in session storage.
+///
+/// Session storage rather than a cookie, deliberately: it is scoped to the tab,
+/// so two tabs can act in two scopes; it is never attached to a request, so the
+/// scope cannot become a header the API did not ask for; and it dies with the
+/// tab, so a scope does not outlive the visit on a shared machine.
+ScopeSource sessionScopeSource({String? fallback}) =>
+    _SessionStorageScopeSource(fallback);
+
+class _SessionStorageScopeSource implements ScopeSource {
+  const _SessionStorageScopeSource(this._fallback);
+
+  /// Used when the caller left nothing — a build that is opened directly
+  /// rather than handed off to.
+  final String? _fallback;
+
+  @override
+  String? read() {
+    final stored = web.window.sessionStorage.getItem(scopeStorageKey);
+
+    if (stored != null && stored.isNotEmpty) {
+      return stored;
+    }
+
+    return FixedScopeSource(_fallback).read();
+  }
+}

--- a/lib/core/storage/token_store.dart
+++ b/lib/core/storage/token_store.dart
@@ -4,21 +4,35 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 /// A bearer token together with the moment it stops being valid.
 class AuthToken {
-  const AuthToken({required this.value, required this.expiresAt});
+  const AuthToken({
+    required this.value,
+    required this.expiresAt,
+    this.viaGoogle = false,
+  });
 
   factory AuthToken.fromJson(Map<String, dynamic> json) => AuthToken(
     value: json['value']! as String,
     expiresAt: DateTime.parse(json['expiresAt']! as String),
+    // Absent in anything written before UI-06, which was password-only.
+    viaGoogle: json['viaGoogle'] as bool? ?? false,
   );
 
   final String value;
   final DateTime expiresAt;
+
+  /// Whether this session was established through Google.
+  ///
+  /// Stored rather than inferred because it outlives the exchange: signing out
+  /// of a restored session still has to tell Google about it, and nothing in
+  /// the token itself says where it came from.
+  final bool viaGoogle;
 
   bool get isExpired => DateTime.now().toUtc().isAfter(expiresAt.toUtc());
 
   Map<String, dynamic> toJson() => <String, dynamic>{
     'value': value,
     'expiresAt': expiresAt.toUtc().toIso8601String(),
+    'viaGoogle': viaGoogle,
   };
 }
 

--- a/lib/features/auth/data/auth_repository_impl.dart
+++ b/lib/features/auth/data/auth_repository_impl.dart
@@ -166,6 +166,61 @@ class ApiAuthRepository implements AuthRepository {
     }
   }
 
+  @override
+  Future<Result<AuthToken>> signInWithGoogle({
+    required String idToken,
+    String? scopeId,
+  }) async {
+    try {
+      final response = await _client.authGoogleSignIn(
+        body: GoogleSignInCommand(idToken: idToken, scopeId: scopeId),
+      );
+
+      if (response.success != true) {
+        return FailureResult<AuthToken>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: response.errors ?? const <String>[],
+          ),
+        );
+      }
+
+      final data = response.data;
+      final token = data?.token;
+      final expiresAt = data?.expiresAt;
+
+      if (token == null || expiresAt == null) {
+        return const FailureResult<AuthToken>(_incompleteResponse);
+      }
+
+      return Success<AuthToken>(
+        AuthToken(value: token, expiresAt: expiresAt, viaGoogle: true),
+      );
+    } on DioException catch (error) {
+      return FailureResult<AuthToken>(failureFromDioException(error));
+    }
+  }
+
+  @override
+  Future<Result<void>> signOutFromGoogle() async {
+    try {
+      final response = await _client.authGoogleSignOut();
+
+      if (response.success != true) {
+        return FailureResult<void>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: response.errors ?? const <String>[],
+          ),
+        );
+      }
+
+      return const Success<void>(null);
+    } on DioException catch (error) {
+      return FailureResult<void>(failureFromDioException(error));
+    }
+  }
+
   /// Reads a login response, which answers one of two ways: a usable token, or
   /// a challenge that must be answered before a session exists.
   Result<LoginOutcome> _outcomeFrom(LoginCommandOutputDataOutput response) {

--- a/lib/features/auth/data/google_sign_in_gateway_impl.dart
+++ b/lib/features/auth/data/google_sign_in_gateway_impl.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/foundation.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+
+import '../domain/google_sign_in_gateway.dart';
+
+/// [GoogleSignInGateway] over the `google_sign_in` plugin.
+///
+/// The only place in the application that knows the plugin exists; everything
+/// above it works in terms of [GoogleSignInAttempt].
+class PluginGoogleSignInGateway implements GoogleSignInGateway {
+  PluginGoogleSignInGateway(this._signIn, this._clientId);
+
+  final GoogleSignIn _signIn;
+
+  /// The client id this build was configured with, which the SDK needs on the
+  /// targets that do not read one from a bundled configuration file.
+  final String? _clientId;
+
+  /// The plugin requires [GoogleSignIn.initialize] exactly once, before
+  /// anything else. It is idempotent here so callers need not track it.
+  Future<void>? _initialization;
+
+  @override
+  GoogleSignInAvailability get availability {
+    // The web SDK answers `supportsAuthenticate()` false and renders its own
+    // button instead, which is a different control rather than no control.
+    if (kIsWeb) {
+      return GoogleSignInAvailability.platformControl;
+    }
+
+    try {
+      return _signIn.supportsAuthenticate()
+          ? GoogleSignInAvailability.interactive
+          : GoogleSignInAvailability.unsupported;
+    } on Object {
+      // AF-06e: Windows and Linux have no implementation to ask, and the
+      // platform interface throws rather than answering.
+      return GoogleSignInAvailability.unsupported;
+    }
+  }
+
+  @override
+  Future<void> initialize() =>
+      _initialization ??= _signIn.initialize(clientId: _clientId);
+
+  @override
+  Stream<GoogleIdTokenObtained> get idTokens => _signIn.authenticationEvents
+      .where((event) => event is GoogleSignInAuthenticationEventSignIn)
+      .map(
+        (event) => (event as GoogleSignInAuthenticationEventSignIn)
+            .user
+            .authentication
+            .idToken,
+      )
+      .where((idToken) => idToken != null)
+      .map((idToken) => GoogleIdTokenObtained(idToken!));
+
+  @override
+  Future<GoogleSignInAttempt> obtainIdToken() async {
+    if (availability != GoogleSignInAvailability.interactive) {
+      return const GoogleSignInUnsupported();
+    }
+
+    try {
+      await initialize();
+
+      final account = await _signIn.authenticate();
+      final idToken = account.authentication.idToken;
+
+      if (idToken == null) {
+        return const GoogleSignInUnavailable(
+          'Google did not return an ID token.',
+        );
+      }
+
+      return GoogleIdTokenObtained(idToken);
+    } on GoogleSignInException catch (error) {
+      // AF-06c: a cancellation is the user changing their mind, not an error.
+      return switch (error.code) {
+        GoogleSignInExceptionCode.canceled => const GoogleSignInCancelled(),
+        _ => GoogleSignInUnavailable(
+          error.description ?? 'Google sign-in could not be completed.',
+        ),
+      };
+    }
+  }
+
+  @override
+  Future<void> signOut() async {
+    if (_initialization == null) {
+      return;
+    }
+
+    await _signIn.signOut();
+  }
+}

--- a/lib/features/auth/domain/auth_repository.dart
+++ b/lib/features/auth/domain/auth_repository.dart
@@ -73,4 +73,18 @@ abstract interface class AuthRepository {
   /// caller can only ever ask for their own — and an anonymous caller cannot
   /// ask at all.
   Future<Result<void>> resendVerificationEmail();
+
+  /// Exchanges a Google ID token for a Heimdall token.
+  ///
+  /// [scopeId] is the scope being entered, which the calling application named
+  /// — the first exchange for a Google account in a scope creates the Google
+  /// User, every later one authenticates it.
+  Future<Result<AuthToken>> signInWithGoogle({
+    required String idToken,
+    String? scopeId,
+  });
+
+  /// Ends the caller's Google-authenticated session at the API. Takes no
+  /// argument: the Google User is read from the bearer token.
+  Future<Result<void>> signOutFromGoogle();
 }

--- a/lib/features/auth/domain/google_sign_in_gateway.dart
+++ b/lib/features/auth/domain/google_sign_in_gateway.dart
@@ -1,0 +1,67 @@
+/// How — or whether — Google's flow can be run on this target.
+enum GoogleSignInAvailability {
+  /// The application offers its own control and drives the flow from it.
+  interactive,
+
+  /// Google renders the control itself and reports the result out of band.
+  /// The web is like this: its SDK refuses to be driven from an arbitrary
+  /// widget, so the button on screen is Google's own.
+  platformControl,
+
+  /// AF-06e — the flow cannot be run here at all.
+  unsupported,
+}
+
+/// What asking Google to identify the user produced.
+sealed class GoogleSignInAttempt {
+  const GoogleSignInAttempt();
+}
+
+/// Google identified the user and issued an ID token for the API to exchange.
+final class GoogleIdTokenObtained extends GoogleSignInAttempt {
+  const GoogleIdTokenObtained(this.idToken);
+
+  final String idToken;
+}
+
+/// AF-06c — the user backed out of Google's own flow. Nothing was sent and
+/// nothing should change; this is not a failure to put in front of them.
+final class GoogleSignInCancelled extends GoogleSignInAttempt {
+  const GoogleSignInCancelled();
+}
+
+/// AF-06e — this target cannot run the flow.
+final class GoogleSignInUnsupported extends GoogleSignInAttempt {
+  const GoogleSignInUnsupported();
+}
+
+/// Google refused, or its SDK is misconfigured. Distinct from a rejection by
+/// Heimdall, which never reaches this type.
+final class GoogleSignInUnavailable extends GoogleSignInAttempt {
+  const GoogleSignInUnavailable(this.message);
+
+  final String message;
+}
+
+/// Google's half of UI-06, behind an interface so that the session controller
+/// and the sign-in screen never see the plugin — and so every flow above can be
+/// tested without Google's SDK.
+abstract interface class GoogleSignInGateway {
+  GoogleSignInAvailability get availability;
+
+  /// Prepares the SDK. Required before anything else, and safe to call twice.
+  Future<void> initialize();
+
+  /// Runs the flow from the application's own control.
+  /// Only meaningful when [availability] is
+  /// [GoogleSignInAvailability.interactive].
+  Future<GoogleSignInAttempt> obtainIdToken();
+
+  /// ID tokens arriving from a control Google rendered itself.
+  /// Only meaningful when [availability] is
+  /// [GoogleSignInAvailability.platformControl].
+  Stream<GoogleIdTokenObtained> get idTokens;
+
+  /// Ends the local Google session. Safe to call when there is none.
+  Future<void> signOut();
+}

--- a/lib/features/auth/presentation/google_button.dart
+++ b/lib/features/auth/presentation/google_button.dart
@@ -1,0 +1,5 @@
+/// The control Google renders for itself, on the targets that insist on it.
+library;
+
+export 'google_button_io.dart'
+    if (dart.library.js_interop) 'google_button_web.dart';

--- a/lib/features/auth/presentation/google_button_io.dart
+++ b/lib/features/auth/presentation/google_button_io.dart
@@ -1,0 +1,5 @@
+import 'package:flutter/widgets.dart';
+
+/// No target off the web renders its own control, so there is nothing to place
+/// here. The screen only reaches this when it should show nothing anyway.
+Widget buildPlatformGoogleButton() => const SizedBox.shrink();

--- a/lib/features/auth/presentation/google_button_web.dart
+++ b/lib/features/auth/presentation/google_button_web.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/widgets.dart';
+import 'package:google_sign_in_web/web_only.dart' as google;
+
+/// Google's own Sign-In button.
+///
+/// The web SDK will not be driven from an arbitrary widget — it answers
+/// `supportsAuthenticate()` false and requires this button — so what the user
+/// presses here is Google's, and the account arrives on the gateway's stream
+/// rather than as the result of a call.
+Widget buildPlatformGoogleButton() => google.renderButton();

--- a/lib/features/auth/presentation/google_sign_in_control.dart
+++ b/lib/features/auth/presentation/google_sign_in_control.dart
@@ -1,0 +1,141 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/result/result.dart';
+import '../../../shared/widgets/failure_banner.dart';
+import '../domain/google_sign_in_gateway.dart';
+import 'google_button.dart';
+import 'session_controller.dart';
+
+/// The Google sign-in control, in whichever form this target allows.
+///
+/// Two shapes, one behaviour: where the application may drive the flow it
+/// offers its own button; where Google insists on rendering the button itself
+/// the ID token arrives on a stream instead, and this listens for it. Either
+/// way the exchange, and everything that can go wrong with it, is the same.
+class GoogleSignInControl extends ConsumerStatefulWidget {
+  const GoogleSignInControl({required this.enabled, super.key});
+
+  /// False while the credentials form is submitting, so the two routes in
+  /// cannot be taken at once.
+  final bool enabled;
+
+  @override
+  ConsumerState<GoogleSignInControl> createState() =>
+      _GoogleSignInControlState();
+}
+
+class _GoogleSignInControlState extends ConsumerState<GoogleSignInControl> {
+  StreamSubscription<GoogleIdTokenObtained>? _tokens;
+
+  Failure? _failure;
+  bool _exchanging = false;
+
+  @override
+  void initState() {
+    super.initState();
+
+    final gateway = ref.read(googleSignInGatewayProvider);
+
+    if (gateway.availability == GoogleSignInAvailability.platformControl) {
+      // The SDK must be ready before its button can render, and the button is
+      // what starts the flow — so there is nothing to await it beside.
+      unawaited(gateway.initialize());
+      _tokens = gateway.idTokens.listen(
+        (obtained) => unawaited(_exchange(obtained.idToken)),
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    unawaited(_tokens?.cancel());
+    super.dispose();
+  }
+
+  /// Runs the flow ourselves, on a target that permits it.
+  Future<void> _signIn() async {
+    setState(() {
+      _exchanging = true;
+      _failure = null;
+    });
+
+    final result = await ref
+        .read(sessionControllerProvider.notifier)
+        .signInWithGoogle();
+
+    if (!mounted) {
+      return;
+    }
+
+    // AF-06c: a cancellation comes back successful and changes nothing, so the
+    // screen is exactly as the user left it.
+    setState(() {
+      _exchanging = false;
+      _failure = result.failureOrNull;
+    });
+  }
+
+  /// Exchanges a token that arrived from Google's own button.
+  Future<void> _exchange(String idToken) async {
+    setState(() {
+      _exchanging = true;
+      _failure = null;
+    });
+
+    final result = await ref
+        .read(sessionControllerProvider.notifier)
+        .exchangeGoogleIdToken(idToken);
+
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _exchanging = false;
+      _failure = result.failureOrNull;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final availability = ref.watch(googleSignInGatewayProvider).availability;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        // AF-06b and AF-06d both land here: what Heimdall said, shown as it
+        // came, with the credentials form untouched above it.
+        if (_failure case final Failure failure) ...<Widget>[
+          ErrorBanner(failure: failure),
+          const SizedBox(height: 16),
+        ],
+        if (_exchanging)
+          const Center(
+            child: Padding(
+              padding: EdgeInsets.all(8),
+              child: SizedBox.square(
+                dimension: 20,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+            ),
+          )
+        else
+          switch (availability) {
+            GoogleSignInAvailability.interactive => OutlinedButton.icon(
+              onPressed: widget.enabled ? _signIn : null,
+              icon: const Icon(Icons.account_circle_outlined),
+              label: const Text('Continue with Google'),
+            ),
+            GoogleSignInAvailability.platformControl =>
+              buildPlatformGoogleButton(),
+            // AF-06e: the screen already withholds this control, so reaching
+            // here would be a bug rather than a state to render.
+            GoogleSignInAvailability.unsupported => const SizedBox.shrink(),
+          },
+      ],
+    );
+  }
+}

--- a/lib/features/auth/presentation/login_screen.dart
+++ b/lib/features/auth/presentation/login_screen.dart
@@ -5,23 +5,9 @@ import 'package:go_router/go_router.dart';
 import '../../../core/network/dio_client.dart';
 import '../../../core/result/result.dart';
 import '../../../shared/widgets/failure_banner.dart';
+import '../domain/google_sign_in_gateway.dart';
+import 'google_sign_in_control.dart';
 import 'session_controller.dart';
-
-/// What activating the Google sign-in control does.
-///
-/// UI-01 owns the control's placement and whether it is offered at all; the
-/// exchange behind it belongs to UI-06, which overrides this. Until then the
-/// control says so rather than failing silently.
-typedef GoogleSignInAction = Future<void> Function(BuildContext context);
-
-final Provider<GoogleSignInAction> googleSignInActionProvider =
-    Provider<GoogleSignInAction>(
-      (ref) => (context) async {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Google sign-in is not available yet.')),
-        );
-      },
-    );
 
 /// The sign-in screen.
 class LoginScreen extends ConsumerStatefulWidget {
@@ -157,20 +143,14 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                       child: const Text('Forgot your password?'),
                     ),
                     // AF-01e: the control the login screen offers alongside the
-                    // credentials form. AF-06a hides it entirely when the build
-                    // carries no Google client id.
-                    if (ref
-                        .watch(appConfigProvider)
-                        .isGoogleSignInConfigured) ...<Widget>[
+                    // credentials form. AF-06a hides it when the build carries
+                    // no Google client id, and AF-06e when the target cannot
+                    // run the flow — both inside the control itself.
+                    if (ref.watch(appConfigProvider).isGoogleSignInConfigured &&
+                        ref.watch(googleSignInGatewayProvider).availability !=
+                            GoogleSignInAvailability.unsupported) ...<Widget>[
                       const SizedBox(height: 16),
-                      OutlinedButton.icon(
-                        onPressed: _submitting
-                            ? null
-                            : () =>
-                                  ref.read(googleSignInActionProvider)(context),
-                        icon: const Icon(Icons.account_circle_outlined),
-                        label: const Text('Continue with Google'),
-                      ),
+                      GoogleSignInControl(enabled: !_submitting),
                     ],
                   ],
                 ),

--- a/lib/features/auth/presentation/session_controller.dart
+++ b/lib/features/auth/presentation/session_controller.dart
@@ -4,8 +4,10 @@ import 'dart:convert';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/result/result.dart';
+import '../../../core/scope/scope_source.dart';
 import '../../../core/storage/token_store.dart';
 import '../domain/auth_repository.dart';
+import '../domain/google_sign_in_gateway.dart';
 import '../domain/session.dart';
 
 /// Overridden at start-up with the platform store, and in tests with a fake.
@@ -18,6 +20,15 @@ final Provider<AuthRepository> authRepositoryProvider =
     Provider<AuthRepository>(
       (ref) =>
           throw UnimplementedError('authRepositoryProvider must be overridden'),
+    );
+
+/// Overridden at start-up with the plugin-backed gateway, and in tests with a
+/// fake, so no test ever reaches Google.
+final Provider<GoogleSignInGateway> googleSignInGatewayProvider =
+    Provider<GoogleSignInGateway>(
+      (ref) => throw UnimplementedError(
+        'googleSignInGatewayProvider must be overridden',
+      ),
     );
 
 final NotifierProvider<SessionController, SessionState>
@@ -89,6 +100,7 @@ class SessionController extends Notifier<SessionState> {
 
   TokenStore get _store => ref.read(tokenStoreProvider);
   AuthRepository get _repository => ref.read(authRepositoryProvider);
+  GoogleSignInGateway get _google => ref.read(googleSignInGatewayProvider);
 
   /// Reads the stored token and settles the session. Called once at start-up,
   /// and directly by tests so they need not race the constructor.
@@ -132,6 +144,60 @@ class SessionController extends Notifier<SessionState> {
 
         return const Success<void>(null);
       case FailureResult<LoginOutcome>(:final failure):
+        state = const Unauthenticated();
+
+        return FailureResult<void>(failure);
+    }
+  }
+
+  /// Runs Google's flow from the application's own control, then exchanges
+  /// what it produced.
+  ///
+  /// AF-06c: a cancellation is a success carrying no change — nothing was
+  /// sent, so there is nothing to report and nothing to undo.
+  Future<Result<void>> signInWithGoogle() async {
+    final attempt = await _google.obtainIdToken();
+
+    return switch (attempt) {
+      GoogleIdTokenObtained(:final idToken) => await exchangeGoogleIdToken(
+        idToken,
+      ),
+      GoogleSignInCancelled() => const Success<void>(null),
+      GoogleSignInUnsupported() => const FailureResult<void>(
+        Failure(
+          kind: FailureKind.unknown,
+          errors: <String>['Google sign-in is not available on this device.'],
+        ),
+      ),
+      GoogleSignInUnavailable(:final message) => FailureResult<void>(
+        Failure(kind: FailureKind.unknown, errors: <String>[message]),
+      ),
+    };
+  }
+
+  /// Exchanges a Google ID token for a Heimdall session.
+  ///
+  /// Separate from [signInWithGoogle] because on the web the token arrives
+  /// from a control Google rendered itself, with no call of ours to await.
+  ///
+  /// The scope comes from the calling application, which is the only party that
+  /// knows which one is being entered.
+  Future<Result<void>> exchangeGoogleIdToken(String idToken) async {
+    final result = await _repository.signInWithGoogle(
+      idToken: idToken,
+      scopeId: ref.read(scopeSourceProvider).read(),
+    );
+
+    switch (result) {
+      case Success<AuthToken>(:final value):
+        await _establish(value);
+
+        return const Success<void>(null);
+      case FailureResult<AuthToken>(:final failure):
+        // AF-06b and AF-06d: Heimdall refused, but Google still considers the
+        // user signed in. Dropping that leaves the next attempt to start from
+        // the account chooser rather than silently reusing the refused one.
+        await _google.signOut();
         state = const Unauthenticated();
 
         return FailureResult<void>(failure);
@@ -209,9 +275,18 @@ class SessionController extends Notifier<SessionState> {
     _ => false,
   };
 
-  /// Ends the session locally. Called on sign-out and whenever the API rejects
-  /// the token with a 401.
+  /// Ends the session. Called on sign-out and whenever the API rejects the
+  /// token with a 401.
+  ///
+  /// A Google session is ended at the API and at Google as well as here. Both
+  /// are best-effort: a refusal from either must not leave the user signed in
+  /// locally, which is the part this side actually controls.
   Future<void> signOut() async {
+    if (state case Authenticated(:final token) when token.viaGoogle) {
+      await _repository.signOutFromGoogle();
+      await _google.signOut();
+    }
+
     await _store.clear();
     state = const Unauthenticated();
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,27 +1,45 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:google_sign_in/google_sign_in.dart';
 import 'package:heimdall_api_client/export.dart';
 
 import 'app/heimdall_app.dart';
 import 'core/config/app_config.dart';
 import 'core/network/dio_client.dart';
+import 'core/scope/scope_source.dart';
+import 'core/scope/session_scope_source.dart';
 import 'core/storage/token_store.dart';
 import 'features/auth/data/auth_repository_impl.dart';
+import 'features/auth/data/google_sign_in_gateway_impl.dart';
 import 'features/auth/presentation/session_controller.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
 
+  final config = AppConfig.fromEnvironment();
+
   runApp(
     ProviderScope(
       overrides: <Override>[
-        appConfigProvider.overrideWithValue(AppConfig.fromEnvironment()),
+        appConfigProvider.overrideWithValue(config),
         tokenStoreProvider.overrideWithValue(
           const SecureTokenStore(FlutterSecureStorage()),
         ),
+        // The scope belongs to whichever application sent the user here; on the
+        // web it is read from session storage on every use, so a caller may
+        // change it between one attempt and the next.
+        scopeSourceProvider.overrideWithValue(
+          sessionScopeSource(fallback: config.scopeId),
+        ),
         authRepositoryProvider.overrideWith(
           (ref) => ApiAuthRepository(AuthClient(ref.watch(dioProvider))),
+        ),
+        googleSignInGatewayProvider.overrideWithValue(
+          PluginGoogleSignInGateway(
+            GoogleSignIn.instance,
+            config.googleClientId,
+          ),
         ),
       ],
       child: const HeimdallApp(),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -320,6 +320,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "17.5.0"
+  google_identity_services_web:
+    dependency: transitive
+    description:
+      name: google_identity_services_web
+      sha256: "5d187c46dc59e02646e10fe82665fc3884a9b71bc1c90c2b8b749316d33ee454"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.3+1"
+  google_sign_in:
+    dependency: "direct main"
+    description:
+      name: google_sign_in
+      sha256: "521031b65853b4409b8213c0387d57edaad7e2a949ce6dea0d8b2afc9cb29763"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.2.0"
+  google_sign_in_android:
+    dependency: transitive
+    description:
+      name: google_sign_in_android
+      sha256: "57782125965ca87b03d42a147d40b046f1fd6a09141a58913e1b86671a5ef22e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.2.16"
+  google_sign_in_ios:
+    dependency: transitive
+    description:
+      name: google_sign_in_ios
+      sha256: ac1e4c1205267cb7999d1d81333fccffdfda29e853f434bbaf71525498bb6950
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.0"
+  google_sign_in_platform_interface:
+    dependency: transitive
+    description:
+      name: google_sign_in_platform_interface
+      sha256: "7f59208c42b415a3cca203571128d6f84f885fead2d5b53eb65a9e27f2965bb5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
+  google_sign_in_web:
+    dependency: "direct main"
+    description:
+      name: google_sign_in_web
+      sha256: d473003eeca892f96a01a64fc803378be765071cb0c265ee872c7f8683245d14
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.3"
   graphs:
     dependency: transitive
     description:
@@ -343,6 +391,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -837,7 +893,7 @@ packages:
     source: hosted
     version: "1.2.1"
   web:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: web
       sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,9 @@ dependencies:
   flutter_secure_storage: ^11.0.0
   shared_preferences: ^2.5.5
   go_router: ^17.5.0
+  google_sign_in: ^7.2.0
+  web: ^1.1.1
+  google_sign_in_web: ^1.1.3
 
 dev_dependencies:
   flutter_test:

--- a/test/core/scope/scope_source_test.dart
+++ b/test/core/scope/scope_source_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdall_ui/core/scope/scope_source.dart';
+import 'package:heimdall_ui/core/scope/session_scope_source.dart';
+
+void main() {
+  test('GivenAConfiguredScope_WhenRead_ThenItIsReturned', () {
+    // Given
+    const source = FixedScopeSource('scope-public-id');
+
+    // When
+    final scopeId = source.read();
+
+    // Then
+    expect(scopeId, 'scope-public-id');
+  });
+
+  // An undefined `String.fromEnvironment` reads as the empty string, which
+  // means the same thing as absent.
+  test('GivenAnEmptyScope_WhenRead_ThenNothingIsReturned', () {
+    // Given
+    const source = FixedScopeSource('');
+
+    // When
+    final scopeId = source.read();
+
+    // Then
+    expect(scopeId, isNull);
+  });
+
+  test('GivenNoScope_WhenRead_ThenNothingIsReturned', () {
+    // Given
+    const source = FixedScopeSource(null);
+
+    // When
+    final scopeId = source.read();
+
+    // Then
+    expect(scopeId, isNull);
+  });
+
+  // Off the web there is no calling application to read from, so the
+  // build-time value is the whole answer.
+  test('GivenTheHostPlatform_WhenSourceBuilt_ThenTheFallbackIsUsed', () {
+    // Given / When
+    final source = sessionScopeSource(fallback: 'scope-public-id');
+
+    // Then
+    expect(source.read(), 'scope-public-id');
+  });
+
+  // The key the calling application writes, which is part of this
+  // application's contract with its callers.
+  test('GivenTheStorageKey_WhenRead_ThenItIsTheAgreedOne', () {
+    // Given / When / Then
+    expect(scopeStorageKey, 'heimdall.scopeId');
+  });
+}

--- a/test/core/storage/token_store_test.dart
+++ b/test/core/storage/token_store_test.dart
@@ -75,4 +75,36 @@ void main() {
     expect(restored.value, token.value);
     expect(restored.expiresAt, token.expiresAt);
   });
+
+  // UI-06 — sign-out has to tell Google about a Google session, including one
+  // restored from storage, so where it came from is stored with it.
+  test('GivenAGoogleToken_WhenRoundTrippedThroughJson_ThenItStaysGoogle', () {
+    // Given
+    final token = AuthToken(
+      value: 'jwt',
+      expiresAt: DateTime.utc(2030),
+      viaGoogle: true,
+    );
+
+    // When
+    final restored = AuthToken.fromJson(token.toJson());
+
+    // Then
+    expect(restored.viaGoogle, isTrue);
+  });
+
+  // Anything written before UI-06 was password-only and carries no such key.
+  test('GivenAStoredTokenWithoutTheFlag_WhenRead_ThenItIsNotGoogle', () {
+    // Given
+    final json = <String, dynamic>{
+      'value': 'jwt',
+      'expiresAt': '2030-01-01T00:00:00.000Z',
+    };
+
+    // When
+    final restored = AuthToken.fromJson(json);
+
+    // Then
+    expect(restored.viaGoogle, isFalse);
+  });
 }

--- a/test/features/auth/data/auth_repository_impl_test.dart
+++ b/test/features/auth/data/auth_repository_impl_test.dart
@@ -666,6 +666,185 @@ void main() {
       expect(result.failureOrNull?.kind, FailureKind.network);
     },
   );
+
+  /// A Google exchange answering with a usable token.
+  const acceptedGoogleExchange = _Answer(
+    status: 200,
+    body: <String, dynamic>{
+      'success': true,
+      'errors': <String>[],
+      'data': <String, dynamic>{
+        'token': 'jwt',
+        'expiresAt': '2030-01-01T00:00:00Z',
+      },
+    },
+  );
+
+  test(
+    'GivenAnIdToken_WhenSigningInWithGoogle_ThenTheTokenIsReturned',
+    () async {
+      // Given
+      repository = repositoryAnswering(acceptedGoogleExchange);
+
+      // When
+      final result = await repository.signInWithGoogle(
+        idToken: 'google-id-token',
+        scopeId: 'scope-public-id',
+      );
+
+      // Then
+      expect(result.valueOrNull?.value, 'jwt');
+    },
+  );
+
+  // The session must remember it came from Google, so sign-out can tell it.
+  test(
+    'GivenAnIdToken_WhenSigningInWithGoogle_ThenTheTokenIsMarkedGoogle',
+    () async {
+      // Given
+      repository = repositoryAnswering(acceptedGoogleExchange);
+
+      // When
+      final result = await repository.signInWithGoogle(
+        idToken: 'google-id-token',
+        scopeId: 'scope-public-id',
+      );
+
+      // Then
+      expect(result.valueOrNull?.viaGoogle, isTrue);
+    },
+  );
+
+  test('GivenAScope_WhenSigningInWithGoogle_ThenBothTravelInTheBody', () async {
+    // Given
+    repository = repositoryAnswering(acceptedGoogleExchange);
+
+    // When
+    await repository.signInWithGoogle(
+      idToken: 'google-id-token',
+      scopeId: 'scope-public-id',
+    );
+
+    // Then
+    expect(adapter.requests.single['idToken'], 'google-id-token');
+    expect(adapter.requests.single['scopeId'], 'scope-public-id');
+  });
+
+  // AF-06b — the scope has Google Sign-In switched off, which the API answers
+  // 403 for a missing, deleted, and disabled scope alike.
+  test(
+    'GivenDisabledScope_WhenSigningInWithGoogle_ThenApiErrorsAreReturned',
+    () async {
+      // Given
+      repository = repositoryAnswering(
+        const _Answer(
+          status: 403,
+          body: <String, dynamic>{
+            'success': false,
+            'errors': <String>['Google Sign-In is not enabled for this scope.'],
+          },
+        ),
+      );
+
+      // When
+      final result = await repository.signInWithGoogle(
+        idToken: 'google-id-token',
+        scopeId: 'scope-public-id',
+      );
+
+      // Then
+      expect(result.failureOrNull?.kind, FailureKind.forbidden);
+      expect(result.failureOrNull?.errors, <String>[
+        'Google Sign-In is not enabled for this scope.',
+      ]);
+    },
+  );
+
+  // AF-06d — the API refuses the ID token, answering 401 as login does.
+  test(
+    'GivenRejectedIdToken_WhenSigningInWithGoogle_ThenApiErrorsAreReturned',
+    () async {
+      // Given
+      repository = repositoryAnswering(
+        const _Answer(
+          status: 401,
+          body: <String, dynamic>{
+            'success': false,
+            'errors': <String>['That Google account could not be signed in.'],
+          },
+        ),
+      );
+
+      // When
+      final result = await repository.signInWithGoogle(
+        idToken: 'forged',
+        scopeId: 'scope-public-id',
+      );
+
+      // Then
+      expect(result.failureOrNull?.kind, FailureKind.unauthorized);
+    },
+  );
+
+  test(
+    'GivenTransportFailure_WhenSigningInWithGoogle_ThenNetworkFailureIsReturned',
+    () async {
+      // Given
+      repository = repositoryAnswering(const _Answer(status: 0));
+
+      // When
+      final result = await repository.signInWithGoogle(
+        idToken: 'google-id-token',
+      );
+
+      // Then
+      expect(result.failureOrNull?.kind, FailureKind.network);
+    },
+  );
+
+  // The sign-out takes no body: the Google User comes from the bearer token.
+  test('GivenAGoogleSession_WhenSigningOut_ThenNoBodyIsSent', () async {
+    // Given
+    repository = repositoryAnswering(
+      const _Answer(
+        status: 200,
+        body: <String, dynamic>{
+          'success': true,
+          'errors': <String>[],
+          'data': null,
+        },
+      ),
+    );
+
+    // When
+    final result = await repository.signOutFromGoogle();
+
+    // Then
+    expect(result.isSuccess, isTrue);
+    expect(adapter.requests, isEmpty);
+  });
+
+  test(
+    'GivenRejectedSignOut_WhenSigningOut_ThenApiErrorsAreReturned',
+    () async {
+      // Given
+      repository = repositoryAnswering(
+        const _Answer(
+          status: 401,
+          body: <String, dynamic>{
+            'success': false,
+            'errors': <String>['Not a Google session.'],
+          },
+        ),
+      );
+
+      // When
+      final result = await repository.signOutFromGoogle();
+
+      // Then
+      expect(result.failureOrNull?.errors, <String>['Not a Google session.']);
+    },
+  );
 }
 
 /// What the stub answers with. A [status] of zero stands for a connection that

--- a/test/features/auth/presentation/google_sign_in_control_test.dart
+++ b/test/features/auth/presentation/google_sign_in_control_test.dart
@@ -1,0 +1,366 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdall_ui/app/theme.dart';
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/core/scope/scope_source.dart';
+import 'package:heimdall_ui/core/storage/token_store.dart';
+import 'package:heimdall_ui/features/auth/domain/auth_repository.dart';
+import 'package:heimdall_ui/features/auth/domain/google_sign_in_gateway.dart';
+import 'package:heimdall_ui/features/auth/domain/session.dart';
+import 'package:heimdall_ui/features/auth/presentation/google_sign_in_control.dart';
+import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
+import 'package:heimdall_ui/shared/widgets/failure_banner.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockAuthRepository extends Mock implements AuthRepository {}
+
+/// Google's half, faked: what it would have returned, without its SDK.
+class _FakeGoogleSignInGateway implements GoogleSignInGateway {
+  _FakeGoogleSignInGateway({
+    this.availability = GoogleSignInAvailability.interactive,
+    this.attempt = const GoogleIdTokenObtained('google-id-token'),
+  });
+
+  @override
+  final GoogleSignInAvailability availability;
+
+  final GoogleSignInAttempt attempt;
+
+  final StreamController<GoogleIdTokenObtained> tokens =
+      StreamController<GoogleIdTokenObtained>.broadcast();
+
+  int initializations = 0;
+  int signOuts = 0;
+
+  @override
+  Future<void> initialize() async => initializations++;
+
+  @override
+  Stream<GoogleIdTokenObtained> get idTokens => tokens.stream;
+
+  @override
+  Future<GoogleSignInAttempt> obtainIdToken() async => attempt;
+
+  @override
+  Future<void> signOut() async => signOuts++;
+}
+
+/// A token naming a User, which is all the control's outcomes need.
+const String _jwt =
+    'header.'
+    'eyJzdWIiOiJpZCIsImVtYWlsIjoiYUBiLmMiLCJyb2xlIjozfQ.'
+    'signature';
+
+void main() {
+  late _MockAuthRepository repository;
+  late InMemoryTokenStore store;
+  late _FakeGoogleSignInGateway gateway;
+  late ProviderContainer container;
+
+  Future<void> pump(
+    WidgetTester tester, {
+    String? scopeId = 'scope-public-id',
+    ThemeData? theme,
+  }) async {
+    container = ProviderContainer(
+      overrides: <Override>[
+        authRepositoryProvider.overrideWithValue(repository),
+        tokenStoreProvider.overrideWithValue(store),
+        googleSignInGatewayProvider.overrideWithValue(gateway),
+        scopeSourceProvider.overrideWithValue(FixedScopeSource(scopeId)),
+      ],
+    );
+    addTearDown(container.dispose);
+    addTearDown(gateway.tokens.close);
+    // Settle the start-up read so it cannot land mid-exchange.
+    await container.read(sessionControllerProvider.notifier).restore();
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          theme: theme ?? buildLightTheme(),
+          home: const Scaffold(body: GoogleSignInControl(enabled: true)),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  void answerExchangeWith(Result<AuthToken> result) {
+    when(
+      () => repository.signInWithGoogle(
+        idToken: any(named: 'idToken'),
+        scopeId: any(named: 'scopeId'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  AuthToken googleToken() =>
+      AuthToken(value: _jwt, expiresAt: DateTime.utc(2030), viaGoogle: true);
+
+  setUp(() {
+    repository = _MockAuthRepository();
+    store = InMemoryTokenStore();
+    gateway = _FakeGoogleSignInGateway();
+  });
+
+  testWidgets('GivenAGoogleIdToken_WhenActivated_ThenItIsExchanged', (
+    tester,
+  ) async {
+    // Given
+    answerExchangeWith(Success<AuthToken>(googleToken()));
+    await pump(tester);
+
+    // When
+    await tester.tap(find.text('Continue with Google'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => repository.signInWithGoogle(
+        idToken: 'google-id-token',
+        scopeId: 'scope-public-id',
+      ),
+    ).called(1);
+  });
+
+  testWidgets(
+    'GivenAcceptedExchange_WhenActivated_ThenSessionIsAuthenticated',
+    (tester) async {
+      // Given
+      answerExchangeWith(Success<AuthToken>(googleToken()));
+      await pump(tester);
+
+      // When
+      await tester.tap(find.text('Continue with Google'));
+      await tester.pumpAndSettle();
+
+      // Then
+      expect(container.read(sessionControllerProvider), isA<Authenticated>());
+    },
+  );
+
+  // The scope belongs to the calling application; when it named none, the API
+  // is asked without one rather than being sent something invented.
+  testWidgets('GivenNoScopeFromTheCaller_WhenActivated_ThenNoScopeIsSent', (
+    tester,
+  ) async {
+    // Given
+    answerExchangeWith(Success<AuthToken>(googleToken()));
+    await pump(tester, scopeId: null);
+
+    // When
+    await tester.tap(find.text('Continue with Google'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => repository.signInWithGoogle(
+        idToken: 'google-id-token',
+        scopeId: null,
+      ),
+    ).called(1);
+  });
+
+  // AF-06b — the scope has Google Sign-In switched off.
+  testWidgets('GivenDisabledScope_WhenActivated_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerExchangeWith(
+      const FailureResult<AuthToken>(
+        Failure(
+          kind: FailureKind.forbidden,
+          errors: <String>['Google Sign-In is not enabled for this scope.'],
+        ),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await tester.tap(find.text('Continue with Google'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(
+      find.text('Google Sign-In is not enabled for this scope.'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('GivenDisabledScope_WhenActivated_ThenTheControlIsStillOffered', (
+    tester,
+  ) async {
+    // Given
+    answerExchangeWith(
+      const FailureResult<AuthToken>(
+        Failure(kind: FailureKind.forbidden, errors: <String>['No.']),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await tester.tap(find.text('Continue with Google'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('Continue with Google'), findsOneWidget);
+  });
+
+  // AF-06d — Heimdall refuses the ID token, and the pending Google session is
+  // dropped so the next attempt starts from the account chooser.
+  testWidgets('GivenRejectedIdToken_WhenActivated_ThenGoogleIsSignedOut', (
+    tester,
+  ) async {
+    // Given
+    answerExchangeWith(
+      const FailureResult<AuthToken>(
+        Failure(
+          kind: FailureKind.unauthorized,
+          errors: <String>['That Google account could not be signed in.'],
+        ),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await tester.tap(find.text('Continue with Google'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(gateway.signOuts, 1);
+  });
+
+  testWidgets('GivenRejectedIdToken_WhenActivated_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerExchangeWith(
+      const FailureResult<AuthToken>(
+        Failure(
+          kind: FailureKind.unauthorized,
+          errors: <String>['That Google account could not be signed in.'],
+        ),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await tester.tap(find.text('Continue with Google'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(
+      find.text('That Google account could not be signed in.'),
+      findsOneWidget,
+    );
+  });
+
+  // AF-06c — the user backs out of Google's flow.
+  testWidgets('GivenACancelledFlow_WhenActivated_ThenNoRequestIsMade', (
+    tester,
+  ) async {
+    // Given
+    gateway = _FakeGoogleSignInGateway(attempt: const GoogleSignInCancelled());
+    await pump(tester);
+
+    // When
+    await tester.tap(find.text('Continue with Google'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verifyNever(
+      () => repository.signInWithGoogle(
+        idToken: any(named: 'idToken'),
+        scopeId: any(named: 'scopeId'),
+      ),
+    );
+  });
+
+  testWidgets('GivenACancelledFlow_WhenActivated_ThenTheScreenIsUnchanged', (
+    tester,
+  ) async {
+    // Given
+    gateway = _FakeGoogleSignInGateway(attempt: const GoogleSignInCancelled());
+    await pump(tester);
+
+    // When
+    await tester.tap(find.text('Continue with Google'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('Continue with Google'), findsOneWidget);
+    expect(find.byType(ErrorBanner), findsNothing);
+  });
+
+  testWidgets('GivenGoogleUnavailable_WhenActivated_ThenTheReasonIsShown', (
+    tester,
+  ) async {
+    // Given
+    gateway = _FakeGoogleSignInGateway(
+      attempt: const GoogleSignInUnavailable('Google is not configured.'),
+    );
+    await pump(tester);
+
+    // When
+    await tester.tap(find.text('Continue with Google'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('Google is not configured.'), findsOneWidget);
+  });
+
+  // Where Google renders its own control, the ID token arrives on a stream
+  // rather than as the result of a call.
+  testWidgets('GivenAPlatformControl_WhenTokenArrives_ThenItIsExchanged', (
+    tester,
+  ) async {
+    // Given
+    gateway = _FakeGoogleSignInGateway(
+      availability: GoogleSignInAvailability.platformControl,
+    );
+    answerExchangeWith(Success<AuthToken>(googleToken()));
+    await pump(tester);
+
+    // When
+    gateway.tokens.add(const GoogleIdTokenObtained('google-id-token'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => repository.signInWithGoogle(
+        idToken: 'google-id-token',
+        scopeId: 'scope-public-id',
+      ),
+    ).called(1);
+  });
+
+  testWidgets('GivenAPlatformControl_WhenRendered_ThenTheSdkIsInitialized', (
+    tester,
+  ) async {
+    // Given
+    gateway = _FakeGoogleSignInGateway(
+      availability: GoogleSignInAvailability.platformControl,
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(gateway.initializations, 1);
+  });
+
+  testWidgets('GivenDarkTheme_WhenRendered_ThenTheControlIsShown', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, theme: buildDarkTheme());
+
+    // Then
+    expect(find.text('Continue with Google'), findsOneWidget);
+  });
+}

--- a/test/features/auth/presentation/login_screen_test.dart
+++ b/test/features/auth/presentation/login_screen_test.dart
@@ -7,11 +7,35 @@ import 'package:heimdall_ui/core/network/dio_client.dart';
 import 'package:heimdall_ui/core/result/result.dart';
 import 'package:heimdall_ui/core/storage/token_store.dart';
 import 'package:heimdall_ui/features/auth/domain/auth_repository.dart';
+import 'package:heimdall_ui/features/auth/domain/google_sign_in_gateway.dart';
 import 'package:heimdall_ui/features/auth/presentation/login_screen.dart';
 import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
 import 'package:mocktail/mocktail.dart';
 
 class _MockAuthRepository extends Mock implements AuthRepository {}
+
+/// Google's half, faked. No test reaches Google's SDK, for the same reason
+/// none reaches the network.
+class _FakeGoogleSignInGateway implements GoogleSignInGateway {
+  _FakeGoogleSignInGateway(this.availability);
+
+  @override
+  final GoogleSignInAvailability availability;
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Stream<GoogleIdTokenObtained> get idTokens =>
+      const Stream<GoogleIdTokenObtained>.empty();
+
+  @override
+  Future<GoogleSignInAttempt> obtainIdToken() async =>
+      const GoogleSignInCancelled();
+
+  @override
+  Future<void> signOut() async {}
+}
 
 /// A token whose payload names a User, which is all the screen's flows need.
 const String _jwt =
@@ -34,6 +58,7 @@ void main() {
     Size size = const Size(400, 900),
     ThemeData? theme,
     AppConfig config = withoutGoogle,
+    GoogleSignInAvailability google = GoogleSignInAvailability.interactive,
   }) async {
     tester.view.physicalSize = size;
     tester.view.devicePixelRatio = 1;
@@ -45,6 +70,9 @@ void main() {
           appConfigProvider.overrideWithValue(config),
           authRepositoryProvider.overrideWithValue(repository),
           tokenStoreProvider.overrideWithValue(store),
+          googleSignInGatewayProvider.overrideWithValue(
+            _FakeGoogleSignInGateway(google),
+          ),
         ],
         child: MaterialApp(
           theme: theme ?? buildLightTheme(),
@@ -228,6 +256,23 @@ void main() {
 
     // Then
     expect(find.text('Continue with Google'), findsOneWidget);
+  });
+
+  // AF-06e — a target that cannot run the flow shows no control, and the
+  // credentials form stays the only route in.
+  testWidgets('GivenUnsupportedTarget_WhenRendered_ThenGoogleControlIsHidden', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(
+      tester,
+      config: withGoogle,
+      google: GoogleSignInAvailability.unsupported,
+    );
+
+    // Then
+    expect(find.text('Continue with Google'), findsNothing);
+    expect(find.widgetWithText(FilledButton, 'Sign in'), findsOneWidget);
   });
 
   // AF-06a — no client id, no control at all.

--- a/test/features/auth/presentation/session_controller_test.dart
+++ b/test/features/auth/presentation/session_controller_test.dart
@@ -5,11 +5,35 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:heimdall_ui/core/result/result.dart';
 import 'package:heimdall_ui/core/storage/token_store.dart';
 import 'package:heimdall_ui/features/auth/domain/auth_repository.dart';
+import 'package:heimdall_ui/features/auth/domain/google_sign_in_gateway.dart';
 import 'package:heimdall_ui/features/auth/domain/session.dart';
 import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
 import 'package:mocktail/mocktail.dart';
 
 class _MockAuthRepository extends Mock implements AuthRepository {}
+
+/// Google's half, faked. No test reaches Google's SDK.
+class _FakeGoogleSignInGateway implements GoogleSignInGateway {
+  int signOuts = 0;
+
+  @override
+  GoogleSignInAvailability get availability =>
+      GoogleSignInAvailability.interactive;
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Stream<GoogleIdTokenObtained> get idTokens =>
+      const Stream<GoogleIdTokenObtained>.empty();
+
+  @override
+  Future<GoogleSignInAttempt> obtainIdToken() async =>
+      const GoogleSignInCancelled();
+
+  @override
+  Future<void> signOut() async => signOuts++;
+}
 
 /// A token whose payload claims the System Admin role, so the principal read
 /// from it is something the guards can be asserted against.
@@ -431,6 +455,110 @@ void main() {
     expect(principal.role, Role.user);
     expect(principal.id, isEmpty);
   });
+
+  // UI-06 sign out — a Google session ends at the API and at Google too.
+  test('GivenAGoogleSession_WhenSignedOut_ThenGoogleIsToldAsWell', () async {
+    // Given
+    final gateway = _FakeGoogleSignInGateway();
+    final store = InMemoryTokenStore();
+    await store.write(
+      AuthToken(
+        value: _systemAdminJwt,
+        expiresAt: DateTime.utc(2030),
+        viaGoogle: true,
+      ),
+    );
+    final repository = _MockAuthRepository();
+    when(
+      () => repository.signOutFromGoogle(),
+    ).thenAnswer((_) async => const Success<void>(null));
+    final container = ProviderContainer(
+      overrides: <Override>[
+        authRepositoryProvider.overrideWithValue(repository),
+        tokenStoreProvider.overrideWithValue(store),
+        googleSignInGatewayProvider.overrideWithValue(gateway),
+      ],
+    );
+    addTearDown(container.dispose);
+    final controller = container.read(sessionControllerProvider.notifier);
+    await controller.restore();
+
+    // When
+    await controller.signOut();
+
+    // Then
+    verify(() => repository.signOutFromGoogle()).called(1);
+    expect(gateway.signOuts, 1);
+  });
+
+  // A password session has no Google half, so nothing is told about it.
+  test('GivenAPasswordSession_WhenSignedOut_ThenGoogleIsNotCalled', () async {
+    // Given
+    final gateway = _FakeGoogleSignInGateway();
+    final store = InMemoryTokenStore();
+    await store.write(
+      AuthToken(value: _systemAdminJwt, expiresAt: DateTime.utc(2030)),
+    );
+    final repository = _MockAuthRepository();
+    final container = ProviderContainer(
+      overrides: <Override>[
+        authRepositoryProvider.overrideWithValue(repository),
+        tokenStoreProvider.overrideWithValue(store),
+        googleSignInGatewayProvider.overrideWithValue(gateway),
+      ],
+    );
+    addTearDown(container.dispose);
+    final controller = container.read(sessionControllerProvider.notifier);
+    await controller.restore();
+
+    // When
+    await controller.signOut();
+
+    // Then
+    verifyNever(() => repository.signOutFromGoogle());
+    expect(gateway.signOuts, 0);
+  });
+
+  // The local session must end even when the API refuses to end its half —
+  // that is the part this side actually controls.
+  test(
+    'GivenARefusedGoogleSignOut_WhenSignedOut_ThenTheSessionStillEnds',
+    () async {
+      // Given
+      final gateway = _FakeGoogleSignInGateway();
+      final store = InMemoryTokenStore();
+      await store.write(
+        AuthToken(
+          value: _systemAdminJwt,
+          expiresAt: DateTime.utc(2030),
+          viaGoogle: true,
+        ),
+      );
+      final repository = _MockAuthRepository();
+      when(() => repository.signOutFromGoogle()).thenAnswer(
+        (_) async => const FailureResult<void>(
+          Failure(kind: FailureKind.unauthorized, errors: <String>['No.']),
+        ),
+      );
+      final container = ProviderContainer(
+        overrides: <Override>[
+          authRepositoryProvider.overrideWithValue(repository),
+          tokenStoreProvider.overrideWithValue(store),
+          googleSignInGatewayProvider.overrideWithValue(gateway),
+        ],
+      );
+      addTearDown(container.dispose);
+      final controller = container.read(sessionControllerProvider.notifier);
+      await controller.restore();
+
+      // When
+      await controller.signOut();
+
+      // Then
+      expect(container.read(sessionControllerProvider), isA<Unauthenticated>());
+      expect(await store.read(), isNull);
+    },
+  );
 
   // AF-05e — the claim the unverified-address prompt is decided by.
   test('GivenUnverifiedClaim_WhenPrincipalRead_ThenEmailIsUnverified', () {


### PR DESCRIPTION
Implements UI-06 from the [Use Case Specification Document](docs/requirements/Use%20Case%20Specification%20Document.md), delivering FR-AU-09.

## The target scope

UI-06's main flow calls `POST /api/auth/google` "with the ID token **and the target scope**", and nothing in the specification said where that scope comes from — there is no screen here that asks for it and no endpoint an anonymous caller could list scopes from. Resolved: **the calling application names it.**

On the web it writes the scope's `PublicId` into session storage before sending the user here:

```js
sessionStorage.setItem('heimdall.scopeId', '<scope-public-id>');
```

Session storage rather than a cookie: it is scoped to the tab, so two tabs can act in two scopes; it is never attached to a request, so the scope cannot become a header the API did not ask for or be replayed by a third party's form; and it dies with the tab, so a scope does not outlive the visit on a shared machine. It is read on **every** use rather than captured at start-up, so a caller may change it between one attempt and the next.

`HEIMDALL_SCOPE_ID` is the fallback for a build with no such caller — Windows, Linux, Android, or a web build opened directly. When neither supplies one the request goes without a scope and the API decides what that means; nothing is invented client-side. Both are documented in the README and in §2.1 of the [Operations & Infrastructure Document](docs/requirements/Operations%20%26%20Infrastructure%20Document.md).

## Flows implemented

| Flow | What it does |
| --- | --- |
| **Main** | The control sits alongside the credentials form, runs Google's flow, exchanges the ID token with the scope at `POST /api/auth/google`, stores the token and establishes the session. |
| **Sign out** | A Google session is ended at `POST /api/auth/google/sign-out` and at Google, as well as locally. |
| **AF-06a** | No client id in the build hides the control entirely. |
| **AF-06b** | A scope with Google Sign-In switched off shows the returned errors; the credentials form is untouched. |
| **AF-06c** | A cancelled Google flow sends nothing and leaves the screen exactly as it was. |
| **AF-06d** | An ID token Heimdall refuses shows the returned errors and drops the pending Google session, so the next attempt starts from the account chooser rather than silently reusing the refused account. |
| **AF-06e** | A target that cannot run the flow hides the control, leaving the credentials form as the only route in. |

## Two things worth knowing

**Three targets, three answers.** The gateway reports *how* the flow may be run, because it differs: Android drives it from our own `OutlinedButton`; the web SDK answers `supportsAuthenticate()` false and requires its own rendered button, delivering the account on a stream instead; Windows and Linux have no implementation at all, which is exactly AF-06e. Treating the web as unsupported would have quietly disabled Google sign-in on the primary target while looking implemented, so it gets the platform-button path via a conditional import.

**Where the session came from is stored.** `AuthToken` gains `viaGoogle`, persisted with the token: a session restored at start-up still has to be signed out of properly, and nothing in the JWT says where it came from. Tokens written before this read as non-Google.

The plugin lives only in `data/` behind `GoogleSignInGateway`, so the session controller and the screen never see it — and no test reaches Google's SDK, for the same reason none reaches the network.

## Verification

```
dart format --set-exit-if-changed . && flutter analyze && flutter test
```

All three pass; **260 tests**, none skipped. Coverage added:

- `google_sign_in_control_test.dart` — the exchange and its scope, the scope-less case, AF-06b, AF-06c (no request, screen unchanged), AF-06d (errors and the Google sign-out), the unavailable case, the platform-control stream path and its initialisation, and the dark theme.
- `login_screen_test.dart` — AF-06a and AF-06e both hide the control, with the credentials form still present.
- `session_controller_test.dart` — a Google sign-out reaches the API and Google, a password sign-out reaches neither, and a refused API sign-out still ends the local session.
- `auth_repository_impl_test.dart` — the exchange, the `viaGoogle` mark, the request body, AF-06b's 403, AF-06d's 401, the transport failure, and the body-less sign-out.
- `scope_source_test.dart` — the configured scope, empty and absent, the host-platform source, and the storage key that is part of the contract with callers.
- `token_store_test.dart` — `viaGoogle` round-trips, and a token stored before this reads as non-Google.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)
