### PR TITLE
UI-07: Guard routes by session and role

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ the board is where an item's status changes as it moves.
 | UI-04: Reset password | ✅ | [#4](https://github.com/artur-rios/heimdall-ui/issues/4) |
 | UI-05: Verify email and resend verification | ✅ | [#5](https://github.com/artur-rios/heimdall-ui/issues/5) |
 | UI-06: Sign in and sign out with Google | ✅ | [#6](https://github.com/artur-rios/heimdall-ui/issues/6) |
-| UI-07: Guard routes by session and role | ⬜ | [#7](https://github.com/artur-rios/heimdall-ui/issues/7) |
+| UI-07: Guard routes by session and role | ✅ | [#7](https://github.com/artur-rios/heimdall-ui/issues/7) |
 
 ### Profile & Security
 

--- a/lib/app/heimdall_app.dart
+++ b/lib/app/heimdall_app.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../features/auth/domain/session.dart';
+import '../features/auth/presentation/session_controller.dart';
 import 'router.dart';
 import 'theme.dart';
 import 'theme_mode_controller.dart';
@@ -13,6 +15,7 @@ class HeimdallApp extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final themeMode =
         ref.watch(themeModeControllerProvider).value ?? ThemeMode.system;
+    final restoring = ref.watch(sessionControllerProvider) is SessionRestoring;
 
     return MaterialApp.router(
       title: 'Heimdall',
@@ -21,6 +24,21 @@ class HeimdallApp extends ConsumerWidget {
       darkTheme: buildDarkTheme(),
       themeMode: themeMode,
       routerConfig: ref.watch(routerProvider),
+      // AF-07c: while the stored token is being read the guard decides nothing,
+      // so this covers whatever the router built underneath rather than
+      // replacing it — the requested URL survives a slow read intact.
+      builder: (context, child) =>
+          restoring ? const _RestoringScreen() : child ?? const SizedBox(),
     );
   }
+}
+
+/// What a caller sees while the session is being restored: a wait, not a
+/// sign-in screen they never asked for.
+class _RestoringScreen extends StatelessWidget {
+  const _RestoringScreen();
+
+  @override
+  Widget build(BuildContext context) =>
+      const Scaffold(body: Center(child: CircularProgressIndicator()));
 }

--- a/lib/app/route_access.dart
+++ b/lib/app/route_access.dart
@@ -1,0 +1,28 @@
+import '../features/auth/domain/session.dart';
+
+/// Whether [role] is offered the screen behind [path].
+///
+/// Reads the Authorization Matrix in the System Requirements Document, and
+/// nothing more. This is a usability decision, not a security one: the API
+/// refuses whatever a caller may not do, whether or not the interface offered
+/// it — so a rule that is wrong here shows the wrong menu, never grants access.
+///
+/// Scope-level ownership ("owned scopes only") is deliberately absent. It is a
+/// per-record question the API answers on the record, and a path alone cannot
+/// tell an owned scope from any other; the screens enforce what the API says.
+bool roleMayReach({required Role role, required String path}) => switch (path) {
+  // Every signed-in caller has a home and an account of their own — and the
+  // refusal screen itself, or AF-07d would be the redirect loop it forbids.
+  '/' || '/not-available' => true,
+  final String p when p == '/profile' || p.startsWith('/profile/') => true,
+  // Creating and permanently deleting a scope is the System Admin's alone.
+  '/scopes/new' => role == Role.systemAdmin,
+  final String p when p == '/scopes' || p.startsWith('/scopes/') =>
+    role != Role.user,
+  // Full for a System Admin, read-only for a Scope Admin, hidden for a User.
+  '/health' => role != Role.user,
+  // A route nobody has built yet is the error screen's business, not the
+  // guard's: answering "not for your role" would be a guess about a screen
+  // that does not exist.
+  _ => true,
+};

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -10,6 +10,7 @@ import '../features/auth/presentation/session_controller.dart';
 import '../features/auth/presentation/two_factor_screen.dart';
 import '../features/auth/presentation/verify_email_screen.dart';
 import '../features/home/presentation/home_screen.dart';
+import 'route_access.dart';
 
 /// Routes an unauthenticated caller may reach.
 ///
@@ -45,6 +46,12 @@ String? redirectFor({required SessionState session, required String location}) {
     Unauthenticated() => '/login?from=${Uri.encodeComponent(location)}',
     Authenticated() when path == '/login' || path == '/login/two-factor' =>
       _returnTo(uri.queryParameters['from']),
+    // AF-07d: a screen this role is not offered answers plainly. Sending them
+    // home instead would be the redirect loop the flow rules out, and would
+    // also lie about why they did not arrive.
+    Authenticated(:final principal)
+        when !isPublic && !roleMayReach(role: principal.role, path: path) =>
+      '/not-available',
     Authenticated() => null,
   };
 }
@@ -102,6 +109,10 @@ final Provider<GoRouter> routerProvider = Provider<GoRouter>((ref) {
         builder: (context, state) =>
             VerifyEmailScreen(token: state.uri.queryParameters['token']),
       ),
+      GoRoute(
+        path: '/not-available',
+        builder: (context, state) => const _NotForYourRoleScreen(),
+      ),
     ],
     // Every screen beyond these two arrives with its own use case. Until then
     // an unknown route says so plainly instead of throwing.
@@ -109,6 +120,59 @@ final Provider<GoRouter> routerProvider = Provider<GoRouter>((ref) {
         _RouteNotReadyScreen(path: state.uri.path),
   );
 });
+
+/// AF-07d — what a caller sees when their role is not offered the screen they
+/// asked for.
+///
+/// A screen rather than a redirect: it says what happened, and it cannot loop.
+class _NotForYourRoleScreen extends StatelessWidget {
+  const _NotForYourRoleScreen();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Not available')),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 420),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                Icon(
+                  Icons.lock_person_outlined,
+                  size: 48,
+                  color: theme.colorScheme.error,
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  'Not available for your role',
+                  style: theme.textTheme.headlineMedium,
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'Your account is signed in, but this screen is not part of '
+                  'what your role does. Nothing is wrong with your session.',
+                  style: theme.textTheme.bodyMedium,
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 24),
+                FilledButton(
+                  onPressed: () => context.go('/'),
+                  child: const Text('Back to home'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
 
 class _RouteNotReadyScreen extends StatelessWidget {
   const _RouteNotReadyScreen({required this.path});

--- a/lib/core/network/dio_client.dart
+++ b/lib/core/network/dio_client.dart
@@ -55,7 +55,9 @@ final Provider<Dio> dioProvider = Provider<Dio>(
   (ref) => createDio(
     config: ref.watch(appConfigProvider),
     tokenStore: ref.watch(tokenStoreProvider),
+    // AF-07e: the token was rejected mid-session, which is not the same as
+    // signing out — the user is told the session ended.
     onUnauthorized: () =>
-        ref.read(sessionControllerProvider.notifier).signOut(),
+        ref.read(sessionControllerProvider.notifier).signOut(expired: true),
   ),
 );

--- a/lib/features/auth/domain/session.dart
+++ b/lib/features/auth/domain/session.dart
@@ -68,7 +68,14 @@ final class SessionRestoring extends SessionState {
 
 /// No valid session exists.
 final class Unauthenticated extends SessionState {
-  const Unauthenticated();
+  const Unauthenticated({this.sessionExpired = false});
+
+  /// Whether this state was reached by a session ending under the caller
+  /// rather than by never having had one.
+  ///
+  /// AF-07e: being returned to sign-in mid-task needs an explanation, and
+  /// "your session ended" is a different message from "please sign in".
+  final bool sessionExpired;
 }
 
 /// Credentials were accepted but a second factor is still outstanding. The

--- a/lib/features/auth/presentation/login_screen.dart
+++ b/lib/features/auth/presentation/login_screen.dart
@@ -6,6 +6,7 @@ import '../../../core/network/dio_client.dart';
 import '../../../core/result/result.dart';
 import '../../../shared/widgets/failure_banner.dart';
 import '../domain/google_sign_in_gateway.dart';
+import '../domain/session.dart';
 import 'google_sign_in_control.dart';
 import 'session_controller.dart';
 
@@ -87,6 +88,13 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                       style: theme.textTheme.bodyMedium,
                     ),
                     const SizedBox(height: 24),
+                    // AF-07e: the token was rejected mid-session. Saying so
+                    // beats leaving the user to wonder why their work stopped.
+                    if (ref.watch(sessionControllerProvider)
+                        case Unauthenticated(sessionExpired: true)) ...<Widget>[
+                      const _SessionEndedBanner(),
+                      const SizedBox(height: 16),
+                    ],
                     if (_failure case final Failure failure) ...<Widget>[
                       if (failure.kind == FailureKind.network)
                         // AF-01d: nothing was rejected, so the only useful
@@ -158,6 +166,29 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
             ),
           ),
         ),
+      ),
+    );
+  }
+}
+
+/// AF-07e — says that the session ended rather than that sign-in failed. It is
+/// not an error banner: nothing the user did was wrong.
+class _SessionEndedBanner extends StatelessWidget {
+  const _SessionEndedBanner();
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: scheme.secondaryContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        'Your session ended. Sign in again to pick up where you left off.',
+        style: TextStyle(color: scheme.onSecondaryContainer),
       ),
     );
   }

--- a/lib/features/auth/presentation/session_controller.dart
+++ b/lib/features/auth/presentation/session_controller.dart
@@ -281,14 +281,17 @@ class SessionController extends Notifier<SessionState> {
   /// A Google session is ended at the API and at Google as well as here. Both
   /// are best-effort: a refusal from either must not leave the user signed in
   /// locally, which is the part this side actually controls.
-  Future<void> signOut() async {
+  ///
+  /// AF-07e: [expired] marks a session that ended under the caller rather than
+  /// one they chose to leave, so the sign-in screen can say which happened.
+  Future<void> signOut({bool expired = false}) async {
     if (state case Authenticated(:final token) when token.viaGoogle) {
       await _repository.signOutFromGoogle();
       await _google.signOut();
     }
 
     await _store.clear();
-    state = const Unauthenticated();
+    state = Unauthenticated(sessionExpired: expired);
   }
 
   Future<void> _establish(AuthToken token) async {

--- a/test/app/heimdall_app_test.dart
+++ b/test/app/heimdall_app_test.dart
@@ -1,7 +1,11 @@
+import 'dart:async';
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:heimdall_ui/app/heimdall_app.dart';
+import 'package:heimdall_ui/app/router.dart';
 import 'package:heimdall_ui/core/config/app_config.dart';
 import 'package:heimdall_ui/core/network/dio_client.dart';
 import 'package:heimdall_ui/core/result/result.dart';
@@ -163,4 +167,224 @@ void main() {
     // Then
     expect(find.text('Signed in as admin@example.com'), findsOneWidget);
   });
+
+  // AF-07c — a slow read of the stored token must not bounce a returning user
+  // to sign-in; they wait instead.
+  testWidgets('GivenASlowTokenRead_WhenAppStarts_ThenALoadingStateIsShown', (
+    tester,
+  ) async {
+    // Given
+    final slow = _SlowTokenStore(
+      AuthToken(value: _systemAdminJwt, expiresAt: DateTime.utc(2030)),
+    );
+    final container = ProviderContainer(
+      overrides: <Override>[
+        appConfigProvider.overrideWithValue(
+          const AppConfig(apiBaseUrl: 'http://localhost:5000'),
+        ),
+        tokenStoreProvider.overrideWithValue(slow),
+        authRepositoryProvider.overrideWithValue(repository),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    // When
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const HeimdallApp(),
+      ),
+    );
+    await tester.pump();
+
+    // Then
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.text('Sign in'), findsNothing);
+    slow.finish();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('GivenASlowTokenRead_WhenItCompletes_ThenTheSessionIsRestored', (
+    tester,
+  ) async {
+    // Given
+    final slow = _SlowTokenStore(
+      AuthToken(value: _systemAdminJwt, expiresAt: DateTime.utc(2030)),
+    );
+    final container = ProviderContainer(
+      overrides: <Override>[
+        appConfigProvider.overrideWithValue(
+          const AppConfig(apiBaseUrl: 'http://localhost:5000'),
+        ),
+        tokenStoreProvider.overrideWithValue(slow),
+        authRepositoryProvider.overrideWithValue(repository),
+      ],
+    );
+    addTearDown(container.dispose);
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const HeimdallApp(),
+      ),
+    );
+    await tester.pump();
+
+    // When
+    slow.finish();
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('Signed in as admin@example.com'), findsOneWidget);
+  });
+
+  // AF-07d — a role that is not offered a screen is told so, and is not
+  // bounced somewhere it did not ask for.
+  testWidgets('GivenAUser_WhenVisitingAnAdminRoute_ThenTheRefusalIsShown', (
+    tester,
+  ) async {
+    // Given
+    await store.write(
+      AuthToken(value: _userJwt(), expiresAt: DateTime.utc(2030)),
+    );
+    final container = ProviderContainer(
+      overrides: <Override>[
+        appConfigProvider.overrideWithValue(
+          const AppConfig(apiBaseUrl: 'http://localhost:5000'),
+        ),
+        tokenStoreProvider.overrideWithValue(store),
+        authRepositoryProvider.overrideWithValue(repository),
+      ],
+    );
+    addTearDown(container.dispose);
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const HeimdallApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // When
+    container.read(routerProvider).go('/scopes');
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('Not available for your role'), findsOneWidget);
+  });
+
+  // AF-07e — a token rejected mid-session ends it and says why.
+  testWidgets('GivenARejectedToken_WhenTheSessionEnds_ThenTheReasonIsShown', (
+    tester,
+  ) async {
+    // Given
+    await store.write(
+      AuthToken(value: _systemAdminJwt, expiresAt: DateTime.utc(2030)),
+    );
+    final container = ProviderContainer(
+      overrides: <Override>[
+        appConfigProvider.overrideWithValue(
+          const AppConfig(apiBaseUrl: 'http://localhost:5000'),
+        ),
+        tokenStoreProvider.overrideWithValue(store),
+        authRepositoryProvider.overrideWithValue(repository),
+      ],
+    );
+    addTearDown(container.dispose);
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const HeimdallApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // When
+    await container
+        .read(sessionControllerProvider.notifier)
+        .signOut(expired: true);
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(
+      find.text(
+        'Your session ended. Sign in again to pick up where you left off.',
+      ),
+      findsOneWidget,
+    );
+  });
+
+  // Signing out deliberately is not a session that ended under the caller.
+  testWidgets('GivenADeliberateSignOut_WhenSignedOut_ThenNoReasonIsShown', (
+    tester,
+  ) async {
+    // Given
+    await store.write(
+      AuthToken(value: _systemAdminJwt, expiresAt: DateTime.utc(2030)),
+    );
+    final container = ProviderContainer(
+      overrides: <Override>[
+        appConfigProvider.overrideWithValue(
+          const AppConfig(apiBaseUrl: 'http://localhost:5000'),
+        ),
+        tokenStoreProvider.overrideWithValue(store),
+        authRepositoryProvider.overrideWithValue(repository),
+      ],
+    );
+    addTearDown(container.dispose);
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const HeimdallApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // When
+    await container.read(sessionControllerProvider.notifier).signOut();
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('Sign in'), findsOneWidget);
+    expect(
+      find.text(
+        'Your session ended. Sign in again to pick up where you left off.',
+      ),
+      findsNothing,
+    );
+  });
+}
+
+/// A token naming a User, which is the role the matrix hides the most from.
+String _userJwt() {
+  final payload = base64Url.encode(
+    utf8.encode(
+      jsonEncode(<String, dynamic>{
+        'sub': 'id',
+        'email': 'user@example.com',
+        'role': 3,
+      }),
+    ),
+  );
+
+  return 'header.$payload.signature';
+}
+
+/// A store whose read does not complete until it is told to, so AF-07c's slow
+/// read is a state a test can actually observe.
+class _SlowTokenStore implements TokenStore {
+  _SlowTokenStore(this._token);
+
+  final AuthToken? _token;
+  final Completer<AuthToken?> _pending = Completer<AuthToken?>();
+
+  void finish() => _pending.complete(_token);
+
+  @override
+  Future<AuthToken?> read() => _pending.future;
+
+  @override
+  Future<void> write(AuthToken token) async {}
+
+  @override
+  Future<void> clear() async {}
 }

--- a/test/app/route_access_test.dart
+++ b/test/app/route_access_test.dart
@@ -1,0 +1,108 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdall_ui/app/route_access.dart';
+import 'package:heimdall_ui/features/auth/domain/session.dart';
+
+void main() {
+  // Every signed-in caller has a home, an account, and — so AF-07d cannot
+  // loop — the refusal screen itself.
+  for (final path in <String>['/', '/profile', '/profile/security']) {
+    for (final role in Role.values) {
+      test('Given${role.name}_WhenAsking${path}_ThenItIsAllowed', () {
+        // Given / When
+        final allowed = roleMayReach(role: role, path: path);
+
+        // Then
+        expect(allowed, isTrue);
+      });
+    }
+  }
+
+  test('GivenAnyRole_WhenAskingTheRefusalScreen_ThenItIsAllowed', () {
+    // Given / When / Then
+    for (final role in Role.values) {
+      expect(roleMayReach(role: role, path: '/not-available'), isTrue);
+    }
+  });
+
+  // Scope listing: all scopes for a System Admin, owned ones for a Scope
+  // Admin, hidden for a User.
+  test('GivenSystemAdmin_WhenAskingScopes_ThenItIsAllowed', () {
+    // Given / When
+    final allowed = roleMayReach(role: Role.systemAdmin, path: '/scopes');
+
+    // Then
+    expect(allowed, isTrue);
+  });
+
+  test('GivenScopeAdmin_WhenAskingScopes_ThenItIsAllowed', () {
+    // Given / When
+    final allowed = roleMayReach(role: Role.scopeAdmin, path: '/scopes');
+
+    // Then
+    expect(allowed, isTrue);
+  });
+
+  test('GivenUser_WhenAskingScopes_ThenItIsRefused', () {
+    // Given / When
+    final allowed = roleMayReach(role: Role.user, path: '/scopes');
+
+    // Then
+    expect(allowed, isFalse);
+  });
+
+  test('GivenUser_WhenAskingAScopesSubRoute_ThenItIsRefused', () {
+    // Given / When
+    final allowed = roleMayReach(
+      role: Role.user,
+      path: '/scopes/scope-id/persons',
+    );
+
+    // Then
+    expect(allowed, isFalse);
+  });
+
+  // Creating a scope is the System Admin's alone.
+  test('GivenScopeAdmin_WhenAskingCreateScope_ThenItIsRefused', () {
+    // Given / When
+    final allowed = roleMayReach(role: Role.scopeAdmin, path: '/scopes/new');
+
+    // Then
+    expect(allowed, isFalse);
+  });
+
+  test('GivenSystemAdmin_WhenAskingCreateScope_ThenItIsAllowed', () {
+    // Given / When
+    final allowed = roleMayReach(role: Role.systemAdmin, path: '/scopes/new');
+
+    // Then
+    expect(allowed, isTrue);
+  });
+
+  // Health: full for a System Admin, read-only for a Scope Admin, hidden for
+  // a User — read-only is still reaching it.
+  test('GivenScopeAdmin_WhenAskingHealth_ThenItIsAllowed', () {
+    // Given / When
+    final allowed = roleMayReach(role: Role.scopeAdmin, path: '/health');
+
+    // Then
+    expect(allowed, isTrue);
+  });
+
+  test('GivenUser_WhenAskingHealth_ThenItIsRefused', () {
+    // Given / When
+    final allowed = roleMayReach(role: Role.user, path: '/health');
+
+    // Then
+    expect(allowed, isFalse);
+  });
+
+  // A route nobody has built is the error screen's business: answering "not
+  // for your role" would be a guess about a screen that does not exist.
+  test('GivenAnyRole_WhenAskingAnUnknownRoute_ThenItIsAllowed', () {
+    // Given / When
+    final allowed = roleMayReach(role: Role.user, path: '/nothing-here');
+
+    // Then
+    expect(allowed, isTrue);
+  });
+}

--- a/test/app/router_test.dart
+++ b/test/app/router_test.dart
@@ -174,4 +174,108 @@ void main() {
     // Then
     expect(redirect, isNull);
   });
+
+  // AF-07d — a screen this role is not offered answers plainly rather than
+  // bouncing the caller somewhere they did not ask for.
+  test('GivenUser_WhenVisitingAnAdminRoute_ThenRedirectsToNotAvailable', () {
+    // Given
+    final session = Authenticated(
+      token: AuthToken(value: 'jwt', expiresAt: DateTime.utc(2030)),
+      principal: const Principal(id: 'id', email: 'a@b.c', role: Role.user),
+    );
+
+    // When
+    final redirect = redirectFor(session: session, location: '/scopes');
+
+    // Then
+    expect(redirect, '/not-available');
+  });
+
+  test(
+    'GivenScopeAdmin_WhenVisitingCreateScope_ThenRedirectsToNotAvailable',
+    () {
+      // Given
+      final session = Authenticated(
+        token: AuthToken(value: 'jwt', expiresAt: DateTime.utc(2030)),
+        principal: const Principal(
+          id: 'id',
+          email: 'a@b.c',
+          role: Role.scopeAdmin,
+        ),
+      );
+
+      // When
+      final redirect = redirectFor(session: session, location: '/scopes/new');
+
+      // Then
+      expect(redirect, '/not-available');
+    },
+  );
+
+  // AF-07d — and the refusal screen must be reachable, or it is the redirect
+  // loop the flow rules out.
+  test('GivenUser_WhenVisitingNotAvailable_ThenNoRedirect', () {
+    // Given
+    final session = Authenticated(
+      token: AuthToken(value: 'jwt', expiresAt: DateTime.utc(2030)),
+      principal: const Principal(id: 'id', email: 'a@b.c', role: Role.user),
+    );
+
+    // When
+    final redirect = redirectFor(session: session, location: '/not-available');
+
+    // Then
+    expect(redirect, isNull);
+  });
+
+  test('GivenUser_WhenVisitingTheirProfile_ThenNoRedirect', () {
+    // Given
+    final session = Authenticated(
+      token: AuthToken(value: 'jwt', expiresAt: DateTime.utc(2030)),
+      principal: const Principal(id: 'id', email: 'a@b.c', role: Role.user),
+    );
+
+    // When
+    final redirect = redirectFor(session: session, location: '/profile');
+
+    // Then
+    expect(redirect, isNull);
+  });
+
+  // A role the guard refuses is still refused with a query string attached.
+  test(
+    'GivenUser_WhenAnAdminRouteCarriesAQuery_ThenRedirectsToNotAvailable',
+    () {
+      // Given
+      final session = Authenticated(
+        token: AuthToken(value: 'jwt', expiresAt: DateTime.utc(2030)),
+        principal: const Principal(id: 'id', email: 'a@b.c', role: Role.user),
+      );
+
+      // When
+      final redirect = redirectFor(
+        session: session,
+        location: '/scopes?page=2',
+      );
+
+      // Then
+      expect(redirect, '/not-available');
+    },
+  );
+
+  // AF-07e — a session that ended under the caller is still unauthenticated,
+  // so the guard treats it exactly as it treats never having had one.
+  test(
+    'GivenAnExpiredSession_WhenVisitingPrivateRoute_ThenRedirectsToLogin',
+    () {
+      // Given
+      const session = Unauthenticated(sessionExpired: true);
+
+      // When
+      final redirect = redirectFor(session: session, location: '/scopes');
+
+      // Then
+      expect(redirect, '/login?from=%2Fscopes');
+    },
+  );
 }

--- a/test/features/auth/presentation/session_controller_test.dart
+++ b/test/features/auth/presentation/session_controller_test.dart
@@ -456,6 +456,57 @@ void main() {
     expect(principal.id, isEmpty);
   });
 
+  // AF-07e — a token rejected mid-session ends it, and the state remembers
+  // that it ended rather than that the user left.
+  test(
+    'GivenARejectedToken_WhenSignedOutAsExpired_ThenTheReasonIsKept',
+    () async {
+      // Given
+      final container = containerWith();
+      final controller = container.read(sessionControllerProvider.notifier);
+      await controller.restore();
+
+      // When
+      await controller.signOut(expired: true);
+
+      // Then
+      final state = container.read(sessionControllerProvider);
+      expect((state as Unauthenticated).sessionExpired, isTrue);
+    },
+  );
+
+  test('GivenADeliberateSignOut_WhenSignedOut_ThenNoReasonIsKept', () async {
+    // Given
+    final container = containerWith();
+    final controller = container.read(sessionControllerProvider.notifier);
+    await controller.restore();
+
+    // When
+    await controller.signOut();
+
+    // Then
+    final state = container.read(sessionControllerProvider);
+    expect((state as Unauthenticated).sessionExpired, isFalse);
+  });
+
+  // AF-07g — an expired stored token is discarded at start-up, and the API is
+  // never asked about it.
+  test('GivenAnExpiredStoredToken_WhenRestored_ThenItIsDiscarded', () async {
+    // Given
+    await store.write(
+      AuthToken(value: _systemAdminJwt, expiresAt: DateTime.utc(2000)),
+    );
+    final container = containerWith();
+
+    // When
+    await container.read(sessionControllerProvider.notifier).restore();
+
+    // Then
+    expect(container.read(sessionControllerProvider), isA<Unauthenticated>());
+    expect(await store.read(), isNull);
+    verifyZeroInteractions(repository);
+  });
+
   // UI-06 sign out — a Google session ends at the API and at Google too.
   test('GivenAGoogleSession_WhenSignedOut_ThenGoogleIsToldAsWell', () async {
     // Given


### PR DESCRIPTION
Implements UI-07 from the [Use Case Specification Document](docs/requirements/Use%20Case%20Specification%20Document.md). Cross-cutting: it enforces the API's authorization matrix in the interface, and delivers the guard half of FR-AU-05 … FR-AU-08.

UI-01 and UI-02 installed the parts of this guard they needed; this completes it.

## Flows implemented

| Flow | What it does |
| --- | --- |
| **Main** | Every route is classified public or private and matched against the session and the caller's role. |
| **AF-07a** | A private route without a session redirects to sign-in, carrying the requested location. *(already in place)* |
| **AF-07b** | A challenge in progress pulls every other route to it. *(already in place)* |
| **AF-07c** | While the stored token is read the guard decides nothing and a loading state covers whatever the router built underneath — the requested URL survives a slow read intact. **New.** |
| **AF-07d** | A role the matrix does not offer a screen gets a screen saying so, at `/not-available`. **New.** |
| **AF-07e** | A `401` clears the session and says it *ended*, which is a different message from "please sign in". **New.** |
| **AF-07f** | An authenticated caller asking for sign-in or the challenge goes to the screen they originally wanted, or home. *(already in place)* |
| **AF-07g** | A stored token whose expiry has passed is discarded without contacting the API. *(already in place, now covered)* |

## Design notes

**AF-07d is a screen, not a redirect.** The flow rules out a redirect loop, and sending someone home would also lie about why they did not arrive. `/not-available` is reachable by every authenticated caller, which is what keeps the guard from looping on its own refusal.

**AF-07c covers rather than replaces.** The loading state is the `MaterialApp.router` builder, so the router stays mounted and the deep link the user opened is still there when the read finishes. Rebuilding the router instead would have discarded it.

**Scope ownership is not in the guard.** "Owned scopes only" is a per-record question the API answers on the record, and a path cannot tell an owned scope from any other. The guard rules by role; the screens enforce what the API says. `roleMayReach` says so in a comment so the next use case does not have to rediscover it.

**An unknown route is allowed through** to the existing "not built yet" screen. Answering "not for your role" would be a guess about a screen that does not exist.

## Verification

```
dart format --set-exit-if-changed . && flutter analyze && flutter test
```

All three pass; **293 tests**, none skipped. Coverage added:

- `route_access_test.dart` — every role against home, profile and the refusal screen; scope listing and its sub-routes; create-scope as System Admin only; health for Scope Admin but not User; and an unknown route.
- `router_test.dart` — AF-07d for a User on an admin route, a Scope Admin on create-scope, and with a query string attached; the refusal screen reachable; a User's own profile; and AF-07e treated as unauthenticated by the guard.
- `heimdall_app_test.dart` — AF-07c's loading state and the restore that follows it, AF-07d end to end through the real router, and AF-07e's message shown after a rejected token but not after a deliberate sign-out.
- `session_controller_test.dart` — the expired marker set and not set, and AF-07g discarding an expired token with no call to the API.

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
