### PR TITLE
feat(ui-10): browse and search scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ the board is where an item's status changes as it moves.
 
 | Use case | Status | Issue |
 | --- | --- | --- |
-| UI-10: Browse and search scopes | ⬜ | [#10](https://github.com/artur-rios/heimdall-ui/issues/10) |
+| UI-10: Browse and search scopes | ✅ | [#10](https://github.com/artur-rios/heimdall-ui/issues/10) |
 | UI-11: Create a scope | ⬜ | [#11](https://github.com/artur-rios/heimdall-ui/issues/11) |
 | UI-12: View and update a scope | ⬜ | [#12](https://github.com/artur-rios/heimdall-ui/issues/12) |
 | UI-13: Delete a scope, logically and permanently | ⬜ | [#13](https://github.com/artur-rios/heimdall-ui/issues/13) |

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -11,6 +11,7 @@ import '../features/auth/presentation/two_factor_screen.dart';
 import '../features/auth/presentation/verify_email_screen.dart';
 import '../features/home/presentation/home_screen.dart';
 import '../features/profile/presentation/profile_screen.dart';
+import '../features/scopes/presentation/scope_list_screen.dart';
 import 'route_access.dart';
 
 /// Routes an unauthenticated caller may reach.
@@ -113,6 +114,10 @@ final Provider<GoRouter> routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/profile',
         builder: (context, state) => const ProfileScreen(),
+      ),
+      GoRoute(
+        path: '/scopes',
+        builder: (context, state) => const ScopeListScreen(),
       ),
       GoRoute(
         path: '/not-available',

--- a/lib/features/scopes/data/scope_repository_impl.dart
+++ b/lib/features/scopes/data/scope_repository_impl.dart
@@ -1,0 +1,75 @@
+import 'package:dio/dio.dart';
+import 'package:heimdall_api_client/export.dart';
+
+import '../../../core/network/envelope.dart';
+import '../../../core/result/result.dart';
+import '../domain/scope.dart';
+import '../domain/scope_repository.dart';
+
+/// [ScopeRepository] over the generated client.
+///
+/// This is the only place in the scope feature that knows the generated types
+/// exist; everything above it works in terms of the domain.
+class ApiScopeRepository implements ScopeRepository {
+  const ApiScopeRepository(this._client);
+
+  final ScopeClient _client;
+
+  @override
+  Future<Result<Page<Scope>>> list({
+    String? name,
+    bool includeDeleted = false,
+    int pageNumber = 1,
+    int pageSize = 20,
+  }) async {
+    try {
+      final response = await _client.scopeList(
+        // An empty search is no search: sending it would ask the API to match
+        // the empty string rather than to stop filtering.
+        name: (name?.trim().isEmpty ?? true) ? null : name!.trim(),
+        includeDeleted: includeDeleted,
+        pageNumber: pageNumber,
+        pageSize: pageSize,
+      );
+
+      if (response.success != true) {
+        return FailureResult<Page<Scope>>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: response.errors ?? const <String>[],
+          ),
+        );
+      }
+
+      final items = (response.data ?? const <ScopeOutput>[])
+          .map(scopeFromOutput)
+          .toList(growable: false);
+
+      return Success<Page<Scope>>(
+        Page<Scope>(
+          items: items,
+          pageNumber: response.pageNumber ?? pageNumber,
+          pageSize: response.pageSize ?? pageSize,
+          totalItems: response.totalItems ?? items.length,
+          totalPages: response.totalPages ?? 1,
+        ),
+      );
+    } on DioException catch (error) {
+      // AF-10b: a transport failure keeps its own kind, which is what lets the
+      // screen offer a retry rather than render the API's silence as an error.
+      return FailureResult<Page<Scope>>(failureFromDioException(error));
+    }
+  }
+}
+
+/// Maps the generated output onto the domain entity.
+Scope scopeFromOutput(ScopeOutput output) => Scope(
+  id: output.id ?? '',
+  name: output.name ?? '',
+  description: output.description ?? '',
+  googleSignInEnabled: output.googleSignInEnabled ?? false,
+  isDeleted: output.isDeleted ?? false,
+  ownerIds: output.ownerIds ?? const <String>[],
+  createdAt: output.createdAt,
+  updatedAt: output.updatedAt,
+);

--- a/lib/features/scopes/domain/scope.dart
+++ b/lib/features/scopes/domain/scope.dart
@@ -1,0 +1,34 @@
+/// A scope as the API describes one.
+///
+/// The generated output makes every field nullable because one shape serves
+/// several endpoints. Here the fields the interface renders are non-nullable
+/// with defined fallbacks, so no screen has to decide what an absent name means.
+class Scope {
+  const Scope({
+    required this.id,
+    required this.name,
+    required this.description,
+    this.googleSignInEnabled = false,
+    this.isDeleted = false,
+    this.ownerIds = const <String>[],
+    this.createdAt,
+    this.updatedAt,
+  });
+
+  final String id;
+  final String name;
+  final String description;
+
+  /// Whether people may sign in to this scope with Google. UI-15 toggles it.
+  final bool googleSignInEnabled;
+
+  /// Whether the scope has been logically deleted. The listing shows these only
+  /// when the user asks for them.
+  final bool isDeleted;
+
+  final List<String> ownerIds;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+
+  int get ownerCount => ownerIds.length;
+}

--- a/lib/features/scopes/domain/scope_repository.dart
+++ b/lib/features/scopes/domain/scope_repository.dart
@@ -1,0 +1,21 @@
+import '../../../core/network/envelope.dart';
+import '../../../core/result/result.dart';
+import 'scope.dart';
+
+/// The scope operations the interface depends on.
+///
+/// Implemented in `features/scopes/data` over the generated client, and faked
+/// in tests — which is why nothing here mentions a transport.
+abstract interface class ScopeRepository {
+  /// Reads one page of scopes.
+  ///
+  /// The API decides what the caller may see: a System Admin gets every scope,
+  /// a Scope Admin only the ones they own (AF-10c). Nothing here filters by
+  /// ownership, because the interface is not the authority on that.
+  Future<Result<Page<Scope>>> list({
+    String? name,
+    bool includeDeleted = false,
+    int pageNumber = 1,
+    int pageSize = 20,
+  });
+}

--- a/lib/features/scopes/presentation/scope_list_controller.dart
+++ b/lib/features/scopes/presentation/scope_list_controller.dart
@@ -1,0 +1,142 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/network/envelope.dart';
+import '../../../core/result/result.dart';
+import '../domain/scope.dart';
+import '../domain/scope_repository.dart';
+
+/// Overridden at start-up with the client-backed implementation, and in tests
+/// with a fake.
+final Provider<ScopeRepository> scopeRepositoryProvider =
+    Provider<ScopeRepository>(
+      (ref) => throw UnimplementedError(
+        'scopeRepositoryProvider must be overridden',
+      ),
+    );
+
+/// What the listing is currently asking the API for.
+///
+/// Kept whole rather than as loose fields so a failed request can be repeated
+/// with exactly the question that failed (FR-UX-07).
+class ScopeQuery {
+  const ScopeQuery({
+    this.name = '',
+    this.includeDeleted = false,
+    this.pageNumber = 1,
+  });
+
+  final String name;
+  final bool includeDeleted;
+  final int pageNumber;
+
+  /// Whether the user has narrowed the listing at all, which is what tells an
+  /// empty result from an unfiltered empty collection (AF-10a).
+  bool get isFiltered => name.trim().isNotEmpty || includeDeleted;
+
+  ScopeQuery copyWith({String? name, bool? includeDeleted, int? pageNumber}) =>
+      ScopeQuery(
+        name: name ?? this.name,
+        includeDeleted: includeDeleted ?? this.includeDeleted,
+        pageNumber: pageNumber ?? this.pageNumber,
+      );
+}
+
+/// How far the listing has got. The query travels with every state, so the
+/// filters survive a failure and a retry.
+sealed class ScopeListState {
+  const ScopeListState(this.query);
+
+  final ScopeQuery query;
+}
+
+/// AF-10e — the first page is on its way and the list shows a placeholder.
+final class ScopeListLoading extends ScopeListState {
+  const ScopeListLoading(super.query);
+}
+
+/// A page arrived. [busy] marks a further page or filter in flight, which keeps
+/// the current rows on screen instead of flashing the placeholder again.
+final class ScopeListLoaded extends ScopeListState {
+  const ScopeListLoaded(super.query, this.page, {this.busy = false});
+
+  final Page<Scope> page;
+  final bool busy;
+}
+
+/// AF-10b — the request failed, and the query that failed is kept.
+final class ScopeListFailed extends ScopeListState {
+  const ScopeListFailed(super.query, this.failure);
+
+  final Failure failure;
+}
+
+final NotifierProvider<ScopeListController, ScopeListState>
+scopeListControllerProvider =
+    NotifierProvider<ScopeListController, ScopeListState>(
+      ScopeListController.new,
+    );
+
+/// Owns the scope listing: the filters, the page, and the request in flight.
+class ScopeListController extends Notifier<ScopeListState> {
+  /// Whether a request is already on its way.
+  ///
+  /// A field rather than a read of [state], because the first load and a later
+  /// page are in different states while being equally in flight, and a second
+  /// request either way would race the first to set the result.
+  bool _inFlight = false;
+
+  @override
+  ScopeListState build() => const ScopeListLoading(ScopeQuery());
+
+  /// Reads the page the current query names.
+  Future<void> load() => _fetch(state.query);
+
+  /// AF-10d — a new search starts at the first page. Leaving the user on page
+  /// four of a listing they just narrowed would show them an empty page that is
+  /// not actually empty.
+  Future<void> search(String name) =>
+      _fetch(state.query.copyWith(name: name, pageNumber: 1));
+
+  /// AF-10d — as with the search, changing what is included starts over.
+  Future<void> setIncludeDeleted(bool includeDeleted) => _fetch(
+    state.query.copyWith(includeDeleted: includeDeleted, pageNumber: 1),
+  );
+
+  Future<void> goToPage(int pageNumber) =>
+      _fetch(state.query.copyWith(pageNumber: pageNumber));
+
+  /// AF-10a — returns to the unfiltered listing from the empty-result panel.
+  Future<void> clearFilters() => _fetch(const ScopeQuery());
+
+  Future<void> _fetch(ScopeQuery query) async {
+    if (_inFlight) {
+      return;
+    }
+
+    final current = state;
+    _inFlight = true;
+
+    // The rows already on screen stay while the next page loads; only a
+    // listing with nothing to show falls back to the placeholder.
+    state = current is ScopeListLoaded
+        ? ScopeListLoaded(query, current.page, busy: true)
+        : ScopeListLoading(query);
+
+    try {
+      final result = await ref
+          .read(scopeRepositoryProvider)
+          .list(
+            name: query.name,
+            includeDeleted: query.includeDeleted,
+            pageNumber: query.pageNumber,
+          );
+
+      state = result.fold(
+        onSuccess: (page) => ScopeListLoaded(query, page),
+        onFailure: (failure) => ScopeListFailed(query, failure),
+      );
+    } finally {
+      _inFlight = false;
+    }
+  }
+}

--- a/lib/features/scopes/presentation/scope_list_screen.dart
+++ b/lib/features/scopes/presentation/scope_list_screen.dart
@@ -1,0 +1,195 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../shared/layout/app_shell.dart';
+import '../../../shared/widgets/adaptive_collection.dart';
+import '../../../shared/widgets/collection_states.dart';
+import '../../auth/domain/session.dart';
+import '../../auth/presentation/session_controller.dart';
+import '../domain/scope.dart';
+import 'scope_list_controller.dart';
+
+/// UI-10 — the scope listing.
+///
+/// What it lists is the API's answer, not a filtered view of everything: a
+/// Scope Admin is returned only the scopes they own (AF-10c), and nothing here
+/// second-guesses that.
+class ScopeListScreen extends ConsumerStatefulWidget {
+  const ScopeListScreen({super.key});
+
+  @override
+  ConsumerState<ScopeListScreen> createState() => _ScopeListScreenState();
+}
+
+class _ScopeListScreenState extends ConsumerState<ScopeListScreen> {
+  final _search = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => ref.read(scopeListControllerProvider.notifier).load(),
+    );
+  }
+
+  @override
+  void dispose() {
+    _search.dispose();
+    super.dispose();
+  }
+
+  void _clearFilters() {
+    _search.clear();
+    ref.read(scopeListControllerProvider.notifier).clearFilters();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(scopeListControllerProvider);
+    final controller = ref.read(scopeListControllerProvider.notifier);
+    final session = ref.watch(sessionControllerProvider);
+    // AF-10c: only a System Admin may create a scope, so nobody else is shown
+    // the control. The API refuses either way.
+    final mayCreate =
+        session is Authenticated && session.principal.isSystemAdmin;
+
+    return AppShell(
+      currentRoute: '/scopes',
+      title: const Text('Scopes'),
+      floatingActionButton: mayCreate
+          ? FloatingActionButton.extended(
+              onPressed: () => context.go('/scopes/new'),
+              icon: const Icon(Icons.add),
+              label: const Text('New scope'),
+            )
+          : null,
+      body: Column(
+        children: <Widget>[
+          _Filters(
+            search: _search,
+            includeDeleted: state.query.includeDeleted,
+            onSearch: controller.search,
+            onIncludeDeletedChanged: controller.setIncludeDeleted,
+          ),
+          Expanded(
+            child: switch (state) {
+              ScopeListLoading() => const CollectionLoading(),
+              ScopeListFailed(:final failure) => CollectionFailed(
+                failure: failure,
+                onRetry: controller.load,
+              ),
+              ScopeListLoaded(:final page, :final query)
+                  when page.items.isEmpty =>
+                _empty(query: query, mayCreate: mayCreate),
+              final ScopeListLoaded loaded => AdaptiveCollection<Scope>(
+                items: loaded.page.items,
+                busy: loaded.busy,
+                reservesFloatingAction: mayCreate,
+                pageNumber: loaded.page.pageNumber,
+                totalPages: loaded.page.totalPages,
+                totalItems: loaded.page.totalItems,
+                onPageChanged: controller.goToPage,
+                onTap: (scope) => context.go('/scopes/${scope.id}'),
+                title: (scope) => scope.name,
+                subtitle: (scope) => scope.description,
+                columns: <CollectionColumn<Scope>>[
+                  CollectionColumn<Scope>(
+                    label: 'Google Sign-In',
+                    cell: (scope) =>
+                        Text(scope.googleSignInEnabled ? 'On' : 'Off'),
+                  ),
+                  CollectionColumn<Scope>(
+                    label: 'Owners',
+                    cell: (scope) => Text('${scope.ownerCount}'),
+                  ),
+                  CollectionColumn<Scope>(
+                    label: 'State',
+                    cell: (scope) =>
+                        Text(scope.isDeleted ? 'Deleted' : 'Active'),
+                  ),
+                ],
+              ),
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// AF-10a — an empty listing and an empty search are different situations,
+  /// and each has its own next action.
+  Widget _empty({required ScopeQuery query, required bool mayCreate}) =>
+      query.isFiltered
+      ? CollectionEmpty(
+          title: 'No scopes matched',
+          message:
+              'Nothing here matches what you searched for. Clearing the '
+              'filters shows the full listing again.',
+          icon: Icons.search_off_outlined,
+          actionLabel: 'Clear filters',
+          onAction: _clearFilters,
+        )
+      : CollectionEmpty(
+          title: 'No scopes yet',
+          message: mayCreate
+              ? 'Scopes are how Heimdall separates one tenant from another. '
+                    'Create the first one to get started.'
+              : 'You do not own any scopes yet. A System Admin can add you as '
+                    'an owner of one.',
+          icon: Icons.domain_outlined,
+          actionLabel: mayCreate ? 'New scope' : null,
+          onAction: mayCreate ? () => context.go('/scopes/new') : null,
+        );
+}
+
+/// The search field and the include-deleted switch.
+class _Filters extends StatelessWidget {
+  const _Filters({
+    required this.search,
+    required this.includeDeleted,
+    required this.onSearch,
+    required this.onIncludeDeletedChanged,
+  });
+
+  final TextEditingController search;
+  final bool includeDeleted;
+  final ValueChanged<String> onSearch;
+  final ValueChanged<bool> onIncludeDeletedChanged;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.fromLTRB(12, 12, 12, 0),
+    child: Wrap(
+      spacing: 16,
+      runSpacing: 8,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: <Widget>[
+        SizedBox(
+          width: 320,
+          child: TextField(
+            controller: search,
+            decoration: InputDecoration(
+              labelText: 'Search by name',
+              prefixIcon: const Icon(Icons.search),
+              suffixIcon: IconButton(
+                tooltip: 'Search',
+                icon: const Icon(Icons.arrow_forward),
+                onPressed: () => onSearch(search.text),
+              ),
+            ),
+            onSubmitted: onSearch,
+          ),
+        ),
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Switch(value: includeDeleted, onChanged: onIncludeDeletedChanged),
+            const SizedBox(width: 8),
+            const Text('Include deleted'),
+          ],
+        ),
+      ],
+    ),
+  );
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,6 +15,8 @@ import 'features/auth/data/google_sign_in_gateway_impl.dart';
 import 'features/auth/presentation/session_controller.dart';
 import 'features/persons/data/person_repository_impl.dart';
 import 'features/profile/presentation/profile_controller.dart';
+import 'features/scopes/data/scope_repository_impl.dart';
+import 'features/scopes/presentation/scope_list_controller.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
@@ -39,6 +41,9 @@ void main() {
         ),
         personRepositoryProvider.overrideWith(
           (ref) => ApiPersonRepository(PersonClient(ref.watch(dioProvider))),
+        ),
+        scopeRepositoryProvider.overrideWith(
+          (ref) => ApiScopeRepository(ScopeClient(ref.watch(dioProvider))),
         ),
         googleSignInGatewayProvider.overrideWithValue(
           PluginGoogleSignInGateway(

--- a/lib/shared/widgets/adaptive_collection.dart
+++ b/lib/shared/widgets/adaptive_collection.dart
@@ -1,0 +1,225 @@
+import 'package:flutter/material.dart';
+
+import '../layout/breakpoints.dart';
+
+/// One column of a collection, and how to read it off an item.
+///
+/// FR-UX-04: a listing declares its columns once, and the same declaration
+/// produces the cards a compact window shows and the table a wider one does.
+class CollectionColumn<T> {
+  const CollectionColumn({
+    required this.label,
+    required this.cell,
+    this.onCard = true,
+  });
+
+  final String label;
+
+  /// What this column shows for [item]. A widget rather than a string so a
+  /// column can be a chip or an icon where that reads better.
+  final Widget Function(T item) cell;
+
+  /// Whether the column also appears on the card. A card with every column is
+  /// a table in disguise, so a listing may keep some columns to the table.
+  final bool onCard;
+}
+
+/// Renders a collection as cards on a compact window and as a table otherwise.
+///
+/// Paging is the API's, so this takes the page it was handed and reports which
+/// page was asked for next; it never slices the list itself.
+class AdaptiveCollection<T> extends StatelessWidget {
+  const AdaptiveCollection({
+    required this.items,
+    required this.columns,
+    required this.title,
+    required this.pageNumber,
+    required this.totalPages,
+    required this.totalItems,
+    required this.onPageChanged,
+    this.subtitle,
+    this.onTap,
+    this.busy = false,
+    this.reservesFloatingAction = false,
+    super.key,
+  });
+
+  final List<T> items;
+  final List<CollectionColumn<T>> columns;
+
+  /// The item's headline, which is the card's title and the table's first cell.
+  final String Function(T item) title;
+  final String Function(T item)? subtitle;
+  final void Function(T item)? onTap;
+
+  final int pageNumber;
+  final int totalPages;
+  final int totalItems;
+  final ValueChanged<int> onPageChanged;
+
+  /// Disables the paging controls while a page is in flight, so a fast tap
+  /// cannot queue two requests.
+  final bool busy;
+
+  /// Whether the screen hosting this collection shows a floating action
+  /// button. Both sit in the bottom-right corner, and the button is drawn over
+  /// the pager — which would leave the next-page control unreachable.
+  final bool reservesFloatingAction;
+
+  @override
+  Widget build(BuildContext context) => Column(
+    crossAxisAlignment: CrossAxisAlignment.stretch,
+    children: <Widget>[
+      Expanded(
+        child: context.breakpoint == Breakpoint.compact
+            ? _cards(context)
+            : _table(context),
+      ),
+      Padding(
+        padding: EdgeInsets.only(bottom: reservesFloatingAction ? 72 : 0),
+        child: _Pager(
+          pageNumber: pageNumber,
+          totalPages: totalPages,
+          totalItems: totalItems,
+          onPageChanged: busy ? null : onPageChanged,
+        ),
+      ),
+    ],
+  );
+
+  Widget _cards(BuildContext context) => ListView.builder(
+    padding: const EdgeInsets.all(12),
+    itemCount: items.length,
+    itemBuilder: (context, index) {
+      final item = items[index];
+      final onCard = columns.where((column) => column.onCard);
+
+      return Card(
+        margin: const EdgeInsets.only(bottom: 8),
+        child: InkWell(
+          onTap: onTap == null ? null : () => onTap!(item),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  title(item),
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                if (subtitle case final String Function(T) read) ...<Widget>[
+                  const SizedBox(height: 4),
+                  Text(
+                    read(item),
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
+                ],
+                for (final column in onCard) ...<Widget>[
+                  const SizedBox(height: 8),
+                  Row(
+                    children: <Widget>[
+                      Text(
+                        '${column.label}: ',
+                        style: Theme.of(context).textTheme.labelMedium,
+                      ),
+                      Flexible(child: column.cell(item)),
+                    ],
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      );
+    },
+  );
+
+  Widget _table(BuildContext context) => SingleChildScrollView(
+    padding: const EdgeInsets.all(12),
+    child: SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: DataTable(
+        showCheckboxColumn: false,
+        columns: <DataColumn>[
+          const DataColumn(label: Text('Name')),
+          for (final column in columns) DataColumn(label: Text(column.label)),
+        ],
+        rows: <DataRow>[
+          for (final item in items)
+            DataRow(
+              onSelectChanged: onTap == null ? null : (_) => onTap!(item),
+              cells: <DataCell>[
+                DataCell(
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: <Widget>[
+                      Text(title(item)),
+                      if (subtitle case final String Function(T) read)
+                        Text(
+                          read(item),
+                          style: Theme.of(context).textTheme.bodySmall,
+                        ),
+                    ],
+                  ),
+                ),
+                for (final column in columns) DataCell(column.cell(item)),
+              ],
+            ),
+        ],
+      ),
+    ),
+  );
+}
+
+/// The page controls, which say where the user is as well as moving them.
+class _Pager extends StatelessWidget {
+  const _Pager({
+    required this.pageNumber,
+    required this.totalPages,
+    required this.totalItems,
+    required this.onPageChanged,
+  });
+
+  final int pageNumber;
+  final int totalPages;
+  final int totalItems;
+
+  /// `null` while a page is in flight, which disables both controls.
+  final ValueChanged<int>? onPageChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final change = onPageChanged;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      // A Wrap rather than a Row: on a narrow window the counts and the
+      // controls do not fit on one line, and an overflowing pager hides the
+      // control that moves the user off the page.
+      child: Wrap(
+        alignment: WrapAlignment.end,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        spacing: 16,
+        children: <Widget>[
+          Text('$totalItems in total'),
+          Text('Page $pageNumber of $totalPages'),
+          IconButton(
+            tooltip: 'Previous page',
+            icon: const Icon(Icons.chevron_left),
+            onPressed: (change == null || pageNumber <= 1)
+                ? null
+                : () => change(pageNumber - 1),
+          ),
+          IconButton(
+            tooltip: 'Next page',
+            icon: const Icon(Icons.chevron_right),
+            onPressed: (change == null || pageNumber >= totalPages)
+                ? null
+                : () => change(pageNumber + 1),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/shared/widgets/collection_states.dart
+++ b/lib/shared/widgets/collection_states.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+
+import '../../core/result/result.dart';
+import 'failure_banner.dart';
+
+/// The placeholder a listing shows while its first page loads.
+///
+/// FR-UX-04's AF-10e: it occupies the same space the list will, so arriving
+/// rows do not shift the layout under the user's pointer.
+class CollectionLoading extends StatelessWidget {
+  const CollectionLoading({this.rows = 6, super.key});
+
+  final int rows;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = Theme.of(context).colorScheme.surfaceContainerHighest;
+
+    return ListView.builder(
+      padding: const EdgeInsets.all(12),
+      itemCount: rows,
+      itemBuilder: (context, index) => Container(
+        height: 72,
+        margin: const EdgeInsets.only(bottom: 8),
+        decoration: BoxDecoration(
+          color: color,
+          borderRadius: BorderRadius.circular(12),
+        ),
+      ),
+    );
+  }
+}
+
+/// What a listing shows when it has nothing to show.
+///
+/// FR-UX-06: "nothing here yet" and "nothing matched your filter" are different
+/// situations with different next actions, so the caller says which this is.
+class CollectionEmpty extends StatelessWidget {
+  const CollectionEmpty({
+    required this.title,
+    required this.message,
+    this.icon = Icons.inbox_outlined,
+    this.actionLabel,
+    this.onAction,
+    super.key,
+  });
+
+  final String title;
+  final String message;
+  final IconData icon;
+  final String? actionLabel;
+  final VoidCallback? onAction;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 420),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Icon(icon, size: 48, color: theme.colorScheme.outline),
+              const SizedBox(height: 16),
+              Text(
+                title,
+                style: theme.textTheme.titleLarge,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                message,
+                style: theme.textTheme.bodyMedium,
+                textAlign: TextAlign.center,
+              ),
+              if (actionLabel case final String label) ...<Widget>[
+                const SizedBox(height: 24),
+                FilledButton(onPressed: onAction, child: Text(label)),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// What a listing shows when the request failed.
+///
+/// FR-UX-07: the filters that produced the request are untouched, so the retry
+/// asks the same question again rather than a fresh one.
+class CollectionFailed extends StatelessWidget {
+  const CollectionFailed({
+    required this.failure,
+    required this.onRetry,
+    super.key,
+  });
+
+  final Failure failure;
+
+  /// `null` while a retry is already in flight.
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) => Center(
+    child: Padding(
+      padding: const EdgeInsets.all(24),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 480),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            if (failure.kind == FailureKind.network)
+              RetryBanner(onRetry: onRetry)
+            else ...<Widget>[
+              ErrorBanner(failure: failure),
+              const SizedBox(height: 16),
+              FilledButton(onPressed: onRetry, child: const Text('Retry')),
+            ],
+          ],
+        ),
+      ),
+    ),
+  );
+}

--- a/test/features/scopes/data/scope_repository_impl_test.dart
+++ b/test/features/scopes/data/scope_repository_impl_test.dart
@@ -1,0 +1,214 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdall_api_client/export.dart';
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/features/scopes/data/scope_repository_impl.dart';
+
+void main() {
+  late Dio dio;
+  late _StubAdapter adapter;
+
+  ApiScopeRepository repositoryAnswering(_Answer answer) {
+    adapter = _StubAdapter(answer);
+    dio.httpClientAdapter = adapter;
+
+    return ApiScopeRepository(ScopeClient(dio));
+  }
+
+  const onePage = _Answer(
+    status: 200,
+    body: <String, dynamic>{
+      'success': true,
+      'errors': <String>[],
+      'data': <Map<String, dynamic>>[
+        <String, dynamic>{
+          'id': 'scope-1',
+          'name': 'Acme',
+          'description': 'The first tenant',
+          'googleSignInEnabled': true,
+          'isDeleted': false,
+          'ownerIds': <String>['person-1', 'person-2'],
+        },
+      ],
+      'pageNumber': 2,
+      'pageSize': 20,
+      'totalItems': 41,
+      'totalPages': 3,
+    },
+  );
+
+  setUp(() {
+    dio = Dio(BaseOptions(baseUrl: 'https://example.invalid'));
+  });
+
+  test('GivenAPageOfScopes_WhenListed_ThenTheItemsAreReturned', () async {
+    // Given
+    final repository = repositoryAnswering(onePage);
+
+    // When
+    final result = await repository.list();
+
+    // Then
+    expect(result.valueOrNull?.items.single.name, 'Acme');
+    expect(result.valueOrNull?.items.single.ownerCount, 2);
+  });
+
+  test('GivenAPageOfScopes_WhenListed_ThenThePagingIsReturned', () async {
+    // Given
+    final repository = repositoryAnswering(onePage);
+
+    // When
+    final result = await repository.list();
+
+    // Then
+    expect(result.valueOrNull?.pageNumber, 2);
+    expect(result.valueOrNull?.totalPages, 3);
+    expect(result.valueOrNull?.hasNextPage, isTrue);
+  });
+
+  test('GivenAName_WhenListed_ThenItTravelsAsAQueryParameter', () async {
+    // Given
+    final repository = repositoryAnswering(onePage);
+
+    // When
+    await repository.list(name: 'Acme', includeDeleted: true, pageNumber: 3);
+
+    // Then
+    expect(adapter.queries.single, containsPair('Name', 'Acme'));
+    expect(adapter.queries.single, containsPair('IncludeDeleted', true));
+    expect(adapter.queries.single, containsPair('PageNumber', 3));
+  });
+
+  // An empty search is no search: sending it would ask the API to match the
+  // empty string rather than to stop filtering.
+  test('GivenABlankName_WhenListed_ThenNoNameIsSent', () async {
+    // Given
+    final repository = repositoryAnswering(onePage);
+
+    // When
+    await repository.list(name: '   ');
+
+    // Then
+    expect(adapter.queries.single.containsKey('Name'), isFalse);
+  });
+
+  test('GivenAnEmptyPage_WhenListed_ThenNoItemsAreReturned', () async {
+    // Given
+    final repository = repositoryAnswering(
+      const _Answer(
+        status: 200,
+        body: <String, dynamic>{
+          'success': true,
+          'errors': <String>[],
+          'data': <Map<String, dynamic>>[],
+          'pageNumber': 1,
+          'totalItems': 0,
+          'totalPages': 1,
+        },
+      ),
+    );
+
+    // When
+    final result = await repository.list();
+
+    // Then
+    expect(result.valueOrNull?.items, isEmpty);
+  });
+
+  // AF-10b — the API refused, and its own strings are what the screen shows.
+  test('GivenARefusedListing_WhenListed_ThenApiErrorsAreReturned', () async {
+    // Given
+    final repository = repositoryAnswering(
+      const _Answer(
+        status: 200,
+        body: <String, dynamic>{
+          'success': false,
+          'errors': <String>['Page size is too large.'],
+        },
+      ),
+    );
+
+    // When
+    final result = await repository.list();
+
+    // Then
+    expect(result.failureOrNull?.errors, <String>['Page size is too large.']);
+  });
+
+  // AF-10b — a transport failure keeps its own kind, which is what offers the
+  // retry rather than an error panel with nothing in it.
+  test('GivenNoConnection_WhenListed_ThenNetworkFailureIsReturned', () async {
+    // Given
+    final repository = repositoryAnswering(const _Answer(status: 0));
+
+    // When
+    final result = await repository.list();
+
+    // Then
+    expect(result.failureOrNull?.kind, FailureKind.network);
+  });
+
+  test('GivenAForbiddenListing_WhenListed_ThenForbiddenIsReturned', () async {
+    // Given
+    final repository = repositoryAnswering(
+      const _Answer(
+        status: 403,
+        body: <String, dynamic>{'success': false, 'errors': <String>[]},
+      ),
+    );
+
+    // When
+    final result = await repository.list();
+
+    // Then
+    expect(result.failureOrNull?.kind, FailureKind.forbidden);
+  });
+}
+
+class _Answer {
+  const _Answer({required this.status, this.body});
+
+  final int status;
+  final Map<String, dynamic>? body;
+}
+
+/// Answers from memory, so no test reaches the network.
+class _StubAdapter implements HttpClientAdapter {
+  _StubAdapter(this._answer);
+
+  final _Answer _answer;
+
+  /// The query parameters it was asked for, so a test can assert which filters
+  /// actually travelled.
+  final List<Map<String, dynamic>> queries = <Map<String, dynamic>>[];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    queries.add(options.queryParameters);
+
+    if (_answer.status == 0) {
+      throw DioException.connectionError(
+        requestOptions: options,
+        reason: 'No route to host',
+      );
+    }
+
+    return ResponseBody.fromString(
+      jsonEncode(_answer.body),
+      _answer.status,
+      headers: <String, List<String>>{
+        Headers.contentTypeHeader: <String>[Headers.jsonContentType],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}

--- a/test/features/scopes/presentation/scope_list_controller_test.dart
+++ b/test/features/scopes/presentation/scope_list_controller_test.dart
@@ -1,0 +1,286 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdall_ui/core/network/envelope.dart';
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/features/scopes/domain/scope.dart';
+import 'package:heimdall_ui/features/scopes/domain/scope_repository.dart';
+import 'package:heimdall_ui/features/scopes/presentation/scope_list_controller.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockScopeRepository extends Mock implements ScopeRepository {}
+
+const _acme = Scope(id: 'scope-1', name: 'Acme', description: 'First tenant');
+
+Page<Scope> _page({
+  List<Scope> items = const <Scope>[_acme],
+  int pageNumber = 1,
+  int totalPages = 1,
+}) => Page<Scope>(
+  items: items,
+  pageNumber: pageNumber,
+  pageSize: 20,
+  totalItems: items.length,
+  totalPages: totalPages,
+);
+
+void main() {
+  late _MockScopeRepository repository;
+  late ProviderContainer container;
+
+  ScopeListController controllerUnderTest() {
+    container = ProviderContainer(
+      overrides: <Override>[
+        scopeRepositoryProvider.overrideWithValue(repository),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    return container.read(scopeListControllerProvider.notifier);
+  }
+
+  void answerWith(Result<Page<Scope>> result) {
+    when(
+      () => repository.list(
+        name: any(named: 'name'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  setUp(() {
+    repository = _MockScopeRepository();
+  });
+
+  test('GivenAPage_WhenLoaded_ThenStateIsLoaded', () async {
+    // Given
+    answerWith(Success<Page<Scope>>(_page()));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    final state = container.read(scopeListControllerProvider);
+    expect((state as ScopeListLoaded).page.items.single.name, 'Acme');
+  });
+
+  // AF-10e — nothing has arrived yet, so the placeholder is what shows.
+  test('GivenNothingLoaded_WhenBuilt_ThenStateIsLoading', () async {
+    // Given
+    answerWith(Success<Page<Scope>>(_page()));
+
+    // When
+    controllerUnderTest();
+
+    // Then
+    expect(
+      container.read(scopeListControllerProvider),
+      isA<ScopeListLoading>(),
+    );
+  });
+
+  test('GivenASearch_WhenSubmitted_ThenTheNameIsSent', () async {
+    // Given
+    answerWith(Success<Page<Scope>>(_page()));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.search('Acme');
+
+    // Then
+    verify(
+      () => repository.list(name: 'Acme', includeDeleted: false, pageNumber: 1),
+    ).called(1);
+  });
+
+  // AF-10d — a new search starts at the first page.
+  test('GivenAPageOtherThanTheFirst_WhenSearched_ThenPagingResets', () async {
+    // Given
+    answerWith(Success<Page<Scope>>(_page(pageNumber: 3, totalPages: 5)));
+    final controller = controllerUnderTest();
+    await controller.load();
+    await controller.goToPage(3);
+
+    // When
+    await controller.search('Acme');
+
+    // Then
+    expect(container.read(scopeListControllerProvider).query.pageNumber, 1);
+  });
+
+  // AF-10d — as does changing what is included.
+  test(
+    'GivenAPageOtherThanTheFirst_WhenIncludeDeletedToggled_ThenPagingResets',
+    () async {
+      // Given
+      answerWith(Success<Page<Scope>>(_page(pageNumber: 3, totalPages: 5)));
+      final controller = controllerUnderTest();
+      await controller.load();
+      await controller.goToPage(3);
+
+      // When
+      await controller.setIncludeDeleted(true);
+
+      // Then
+      expect(container.read(scopeListControllerProvider).query.pageNumber, 1);
+    },
+  );
+
+  test('GivenIncludeDeleted_WhenToggled_ThenTheFlagIsSent', () async {
+    // Given
+    answerWith(Success<Page<Scope>>(_page()));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.setIncludeDeleted(true);
+
+    // Then
+    verify(
+      () => repository.list(name: '', includeDeleted: true, pageNumber: 1),
+    ).called(1);
+  });
+
+  test('GivenAPageChange_WhenRequested_ThenThatPageIsRead', () async {
+    // Given
+    answerWith(Success<Page<Scope>>(_page(totalPages: 4)));
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.goToPage(2);
+
+    // Then
+    verify(
+      () => repository.list(name: '', includeDeleted: false, pageNumber: 2),
+    ).called(1);
+  });
+
+  // AF-10b — the query that failed is kept, so the retry asks it again.
+  test('GivenAFailedRequest_WhenLoaded_ThenTheFiltersSurvive', () async {
+    // Given
+    when(
+      () => repository.list(
+        name: any(named: 'name'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer(
+      (_) async => const FailureResult<Page<Scope>>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.search('Acme');
+
+    // Then
+    final state = container.read(scopeListControllerProvider);
+    expect(state, isA<ScopeListFailed>());
+    expect(state.query.name, 'Acme');
+  });
+
+  test('GivenARefusedListing_WhenLoaded_ThenApiErrorsAreKept', () async {
+    // Given
+    answerWith(
+      const FailureResult<Page<Scope>>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['Page size is too large.'],
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    final state = container.read(scopeListControllerProvider);
+    expect((state as ScopeListFailed).failure.errors, <String>[
+      'Page size is too large.',
+    ]);
+  });
+
+  // AF-10a — a filtered listing knows it is filtered, which is what tells "no
+  // matches" from "nothing here yet".
+  test('GivenASearch_WhenApplied_ThenTheQueryIsFiltered', () async {
+    // Given
+    answerWith(Success<Page<Scope>>(_page(items: const <Scope>[])));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.search('nothing');
+
+    // Then
+    expect(
+      container.read(scopeListControllerProvider).query.isFiltered,
+      isTrue,
+    );
+  });
+
+  test('GivenNoFilters_WhenLoaded_ThenTheQueryIsUnfiltered', () async {
+    // Given
+    answerWith(Success<Page<Scope>>(_page(items: const <Scope>[])));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    expect(
+      container.read(scopeListControllerProvider).query.isFiltered,
+      isFalse,
+    );
+  });
+
+  test('GivenFilters_WhenCleared_ThenTheFullListingIsRead', () async {
+    // Given
+    answerWith(Success<Page<Scope>>(_page()));
+    final controller = controllerUnderTest();
+    await controller.search('Acme');
+
+    // When
+    await controller.clearFilters();
+
+    // Then
+    verify(
+      () => repository.list(name: '', includeDeleted: false, pageNumber: 1),
+    ).called(1);
+  });
+
+  test('GivenARequestInFlight_WhenAskedAgain_ThenOnlyOneIsSent', () async {
+    // Given
+    final pending = Completer<Result<Page<Scope>>>();
+    when(
+      () => repository.list(
+        name: any(named: 'name'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer((_) => pending.future);
+    final controller = controllerUnderTest();
+
+    // When
+    final first = controller.goToPage(2);
+    final second = controller.goToPage(3);
+    pending.complete(Success<Page<Scope>>(_page()));
+    await Future.wait<void>(<Future<void>>[first, second]);
+
+    // Then
+    verify(
+      () => repository.list(
+        name: any(named: 'name'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).called(1);
+  });
+}

--- a/test/features/scopes/presentation/scope_list_screen_test.dart
+++ b/test/features/scopes/presentation/scope_list_screen_test.dart
@@ -1,0 +1,440 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:heimdall_ui/app/theme.dart';
+import 'package:heimdall_ui/core/network/envelope.dart' as envelope;
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/core/storage/token_store.dart';
+import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
+import 'package:heimdall_ui/features/scopes/domain/scope.dart';
+import 'package:heimdall_ui/features/scopes/domain/scope_repository.dart';
+import 'package:heimdall_ui/features/scopes/presentation/scope_list_controller.dart';
+import 'package:heimdall_ui/features/scopes/presentation/scope_list_screen.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockScopeRepository extends Mock implements ScopeRepository {}
+
+/// A token naming a person of [role]: 1 System Admin, 2 Scope Admin.
+String _jwt({int role = 1}) {
+  final payload = base64Url.encode(
+    utf8.encode(
+      jsonEncode(<String, dynamic>{
+        'sub': 'person-1',
+        'email': 'admin@example.com',
+        'role': role,
+      }),
+    ),
+  );
+
+  return 'header.$payload.signature';
+}
+
+const _acme = Scope(
+  id: 'scope-1',
+  name: 'Acme',
+  description: 'The first tenant',
+  googleSignInEnabled: true,
+  ownerIds: <String>['person-1', 'person-2'],
+);
+
+envelope.Page<Scope> _page({
+  List<Scope> items = const <Scope>[_acme],
+  int pageNumber = 1,
+  int totalPages = 1,
+}) => envelope.Page<Scope>(
+  items: items,
+  pageNumber: pageNumber,
+  pageSize: 20,
+  totalItems: items.length,
+  totalPages: totalPages,
+);
+
+const Size _compact = Size(400, 900);
+const Size _medium = Size(800, 900);
+const Size _expanded = Size(1400, 900);
+
+void main() {
+  late _MockScopeRepository repository;
+  late InMemoryTokenStore store;
+  late ProviderContainer container;
+  late GoRouter router;
+
+  Future<void> pump(
+    WidgetTester tester, {
+    Size size = _expanded,
+    ThemeData? theme,
+    int role = 1,
+  }) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await store.write(
+      AuthToken(
+        value: _jwt(role: role),
+        expiresAt: DateTime.utc(2030),
+      ),
+    );
+
+    container = ProviderContainer(
+      overrides: <Override>[
+        scopeRepositoryProvider.overrideWithValue(repository),
+        tokenStoreProvider.overrideWithValue(store),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(sessionControllerProvider.notifier).restore();
+
+    router = GoRouter(
+      initialLocation: '/scopes',
+      routes: <RouteBase>[
+        GoRoute(
+          path: '/scopes',
+          builder: (context, state) => const ScopeListScreen(),
+        ),
+        GoRoute(
+          path: '/scopes/new',
+          builder: (context, state) => const Scaffold(body: Text('create')),
+        ),
+        GoRoute(
+          path: '/scopes/:id',
+          builder: (context, state) =>
+              Scaffold(body: Text('detail ${state.pathParameters['id']}')),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(
+          theme: theme ?? buildLightTheme(),
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  void answerWith(Result<envelope.Page<Scope>> result) {
+    when(
+      () => repository.list(
+        name: any(named: 'name'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    repository = _MockScopeRepository();
+    store = InMemoryTokenStore();
+  });
+
+  testWidgets('GivenAPageOfScopes_WhenOpened_ThenTheScopesAreListed', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Scope>>(_page()));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Acme'), findsOneWidget);
+  });
+
+  // FR-UX-04 — a table when the window is wide.
+  testWidgets('GivenAnExpandedWindow_WhenListed_ThenATableIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Scope>>(_page()));
+
+    // When
+    await pump(tester, size: _expanded);
+
+    // Then
+    expect(find.byType(DataTable), findsOneWidget);
+  });
+
+  testWidgets('GivenAMediumWindow_WhenListed_ThenATableIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Scope>>(_page()));
+
+    // When
+    await pump(tester, size: _medium);
+
+    // Then
+    expect(find.byType(DataTable), findsOneWidget);
+  });
+
+  // FR-UX-04 — cards when it is not.
+  testWidgets('GivenACompactWindow_WhenListed_ThenCardsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Scope>>(_page()));
+
+    // When
+    await pump(tester, size: _compact);
+
+    // Then
+    expect(find.byType(DataTable), findsNothing);
+    expect(find.byType(Card), findsOneWidget);
+  });
+
+  testWidgets('GivenAScope_WhenTapped_ThenItsDetailOpens', (tester) async {
+    // Given
+    answerWith(Success<envelope.Page<Scope>>(_page()));
+    await pump(tester, size: _compact);
+
+    // When
+    await tester.tap(find.text('Acme'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('detail scope-1'), findsOneWidget);
+  });
+
+  // AF-10a — nothing here yet, which offers UI-11.
+  testWidgets('GivenNoScopesAndNoFilter_WhenListed_ThenCreateIsOffered', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Scope>>(_page(items: const <Scope>[])));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('No scopes yet'), findsOneWidget);
+  });
+
+  // AF-10a — no matches, which offers to clear the filter.
+  testWidgets('GivenNoMatches_WhenSearched_ThenClearingIsOffered', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Scope>>(_page(items: const <Scope>[])));
+    await pump(tester);
+
+    // When
+    await tester.enterText(find.byType(TextField), 'nothing');
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('No scopes matched'), findsOneWidget);
+  });
+
+  testWidgets('GivenNoMatches_WhenFiltersCleared_ThenTheFullListingIsRead', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Scope>>(_page(items: const <Scope>[])));
+    await pump(tester);
+    await tester.enterText(find.byType(TextField), 'nothing');
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Clear filters'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => repository.list(name: '', includeDeleted: false, pageNumber: 1),
+    ).called(greaterThanOrEqualTo(1));
+  });
+
+  // AF-10b — the returned errors, with a retry that keeps the filters.
+  testWidgets('GivenARefusedListing_WhenOpened_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(
+      const FailureResult<envelope.Page<Scope>>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['Page size is too large.'],
+        ),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Page size is too large.'), findsOneWidget);
+  });
+
+  testWidgets('GivenATransportFailure_WhenOpened_ThenARetryIsOffered', (
+    tester,
+  ) async {
+    // Given
+    answerWith(
+      const FailureResult<envelope.Page<Scope>>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.widgetWithText(TextButton, 'Retry'), findsOneWidget);
+  });
+
+  testWidgets('GivenAFailedSearch_WhenRetried_ThenTheSameQueryIsSent', (
+    tester,
+  ) async {
+    // Given
+    answerWith(
+      const FailureResult<envelope.Page<Scope>>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
+    await pump(tester);
+    await tester.enterText(find.byType(TextField), 'Acme');
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(find.widgetWithText(TextButton, 'Retry'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => repository.list(name: 'Acme', includeDeleted: false, pageNumber: 1),
+    ).called(2);
+  });
+
+  // AF-10c — only a System Admin may create a scope.
+  testWidgets('GivenASystemAdmin_WhenListed_ThenCreateIsOffered', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Scope>>(_page()));
+
+    // When
+    await pump(tester, role: 1);
+
+    // Then
+    expect(
+      find.widgetWithText(FloatingActionButton, 'New scope'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('GivenAScopeAdmin_WhenListed_ThenCreateIsHidden', (tester) async {
+    // Given
+    answerWith(Success<envelope.Page<Scope>>(_page()));
+
+    // When
+    await pump(tester, role: 2);
+
+    // Then
+    expect(
+      find.widgetWithText(FloatingActionButton, 'New scope'),
+      findsNothing,
+    );
+  });
+
+  testWidgets('GivenAScopeAdminAndNoScopes_WhenListed_ThenCreateIsNotOffered', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Scope>>(_page(items: const <Scope>[])));
+
+    // When
+    await pump(tester, role: 2);
+
+    // Then
+    expect(find.widgetWithText(FilledButton, 'New scope'), findsNothing);
+  });
+
+  testWidgets('GivenIncludeDeleted_WhenToggled_ThenTheFlagIsSent', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Scope>>(_page()));
+    await pump(tester);
+
+    // When
+    await tester.tap(find.byType(Switch));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => repository.list(name: '', includeDeleted: true, pageNumber: 1),
+    ).called(1);
+  });
+
+  testWidgets('GivenSeveralPages_WhenNextTapped_ThenTheNextPageIsRead', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Scope>>(_page(totalPages: 3)));
+    await pump(tester);
+
+    // When
+    await tester.tap(
+      find.ancestor(
+        of: find.byIcon(Icons.chevron_right),
+        matching: find.byType(IconButton),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => repository.list(name: '', includeDeleted: false, pageNumber: 2),
+    ).called(1);
+  });
+
+  testWidgets('GivenTheFirstPage_WhenRendered_ThenPreviousIsDisabled', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Scope>>(_page(totalPages: 3)));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(
+      tester
+          .widget<IconButton>(
+            find.ancestor(
+              of: find.byIcon(Icons.chevron_left),
+              matching: find.byType(IconButton),
+            ),
+          )
+          .onPressed,
+      isNull,
+    );
+  });
+
+  testWidgets('GivenTheDarkTheme_WhenListed_ThenTheScopesAreStillShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Scope>>(_page()));
+
+    // When
+    await pump(tester, theme: buildDarkTheme());
+
+    // Then
+    expect(find.text('Acme'), findsOneWidget);
+  });
+}

--- a/test/shared/widgets/adaptive_collection_test.dart
+++ b/test/shared/widgets/adaptive_collection_test.dart
@@ -1,0 +1,234 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdall_ui/app/theme.dart';
+import 'package:heimdall_ui/shared/widgets/adaptive_collection.dart';
+
+/// A minimal item, so the widget's own behavior is what is under test rather
+/// than any one feature's entity.
+class _Row {
+  const _Row(this.name, this.state);
+
+  final String name;
+  final String state;
+}
+
+const List<_Row> _rows = <_Row>[
+  _Row('Acme', 'Active'),
+  _Row('Globex', 'Deleted'),
+];
+
+void main() {
+  Future<void> pump(
+    WidgetTester tester, {
+    required Size size,
+    List<_Row> items = _rows,
+    int pageNumber = 1,
+    int totalPages = 1,
+    bool busy = false,
+    bool reservesFloatingAction = false,
+    void Function(_Row item)? onTap,
+    ValueChanged<int>? onPageChanged,
+    ThemeData? theme,
+  }) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme ?? buildLightTheme(),
+        home: Scaffold(
+          body: AdaptiveCollection<_Row>(
+            items: items,
+            busy: busy,
+            reservesFloatingAction: reservesFloatingAction,
+            pageNumber: pageNumber,
+            totalPages: totalPages,
+            totalItems: items.length,
+            onPageChanged: onPageChanged ?? (_) {},
+            onTap: onTap,
+            title: (item) => item.name,
+            subtitle: (item) => 'subtitle',
+            columns: <CollectionColumn<_Row>>[
+              CollectionColumn<_Row>(
+                label: 'State',
+                cell: (item) => Text(item.state),
+              ),
+              CollectionColumn<_Row>(
+                label: 'Table only',
+                onCard: false,
+                cell: (item) => const Text('table-only'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  // FR-UX-04 — one declaration, two renderings.
+  testWidgets('GivenACompactWindow_WhenRendered_ThenCardsAreUsed', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, size: const Size(400, 900));
+
+    // Then
+    expect(find.byType(Card), findsNWidgets(2));
+    expect(find.byType(DataTable), findsNothing);
+  });
+
+  testWidgets('GivenAnExpandedWindow_WhenRendered_ThenATableIsUsed', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, size: const Size(1400, 900));
+
+    // Then
+    expect(find.byType(DataTable), findsOneWidget);
+  });
+
+  testWidgets('GivenATableOnlyColumn_WhenCardsAreUsed_ThenItIsOmitted', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, size: const Size(400, 900));
+
+    // Then
+    expect(find.text('table-only'), findsNothing);
+  });
+
+  testWidgets('GivenATableOnlyColumn_WhenATableIsUsed_ThenItIsShown', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, size: const Size(1400, 900));
+
+    // Then
+    expect(find.text('table-only'), findsNWidgets(2));
+  });
+
+  testWidgets('GivenACard_WhenTapped_ThenTheItemIsReported', (tester) async {
+    // Given
+    _Row? tapped;
+    await pump(
+      tester,
+      size: const Size(400, 900),
+      onTap: (item) => tapped = item,
+    );
+
+    // When
+    await tester.tap(find.text('Globex'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(tapped?.name, 'Globex');
+  });
+
+  testWidgets('GivenTheLastPage_WhenRendered_ThenNextIsDisabled', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(
+      tester,
+      size: const Size(1400, 900),
+      pageNumber: 3,
+      totalPages: 3,
+    );
+
+    // Then
+    expect(
+      tester
+          .widget<IconButton>(
+            find.ancestor(
+              of: find.byIcon(Icons.chevron_right),
+              matching: find.byType(IconButton),
+            ),
+          )
+          .onPressed,
+      isNull,
+    );
+  });
+
+  testWidgets('GivenAPageInFlight_WhenRendered_ThenPagingIsDisabled', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(
+      tester,
+      size: const Size(1400, 900),
+      pageNumber: 2,
+      totalPages: 3,
+      busy: true,
+    );
+
+    // Then
+    expect(
+      tester
+          .widget<IconButton>(
+            find.ancestor(
+              of: find.byIcon(Icons.chevron_right),
+              matching: find.byType(IconButton),
+            ),
+          )
+          .onPressed,
+      isNull,
+    );
+  });
+
+  testWidgets('GivenAMiddlePage_WhenNextTapped_ThenTheNextPageIsReported', (
+    tester,
+  ) async {
+    // Given
+    int? requested;
+    await pump(
+      tester,
+      size: const Size(1400, 900),
+      pageNumber: 2,
+      totalPages: 5,
+      onPageChanged: (page) => requested = page,
+    );
+
+    // When
+    await tester.tap(
+      find.ancestor(
+        of: find.byIcon(Icons.chevron_right),
+        matching: find.byType(IconButton),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(requested, 3);
+  });
+
+  // The pager and a floating action button share the bottom-right corner, and
+  // the button is drawn on top.
+  testWidgets('GivenAFloatingAction_WhenRendered_ThenThePagerIsClearOfIt', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(
+      tester,
+      size: const Size(1400, 900),
+      reservesFloatingAction: true,
+    );
+
+    // Then
+    expect(
+      tester.getBottomRight(find.byIcon(Icons.chevron_right)).dy,
+      lessThan(900 - 72),
+    );
+  });
+
+  testWidgets('GivenTheDarkTheme_WhenRendered_ThenTheItemsAreStillShown', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, size: const Size(1400, 900), theme: buildDarkTheme());
+
+    // Then
+    expect(find.text('Acme'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #10

Implements UI-10 — the scope listing at `/scopes` over `GET /api/scopes` (FR-SC-01, FR-SC-02), with the name filter, the include-deleted flag, and the API's own paging.

## Flows

| Flow | How it is handled |
| --- | --- |
| Main | The page is read on open and rendered; the user searches, toggles deleted, and pages. |
| AF-10a | "No scopes yet" offers UI-11; "No scopes matched" offers to clear the filter. |
| AF-10b | The returned errors, or a retry for a transport failure, with the failing query kept. |
| AF-10c | The create control is shown only to a System Admin. What a Scope Admin is returned is the API's decision. |
| AF-10d | A new search or a changed include-deleted flag returns to page 1. |
| AF-10e | A placeholder holds the list's space while the first page loads. |

## Shared widgets — what UI-16, UI-20, UI-24 and UI-28 build on

- **`AdaptiveCollection`** (FR-UX-04): one column declaration renders cards on a compact window and a `DataTable` otherwise. Columns may opt out of the card, so a card is not a table in disguise.
- **`collection_states.dart`**: the loading placeholder, both empty states of FR-UX-06, and the retryable error panel of FR-UX-07.

## A layout fix

The pager and a floating action button both live in the bottom-right corner, and the button is drawn on top — which made the next-page control unreachable. `AdaptiveCollection` now reserves that space when the hosting screen has a FAB, and a widget test asserts the pager clears it.

## Verification

`dart format --set-exit-if-changed .`, `flutter analyze`, and `flutter test` all pass — **391 tests**, 49 of them new. Unit tests cover the repository over a stubbed adapter and the controller over a fake; widget tests cover the screen and the shared collection at all three breakpoints and under the dark theme. No presentation file imports `package:heimdall_api_client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)