### PR TITLE
Read the verified address from the API, not a JWT claim

### DIFF
--- a/api/heimdall.json
+++ b/api/heimdall.json
@@ -4073,6 +4073,9 @@
           "expiresAt": {
             "type": "string",
             "format": "date-time"
+          },
+          "emailVerified": {
+            "type": "boolean"
           }
         },
         "additionalProperties": false
@@ -4576,6 +4579,10 @@
           "expiresAt": {
             "type": "string",
             "format": "date-time",
+            "nullable": true
+          },
+          "emailVerified": {
+            "type": "boolean",
             "nullable": true
           },
           "requiresTwoFactor": {
@@ -5840,6 +5847,9 @@
           "expiresAt": {
             "type": "string",
             "format": "date-time"
+          },
+          "emailVerified": {
+            "type": "boolean"
           }
         },
         "additionalProperties": false

--- a/lib/core/storage/token_store.dart
+++ b/lib/core/storage/token_store.dart
@@ -8,6 +8,7 @@ class AuthToken {
     required this.value,
     required this.expiresAt,
     this.viaGoogle = false,
+    this.emailVerified = true,
   });
 
   factory AuthToken.fromJson(Map<String, dynamic> json) => AuthToken(
@@ -15,10 +16,20 @@ class AuthToken {
     expiresAt: DateTime.parse(json['expiresAt']! as String),
     // Absent in anything written before UI-06, which was password-only.
     viaGoogle: json['viaGoogle'] as bool? ?? false,
+    // Absent in anything written before the API reported it. Absent is not
+    // evidence of an unverified address, so it reads as verified.
+    emailVerified: json['emailVerified'] as bool? ?? true,
   );
 
   final String value;
   final DateTime expiresAt;
+
+  /// Whether the API considers this person's address verified, as reported
+  /// alongside the token it was issued with.
+  ///
+  /// Stored with the token because a session restored at start-up needs it and
+  /// there is nothing to re-read it from until the person endpoint arrives.
+  final bool emailVerified;
 
   /// Whether this session was established through Google.
   ///
@@ -29,10 +40,20 @@ class AuthToken {
 
   bool get isExpired => DateTime.now().toUtc().isAfter(expiresAt.toUtc());
 
+  /// The same token with its address now known to be verified, for after the
+  /// person has just verified it in this session.
+  AuthToken asVerified() => AuthToken(
+    value: value,
+    expiresAt: expiresAt,
+    viaGoogle: viaGoogle,
+    emailVerified: true,
+  );
+
   Map<String, dynamic> toJson() => <String, dynamic>{
     'value': value,
     'expiresAt': expiresAt.toUtc().toIso8601String(),
     'viaGoogle': viaGoogle,
+    'emailVerified': emailVerified,
   };
 }
 

--- a/lib/features/auth/data/auth_repository_impl.dart
+++ b/lib/features/auth/data/auth_repository_impl.dart
@@ -65,7 +65,15 @@ class ApiAuthRepository implements AuthRepository {
         return const FailureResult<AuthToken>(_incompleteResponse);
       }
 
-      return Success<AuthToken>(AuthToken(value: token, expiresAt: expiresAt));
+      return Success<AuthToken>(
+        AuthToken(
+          value: token,
+          expiresAt: expiresAt,
+          // AF-05e: the API reports this with the token. A response that omits
+          // it is not saying the address is unverified.
+          emailVerified: data?.emailVerified ?? true,
+        ),
+      );
     } on DioException catch (error) {
       return FailureResult<AuthToken>(failureFromDioException(error));
     }
@@ -194,7 +202,12 @@ class ApiAuthRepository implements AuthRepository {
       }
 
       return Success<AuthToken>(
-        AuthToken(value: token, expiresAt: expiresAt, viaGoogle: true),
+        AuthToken(
+          value: token,
+          expiresAt: expiresAt,
+          viaGoogle: true,
+          emailVerified: data?.emailVerified ?? true,
+        ),
       );
     } on DioException catch (error) {
       return FailureResult<AuthToken>(failureFromDioException(error));
@@ -262,7 +275,13 @@ class ApiAuthRepository implements AuthRepository {
     }
 
     return Success<LoginOutcome>(
-      LoggedIn(AuthToken(value: token, expiresAt: expiresAt)),
+      LoggedIn(
+        AuthToken(
+          value: token,
+          expiresAt: expiresAt,
+          emailVerified: data.emailVerified ?? true,
+        ),
+      ),
     );
   }
 }

--- a/lib/features/auth/presentation/email_verification_controller.dart
+++ b/lib/features/auth/presentation/email_verification_controller.dart
@@ -121,6 +121,13 @@ class EmailVerificationController extends Notifier<EmailVerificationState> {
         onFailure: VerifyRejected.new,
       ),
     );
+
+    // AF-05e: a signed-in person who just verified should stop being asked to.
+    // The session's answer came with a token the API will not reissue for this,
+    // so it is corrected here instead.
+    if (result.isSuccess) {
+      await ref.read(sessionControllerProvider.notifier).markEmailVerified();
+    }
   }
 
   /// AF-05c — asks the API to send a fresh verification email.

--- a/lib/features/auth/presentation/session_controller.dart
+++ b/lib/features/auth/presentation/session_controller.dart
@@ -78,13 +78,9 @@ Principal principalFromToken(AuthToken token) {
         (payload['ownedScopeIds'] as List<dynamic>? ?? const <dynamic>[])
             .map((id) => id.toString())
             .toList(growable: false),
-    // AF-05e: read like every other claim here. Absent means "say nothing",
-    // not "unverified", so only an explicit false raises the prompt.
-    emailVerified: switch (payload['emailVerified']) {
-      final bool value => value,
-      final String value => value.toLowerCase() != 'false',
-      _ => true,
-    },
+    // AF-05e: not a claim. The API reports it alongside the token it issues,
+    // and that answer travels on [AuthToken] rather than inside the JWT.
+    emailVerified: token.emailVerified,
   );
 }
 
@@ -201,6 +197,22 @@ class SessionController extends Notifier<SessionState> {
         state = const Unauthenticated();
 
         return FailureResult<void>(failure);
+    }
+  }
+
+  /// Records that the signed-in person's address is now verified.
+  ///
+  /// AF-05e: the API reported the address as unverified when it issued this
+  /// token, and verifying it in this session does not issue a new one. Without
+  /// this the prompt would go on nagging about something already done.
+  Future<void> markEmailVerified() async {
+    if (state case Authenticated(:final token) when !token.emailVerified) {
+      final verified = token.asVerified();
+      await _store.write(verified);
+      state = Authenticated(
+        token: verified,
+        principal: principalFromToken(verified),
+      );
     }
   }
 

--- a/packages/heimdall_api_client/lib/models/google_sign_in_command_output.dart
+++ b/packages/heimdall_api_client/lib/models/google_sign_in_command_output.dart
@@ -8,13 +8,18 @@ part 'google_sign_in_command_output.g.dart';
 
 @JsonSerializable()
 class GoogleSignInCommandOutput {
-  const GoogleSignInCommandOutput({this.token, this.expiresAt});
+  const GoogleSignInCommandOutput({
+    this.token,
+    this.expiresAt,
+    this.emailVerified,
+  });
 
   factory GoogleSignInCommandOutput.fromJson(Map<String, Object?> json) =>
       _$GoogleSignInCommandOutputFromJson(json);
 
   final String? token;
   final DateTime? expiresAt;
+  final bool? emailVerified;
 
   Map<String, Object?> toJson() => _$GoogleSignInCommandOutputToJson(this);
 }

--- a/packages/heimdall_api_client/lib/models/google_sign_in_command_output.g.dart
+++ b/packages/heimdall_api_client/lib/models/google_sign_in_command_output.g.dart
@@ -13,6 +13,7 @@ GoogleSignInCommandOutput _$GoogleSignInCommandOutputFromJson(
   expiresAt: json['expiresAt'] == null
       ? null
       : DateTime.parse(json['expiresAt'] as String),
+  emailVerified: json['emailVerified'] as bool?,
 );
 
 Map<String, dynamic> _$GoogleSignInCommandOutputToJson(
@@ -20,4 +21,5 @@ Map<String, dynamic> _$GoogleSignInCommandOutputToJson(
 ) => <String, dynamic>{
   'token': instance.token,
   'expiresAt': instance.expiresAt?.toIso8601String(),
+  'emailVerified': instance.emailVerified,
 };

--- a/packages/heimdall_api_client/lib/models/login_command_output.dart
+++ b/packages/heimdall_api_client/lib/models/login_command_output.dart
@@ -11,6 +11,7 @@ class LoginCommandOutput {
   const LoginCommandOutput({
     this.token,
     this.expiresAt,
+    this.emailVerified,
     this.requiresTwoFactor,
     this.challengeToken,
     this.availableMethods,
@@ -21,6 +22,7 @@ class LoginCommandOutput {
 
   final String? token;
   final DateTime? expiresAt;
+  final bool? emailVerified;
   final bool? requiresTwoFactor;
   final String? challengeToken;
   final List<String>? availableMethods;

--- a/packages/heimdall_api_client/lib/models/login_command_output.g.dart
+++ b/packages/heimdall_api_client/lib/models/login_command_output.g.dart
@@ -12,6 +12,7 @@ LoginCommandOutput _$LoginCommandOutputFromJson(Map<String, dynamic> json) =>
       expiresAt: json['expiresAt'] == null
           ? null
           : DateTime.parse(json['expiresAt'] as String),
+      emailVerified: json['emailVerified'] as bool?,
       requiresTwoFactor: json['requiresTwoFactor'] as bool?,
       challengeToken: json['challengeToken'] as String?,
       availableMethods: (json['availableMethods'] as List<dynamic>?)
@@ -23,6 +24,7 @@ Map<String, dynamic> _$LoginCommandOutputToJson(LoginCommandOutput instance) =>
     <String, dynamic>{
       'token': instance.token,
       'expiresAt': instance.expiresAt?.toIso8601String(),
+      'emailVerified': instance.emailVerified,
       'requiresTwoFactor': instance.requiresTwoFactor,
       'challengeToken': instance.challengeToken,
       'availableMethods': instance.availableMethods,

--- a/packages/heimdall_api_client/lib/models/verify_two_factor_auth_command_output.dart
+++ b/packages/heimdall_api_client/lib/models/verify_two_factor_auth_command_output.dart
@@ -8,7 +8,11 @@ part 'verify_two_factor_auth_command_output.g.dart';
 
 @JsonSerializable()
 class VerifyTwoFactorAuthCommandOutput {
-  const VerifyTwoFactorAuthCommandOutput({this.token, this.expiresAt});
+  const VerifyTwoFactorAuthCommandOutput({
+    this.token,
+    this.expiresAt,
+    this.emailVerified,
+  });
 
   factory VerifyTwoFactorAuthCommandOutput.fromJson(
     Map<String, Object?> json,
@@ -16,6 +20,7 @@ class VerifyTwoFactorAuthCommandOutput {
 
   final String? token;
   final DateTime? expiresAt;
+  final bool? emailVerified;
 
   Map<String, Object?> toJson() =>
       _$VerifyTwoFactorAuthCommandOutputToJson(this);

--- a/packages/heimdall_api_client/lib/models/verify_two_factor_auth_command_output.g.dart
+++ b/packages/heimdall_api_client/lib/models/verify_two_factor_auth_command_output.g.dart
@@ -13,6 +13,7 @@ VerifyTwoFactorAuthCommandOutput _$VerifyTwoFactorAuthCommandOutputFromJson(
   expiresAt: json['expiresAt'] == null
       ? null
       : DateTime.parse(json['expiresAt'] as String),
+  emailVerified: json['emailVerified'] as bool?,
 );
 
 Map<String, dynamic> _$VerifyTwoFactorAuthCommandOutputToJson(
@@ -20,4 +21,5 @@ Map<String, dynamic> _$VerifyTwoFactorAuthCommandOutputToJson(
 ) => <String, dynamic>{
   'token': instance.token,
   'expiresAt': instance.expiresAt?.toIso8601String(),
+  'emailVerified': instance.emailVerified,
 };

--- a/test/core/storage/token_store_test.dart
+++ b/test/core/storage/token_store_test.dart
@@ -93,6 +93,58 @@ void main() {
     expect(restored.viaGoogle, isTrue);
   });
 
+  // AF-05e — the API reports this with the token, and a restored session needs
+  // it as much as a fresh one does.
+  test('GivenAnUnverifiedToken_WhenRoundTrippedThroughJson_ThenItStays', () {
+    // Given
+    final token = AuthToken(
+      value: 'jwt',
+      expiresAt: DateTime.utc(2030),
+      emailVerified: false,
+    );
+
+    // When
+    final restored = AuthToken.fromJson(token.toJson());
+
+    // Then
+    expect(restored.emailVerified, isFalse);
+  });
+
+  // A token stored before the API reported it says nothing, which is not the
+  // same as saying the address is unverified.
+  test('GivenAStoredTokenWithoutTheAnswer_WhenRead_ThenItIsVerified', () {
+    // Given
+    final json = <String, dynamic>{
+      'value': 'jwt',
+      'expiresAt': '2030-01-01T00:00:00.000Z',
+    };
+
+    // When
+    final restored = AuthToken.fromJson(json);
+
+    // Then
+    expect(restored.emailVerified, isTrue);
+  });
+
+  test('GivenAnUnverifiedToken_WhenMarkedVerified_ThenOnlyThatChanges', () {
+    // Given
+    final token = AuthToken(
+      value: 'jwt',
+      expiresAt: DateTime.utc(2030),
+      viaGoogle: true,
+      emailVerified: false,
+    );
+
+    // When
+    final verified = token.asVerified();
+
+    // Then
+    expect(verified.emailVerified, isTrue);
+    expect(verified.value, token.value);
+    expect(verified.expiresAt, token.expiresAt);
+    expect(verified.viaGoogle, isTrue);
+  });
+
   // Anything written before UI-06 was password-only and carries no such key.
   test('GivenAStoredTokenWithoutTheFlag_WhenRead_ThenItIsNotGoogle', () {
     // Given

--- a/test/features/auth/data/auth_repository_impl_test.dart
+++ b/test/features/auth/data/auth_repository_impl_test.dart
@@ -824,6 +824,117 @@ void main() {
     expect(adapter.requests, isEmpty);
   });
 
+  // AF-05e — the API reports the address's state with every token it issues,
+  // on all three of the endpoints that issue one.
+  test('GivenAnUnverifiedAddress_WhenLoggingIn_ThenTheTokenSaysSo', () async {
+    // Given
+    repository = repositoryAnswering(
+      const _Answer(
+        status: 200,
+        body: <String, dynamic>{
+          'success': true,
+          'errors': <String>[],
+          'data': <String, dynamic>{
+            'token': 'jwt',
+            'expiresAt': '2030-01-01T00:00:00Z',
+            'requiresTwoFactor': false,
+            'emailVerified': false,
+          },
+        },
+      ),
+    );
+
+    // When
+    final result = await repository.login(email: 'a@b.c', password: 'secret');
+
+    // Then
+    expect((result.valueOrNull! as LoggedIn).token.emailVerified, isFalse);
+  });
+
+  test(
+    'GivenAnUnverifiedAddress_WhenVerifyingTheFactor_ThenTheTokenSaysSo',
+    () async {
+      // Given
+      repository = repositoryAnswering(
+        const _Answer(
+          status: 200,
+          body: <String, dynamic>{
+            'success': true,
+            'errors': <String>[],
+            'data': <String, dynamic>{
+              'token': 'jwt',
+              'expiresAt': '2030-01-01T00:00:00Z',
+              'emailVerified': false,
+            },
+          },
+        ),
+      );
+
+      // When
+      final result = await repository.verifySecondFactor(
+        challengeToken: 'challenge',
+        code: '123456',
+      );
+
+      // Then
+      expect(result.valueOrNull?.emailVerified, isFalse);
+    },
+  );
+
+  test(
+    'GivenAnUnverifiedAddress_WhenSigningInWithGoogle_ThenTheTokenSaysSo',
+    () async {
+      // Given
+      repository = repositoryAnswering(
+        const _Answer(
+          status: 200,
+          body: <String, dynamic>{
+            'success': true,
+            'errors': <String>[],
+            'data': <String, dynamic>{
+              'token': 'jwt',
+              'expiresAt': '2030-01-01T00:00:00Z',
+              'emailVerified': false,
+            },
+          },
+        ),
+      );
+
+      // When
+      final result = await repository.signInWithGoogle(
+        idToken: 'google-id-token',
+      );
+
+      // Then
+      expect(result.valueOrNull?.emailVerified, isFalse);
+    },
+  );
+
+  // A response that omits it is not saying the address is unverified.
+  test('GivenNoAnswerAboutTheAddress_WhenLoggingIn_ThenItIsVerified', () async {
+    // Given
+    repository = repositoryAnswering(
+      const _Answer(
+        status: 200,
+        body: <String, dynamic>{
+          'success': true,
+          'errors': <String>[],
+          'data': <String, dynamic>{
+            'token': 'jwt',
+            'expiresAt': '2030-01-01T00:00:00Z',
+            'requiresTwoFactor': false,
+          },
+        },
+      ),
+    );
+
+    // When
+    final result = await repository.login(email: 'a@b.c', password: 'secret');
+
+    // Then
+    expect((result.valueOrNull! as LoggedIn).token.emailVerified, isTrue);
+  });
+
   test(
     'GivenRejectedSignOut_WhenSigningOut_ThenApiErrorsAreReturned',
     () async {

--- a/test/features/auth/presentation/email_verification_controller_test.dart
+++ b/test/features/auth/presentation/email_verification_controller_test.dart
@@ -3,12 +3,20 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/core/storage/token_store.dart';
 import 'package:heimdall_ui/features/auth/domain/auth_repository.dart';
+import 'package:heimdall_ui/features/auth/domain/session.dart';
 import 'package:heimdall_ui/features/auth/presentation/email_verification_controller.dart';
 import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
 import 'package:mocktail/mocktail.dart';
 
 class _MockAuthRepository extends Mock implements AuthRepository {}
+
+/// A token naming a User, for the flows that need a session to correct.
+const String _jwt =
+    'header.'
+    'eyJzdWIiOiJpZCIsImVtYWlsIjoiYUBiLmMiLCJyb2xlIjozfQ.'
+    'signature';
 
 void main() {
   late _MockAuthRepository repository;
@@ -18,6 +26,9 @@ void main() {
     container = ProviderContainer(
       overrides: <Override>[
         authRepositoryProvider.overrideWithValue(repository),
+        // A successful verification corrects the session's own answer, so the
+        // controller reaches the store even with nobody signed in.
+        tokenStoreProvider.overrideWithValue(InMemoryTokenStore()),
       ],
     );
     addTearDown(container.dispose);
@@ -86,6 +97,73 @@ void main() {
     expect((currentState().verification as Verified).messages, <String>[
       'This address was already verified.',
     ]);
+  });
+
+  // AF-05e — verifying in this session does not get a new token from the API,
+  // so the session's own answer is corrected and the prompt stops.
+  test('GivenAnUnverifiedSession_WhenVerified_ThenThePromptEnds', () async {
+    // Given
+    answerVerifyWith(const Success<List<String>>(<String>[]));
+    final store = InMemoryTokenStore();
+    await store.write(
+      AuthToken(
+        value: _jwt,
+        expiresAt: DateTime.utc(2030),
+        emailVerified: false,
+      ),
+    );
+    container = ProviderContainer(
+      overrides: <Override>[
+        authRepositoryProvider.overrideWithValue(repository),
+        tokenStoreProvider.overrideWithValue(store),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(sessionControllerProvider.notifier).restore();
+
+    // When
+    await container
+        .read(emailVerificationControllerProvider.notifier)
+        .verify('verification-token');
+
+    // Then
+    final session = container.read(sessionControllerProvider) as Authenticated;
+    expect(session.principal.emailVerified, isTrue);
+  });
+
+  // A refused token verified nothing, so the prompt has to stay.
+  test('GivenARejectedToken_WhenVerified_ThenThePromptStays', () async {
+    // Given
+    answerVerifyWith(
+      const FailureResult<List<String>>(
+        Failure(kind: FailureKind.validation, errors: <String>['No good.']),
+      ),
+    );
+    final store = InMemoryTokenStore();
+    await store.write(
+      AuthToken(
+        value: _jwt,
+        expiresAt: DateTime.utc(2030),
+        emailVerified: false,
+      ),
+    );
+    container = ProviderContainer(
+      overrides: <Override>[
+        authRepositoryProvider.overrideWithValue(repository),
+        tokenStoreProvider.overrideWithValue(store),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(sessionControllerProvider.notifier).restore();
+
+    // When
+    await container
+        .read(emailVerificationControllerProvider.notifier)
+        .verify('stale');
+
+    // Then
+    final session = container.read(sessionControllerProvider) as Authenticated;
+    expect(session.principal.emailVerified, isFalse);
   });
 
   // AF-05a — no token means no request.

--- a/test/features/auth/presentation/session_controller_test.dart
+++ b/test/features/auth/presentation/session_controller_test.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:heimdall_ui/core/result/result.dart';
@@ -611,12 +609,14 @@ void main() {
     },
   );
 
-  // AF-05e — the claim the unverified-address prompt is decided by.
-  test('GivenUnverifiedClaim_WhenPrincipalRead_ThenEmailIsUnverified', () {
+  // AF-05e — the API reports this with the token, so that is where the
+  // principal reads it from. The JWT says nothing about it.
+  test('GivenAnUnverifiedToken_WhenPrincipalRead_ThenEmailIsUnverified', () {
     // Given
     final token = AuthToken(
-      value: _jwtWith(<String, dynamic>{'emailVerified': false}),
+      value: _systemAdminJwt,
       expiresAt: DateTime.utc(2030),
+      emailVerified: false,
     );
 
     // When
@@ -626,12 +626,10 @@ void main() {
     expect(principal.emailVerified, isFalse);
   });
 
-  // Absent is not the same as false: a token that says nothing about
-  // verification must not raise the prompt.
-  test('GivenNoVerificationClaim_WhenPrincipalRead_ThenEmailIsVerified', () {
+  test('GivenAVerifiedToken_WhenPrincipalRead_ThenEmailIsVerified', () {
     // Given
     final token = AuthToken(
-      value: _jwtWith(<String, dynamic>{}),
+      value: _systemAdminJwt,
       expiresAt: DateTime.utc(2030),
     );
 
@@ -641,16 +639,64 @@ void main() {
     // Then
     expect(principal.emailVerified, isTrue);
   });
-}
 
-/// Builds a JWT whose payload is the standard User claims plus [extra].
-String _jwtWith(Map<String, dynamic> extra) {
-  final claims = <String, dynamic>{
-    'sub': 'id',
-    'email': 'a@b.c',
-    'role': 3,
-    ...extra,
-  };
+  // AF-05e — verifying in this session does not get a new token from the API,
+  // so the session's own answer is corrected rather than left stale.
+  test(
+    'GivenAnUnverifiedSession_WhenMarkedVerified_ThenThePromptEnds',
+    () async {
+      // Given
+      await store.write(
+        AuthToken(
+          value: _systemAdminJwt,
+          expiresAt: DateTime.utc(2030),
+          emailVerified: false,
+        ),
+      );
+      final container = containerWith();
+      final controller = container.read(sessionControllerProvider.notifier);
+      await controller.restore();
 
-  return 'header.${base64Url.encode(utf8.encode(jsonEncode(claims)))}.signature';
+      // When
+      await controller.markEmailVerified();
+
+      // Then
+      final state = container.read(sessionControllerProvider);
+      expect((state as Authenticated).principal.emailVerified, isTrue);
+    },
+  );
+
+  // And it survives a restart, or the prompt would return on the next launch.
+  test('GivenAnUnverifiedSession_WhenMarkedVerified_ThenItIsStored', () async {
+    // Given
+    await store.write(
+      AuthToken(
+        value: _systemAdminJwt,
+        expiresAt: DateTime.utc(2030),
+        emailVerified: false,
+      ),
+    );
+    final container = containerWith();
+    final controller = container.read(sessionControllerProvider.notifier);
+    await controller.restore();
+
+    // When
+    await controller.markEmailVerified();
+
+    // Then
+    expect((await store.read())?.emailVerified, isTrue);
+  });
+
+  test('GivenNoSession_WhenMarkedVerified_ThenNothingIsStored', () async {
+    // Given
+    final container = containerWith();
+    final controller = container.read(sessionControllerProvider.notifier);
+    await controller.restore();
+
+    // When
+    await controller.markEmailVerified();
+
+    // Then
+    expect(await store.read(), isNull);
+  });
 }

--- a/test/features/auth/presentation/verification_banner_test.dart
+++ b/test/features/auth/presentation/verification_banner_test.dart
@@ -13,30 +13,33 @@ import 'package:mocktail/mocktail.dart';
 
 class _MockAuthRepository extends Mock implements AuthRepository {}
 
-/// A token naming a User, with [verified] deciding the claim AF-05e reads.
-/// Pass `null` to leave the claim out entirely.
-String jwtWith({bool? verified}) {
-  final claims = <String, dynamic>{'sub': 'id', 'email': 'a@b.c', 'role': 3};
-
-  if (verified != null) {
-    claims['emailVerified'] = verified;
-  }
-
-  return 'header.${base64Url.encode(utf8.encode(jsonEncode(claims)))}.signature';
-}
+/// A token naming a User. The JWT says nothing about verification — the API
+/// reports that alongside the token, which is where AF-05e reads it from.
+final String _jwt =
+    'header.'
+    '${base64Url.encode(utf8.encode(jsonEncode(<String, dynamic>{'sub': 'id', 'email': 'a@b.c', 'role': 3})))}'
+    '.signature';
 
 void main() {
   late _MockAuthRepository repository;
   late InMemoryTokenStore store;
   late ProviderContainer container;
 
+  /// [emailVerified] is what the API said when it issued the token; `null`
+  /// stands for no session at all.
   Future<void> pump(
     WidgetTester tester, {
-    String? jwt,
+    bool? emailVerified,
     ThemeData? theme,
   }) async {
-    if (jwt != null) {
-      await store.write(AuthToken(value: jwt, expiresAt: DateTime.utc(2030)));
+    if (emailVerified != null) {
+      await store.write(
+        AuthToken(
+          value: _jwt,
+          expiresAt: DateTime.utc(2030),
+          emailVerified: emailVerified,
+        ),
+      );
     }
 
     container = ProviderContainer(
@@ -73,7 +76,7 @@ void main() {
     tester,
   ) async {
     // Given / When
-    await pump(tester, jwt: jwtWith(verified: false));
+    await pump(tester, emailVerified: false);
 
     // Then
     expect(
@@ -86,7 +89,7 @@ void main() {
     tester,
   ) async {
     // Given / When
-    await pump(tester, jwt: jwtWith(verified: true));
+    await pump(tester, emailVerified: true);
 
     // Then
     expect(find.text('Your email address is not verified yet.'), findsNothing);
@@ -100,23 +103,35 @@ void main() {
     expect(find.text('Your email address is not verified yet.'), findsNothing);
   });
 
-  // An absent claim is not evidence of an unverified address, so it stays
-  // quiet rather than nagging on data it does not have.
-  testWidgets('GivenNoVerificationClaim_WhenRendered_ThenNothingIsShown', (
-    tester,
-  ) async {
-    // Given / When
-    await pump(tester, jwt: jwtWith());
+  // A response that said nothing is not evidence of an unverified address, so
+  // the prompt stays quiet rather than nagging on data it does not have.
+  testWidgets(
+    'GivenATokenStoredBeforeTheApiReportedIt_WhenRendered_ThenNothingIsShown',
+    (tester) async {
+      // Given
+      await store.write(
+        AuthToken.fromJson(<String, dynamic>{
+          'value': _jwt,
+          'expiresAt': '2030-01-01T00:00:00.000Z',
+        }),
+      );
 
-    // Then
-    expect(find.text('Your email address is not verified yet.'), findsNothing);
-  });
+      // When
+      await pump(tester);
+
+      // Then
+      expect(
+        find.text('Your email address is not verified yet.'),
+        findsNothing,
+      );
+    },
+  );
 
   testWidgets('GivenThePrompt_WhenResendTapped_ThenTheApiIsCalled', (
     tester,
   ) async {
     // Given
-    await pump(tester, jwt: jwtWith(verified: false));
+    await pump(tester, emailVerified: false);
 
     // When
     await tester.tap(find.widgetWithText(TextButton, 'Resend'));
@@ -130,7 +145,7 @@ void main() {
     tester,
   ) async {
     // Given
-    await pump(tester, jwt: jwtWith(verified: false));
+    await pump(tester, emailVerified: false);
 
     // When
     await tester.tap(find.widgetWithText(TextButton, 'Resend'));
@@ -155,7 +170,7 @@ void main() {
         ),
       ),
     );
-    await pump(tester, jwt: jwtWith(verified: false));
+    await pump(tester, emailVerified: false);
 
     // When
     await tester.tap(find.widgetWithText(TextButton, 'Resend'));
@@ -168,7 +183,7 @@ void main() {
   // AF-05e — and it is dismissible.
   testWidgets('GivenThePrompt_WhenDismissed_ThenItIsGone', (tester) async {
     // Given
-    await pump(tester, jwt: jwtWith(verified: false));
+    await pump(tester, emailVerified: false);
 
     // When
     await tester.tap(find.byIcon(Icons.close));
@@ -182,7 +197,7 @@ void main() {
     tester,
   ) async {
     // Given / When
-    await pump(tester, jwt: jwtWith(verified: false), theme: buildDarkTheme());
+    await pump(tester, emailVerified: false, theme: buildDarkTheme());
 
     // Then
     expect(

--- a/test/features/auth/presentation/verify_email_screen_test.dart
+++ b/test/features/auth/presentation/verify_email_screen_test.dart
@@ -14,17 +14,12 @@ import 'package:mocktail/mocktail.dart';
 
 class _MockAuthRepository extends Mock implements AuthRepository {}
 
-/// A token whose payload names a verified User, which is all this screen needs
-/// to decide that a session exists.
+/// A token naming a User, which is all this screen needs to decide that a
+/// session exists.
 String _jwt() {
   final payload = base64Url.encode(
     utf8.encode(
-      jsonEncode(<String, dynamic>{
-        'sub': 'id',
-        'email': 'a@b.c',
-        'role': 3,
-        'emailVerified': true,
-      }),
+      jsonEncode(<String, dynamic>{'sub': 'id', 'email': 'a@b.c', 'role': 3}),
     ),
   );
 


### PR DESCRIPTION
The API now reports whether the signed-in person's address is verified. This reads it from there and drops the assumption UI-05 shipped with.

## What changed at the API

`emailVerified` is now returned **alongside the token** on all three endpoints that issue one:

| Endpoint | Field |
| --- | --- |
| `POST /api/auth/login` | `emailVerified` (nullable) |
| `POST /api/auth/2fa/verify` | `emailVerified` |
| `POST /api/auth/google` | `emailVerified` |

The vendored specification and the generated client are refreshed for it. Only seven files changed materially — the three output models, their `.g.dart` companions, and `api/heimdall.json`; everything else in the regenerated client is byte-identical.

## What changed here

[PR #41](https://github.com/artur-rios/heimdall-ui/pull/41) flagged this as an assumption to check: nothing carried the answer at the time, so AF-05e read an `emailVerified` **JWT claim**, the way the role and scope claims are read. That was never confirmed, which means **the AF-05e prompt may never have fired in production**. It reads the API's answer now.

- The answer travels on `AuthToken` and is **stored with it**. A session restored at start-up needs it as much as a fresh one, and there is nothing to re-read it from until the person endpoint arrives with UI-08.
- A response, or a stored token, that says nothing still reads as **verified**. Silence is not evidence of an unverified address, and nagging on data the client does not have is worse than staying quiet.
- `principalFromToken` no longer parses the claim.

## One behaviour worth calling out

Verifying an address while signed in does **not** get a new token from the API, so the session's own answer would stay stale and the prompt would go on nagging about something already done. `SessionController.markEmailVerified()` corrects it when verification succeeds, and persists it so the prompt does not return on the next launch. A refused token corrects nothing.

This is slightly beyond a straight rewiring, but without it the feature you just enabled would visibly misbehave the first time someone used it.

## Verification

```
dart format --set-exit-if-changed . && flutter analyze && flutter test
```

All three pass; **305 tests**, none skipped — up from 293. Coverage added:

- `auth_repository_impl_test.dart` — an unverified address reported on each of the three token-issuing endpoints, and a response that omits it reading as verified.
- `token_store_test.dart` — the answer round-trips, a token stored before the API reported it reads as verified, and `asVerified()` changes only that.
- `session_controller_test.dart` — the principal reads it from the token rather than the JWT, and `markEmailVerified` updates the session and the store, with no session left alone.
- `email_verification_controller_test.dart` — a successful verification ends the prompt, a refused one leaves it.
- `verification_banner_test.dart` — rebuilt on the response-sourced answer; the "no claim" case becomes "a token stored before the API reported it".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
