### PR TITLE
feat(ui-11): create a scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ the board is where an item's status changes as it moves.
 | Use case | Status | Issue |
 | --- | --- | --- |
 | UI-10: Browse and search scopes | ✅ | [#10](https://github.com/artur-rios/heimdall-ui/issues/10) |
-| UI-11: Create a scope | ⬜ | [#11](https://github.com/artur-rios/heimdall-ui/issues/11) |
+| UI-11: Create a scope | ✅ | [#11](https://github.com/artur-rios/heimdall-ui/issues/11) |
 | UI-12: View and update a scope | ⬜ | [#12](https://github.com/artur-rios/heimdall-ui/issues/12) |
 | UI-13: Delete a scope, logically and permanently | ⬜ | [#13](https://github.com/artur-rios/heimdall-ui/issues/13) |
 | UI-14: Manage scope owners | ⬜ | [#14](https://github.com/artur-rios/heimdall-ui/issues/14) |

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -11,6 +11,7 @@ import '../features/auth/presentation/two_factor_screen.dart';
 import '../features/auth/presentation/verify_email_screen.dart';
 import '../features/home/presentation/home_screen.dart';
 import '../features/profile/presentation/profile_screen.dart';
+import '../features/scopes/presentation/scope_create_screen.dart';
 import '../features/scopes/presentation/scope_list_screen.dart';
 import 'route_access.dart';
 
@@ -118,6 +119,10 @@ final Provider<GoRouter> routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/scopes',
         builder: (context, state) => const ScopeListScreen(),
+      ),
+      GoRoute(
+        path: '/scopes/new',
+        builder: (context, state) => const ScopeCreateScreen(),
       ),
       GoRoute(
         path: '/not-available',

--- a/lib/features/scopes/data/scope_repository_impl.dart
+++ b/lib/features/scopes/data/scope_repository_impl.dart
@@ -60,6 +60,61 @@ class ApiScopeRepository implements ScopeRepository {
       return FailureResult<Page<Scope>>(failureFromDioException(error));
     }
   }
+
+  @override
+  Future<Result<Scope>> create({
+    required String name,
+    required String description,
+    required List<String> ownerIds,
+  }) async {
+    try {
+      final response = await _client.scopeCreate(
+        body: CreateScopeCommand(
+          name: name,
+          description: description,
+          ownerIds: ownerIds,
+        ),
+      );
+
+      if (response.success != true) {
+        // AF-11b and AF-11c: a duplicate name and an owner who is not a Scope
+        // Admin both arrive here, and both are told apart by the API's own
+        // strings rather than by anything this layer decides.
+        return FailureResult<Scope>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: response.errors ?? const <String>[],
+          ),
+        );
+      }
+
+      final data = response.data;
+
+      if (data == null) {
+        return const FailureResult<Scope>(
+          Failure(
+            kind: FailureKind.unknown,
+            errors: <String>['The API returned an incomplete response.'],
+          ),
+        );
+      }
+
+      // The create endpoint answers with its own output type, which carries no
+      // `isDeleted`: a scope you just created is not a deleted one.
+      return Success<Scope>(
+        Scope(
+          id: data.id ?? '',
+          name: data.name ?? name,
+          description: data.description ?? description,
+          googleSignInEnabled: data.googleSignInEnabled ?? false,
+          ownerIds: data.ownerIds ?? ownerIds,
+          createdAt: data.createdAt,
+        ),
+      );
+    } on DioException catch (error) {
+      return FailureResult<Scope>(failureFromDioException(error));
+    }
+  }
 }
 
 /// Maps the generated output onto the domain entity.

--- a/lib/features/scopes/domain/scope_repository.dart
+++ b/lib/features/scopes/domain/scope_repository.dart
@@ -18,4 +18,15 @@ abstract interface class ScopeRepository {
     int pageNumber = 1,
     int pageSize = 20,
   });
+
+  /// Creates a scope.
+  ///
+  /// [ownerIds] names the persons who will own it. Whether each is a usable
+  /// Scope Admin is the API's question, not this layer's — AF-11c is what its
+  /// answer looks like when one is not.
+  Future<Result<Scope>> create({
+    required String name,
+    required String description,
+    required List<String> ownerIds,
+  });
 }

--- a/lib/features/scopes/presentation/scope_create_controller.dart
+++ b/lib/features/scopes/presentation/scope_create_controller.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/result/result.dart';
+import '../domain/scope.dart';
+import 'scope_list_controller.dart';
+
+/// How far a create attempt has got.
+sealed class ScopeCreateState {
+  const ScopeCreateState();
+}
+
+/// The form is being filled in.
+final class ScopeCreateEditing extends ScopeCreateState {
+  const ScopeCreateEditing();
+}
+
+/// A request is in flight. The form refuses a second submission in this state,
+/// so a double tap cannot create two scopes.
+final class ScopeCreateSending extends ScopeCreateState {
+  const ScopeCreateSending();
+}
+
+/// The scope exists. The screen opens its detail from here.
+final class ScopeCreated extends ScopeCreateState {
+  const ScopeCreated(this.scope);
+
+  final Scope scope;
+}
+
+/// AF-11b, AF-11c, AF-11e — the API refused, or nothing reached it. The form
+/// keeps everything the user typed either way.
+final class ScopeCreateRejected extends ScopeCreateState {
+  const ScopeCreateRejected(this.failure);
+
+  final Failure failure;
+}
+
+final NotifierProvider<ScopeCreateController, ScopeCreateState>
+scopeCreateControllerProvider =
+    NotifierProvider<ScopeCreateController, ScopeCreateState>(
+      ScopeCreateController.new,
+    );
+
+/// Owns one create attempt from filled in to created.
+class ScopeCreateController extends Notifier<ScopeCreateState> {
+  @override
+  ScopeCreateState build() => const ScopeCreateEditing();
+
+  /// Creates the scope.
+  ///
+  /// The owner list is the API's to judge: whether each identifier names a
+  /// usable Scope Admin is a question only it can answer (AF-11c).
+  Future<void> create({
+    required String name,
+    required String description,
+    required List<String> ownerIds,
+  }) async {
+    if (state is ScopeCreateSending) {
+      return;
+    }
+
+    state = const ScopeCreateSending();
+
+    final result = await ref
+        .read(scopeRepositoryProvider)
+        .create(name: name, description: description, ownerIds: ownerIds);
+
+    state = result.fold(
+      onSuccess: ScopeCreated.new,
+      onFailure: ScopeCreateRejected.new,
+    );
+  }
+
+  /// AF-11e — returns a refused attempt to the form so the same submission can
+  /// be made again against what is already typed.
+  void backToEditing() {
+    if (state is ScopeCreateRejected) {
+      state = const ScopeCreateEditing();
+    }
+  }
+}

--- a/lib/features/scopes/presentation/scope_create_screen.dart
+++ b/lib/features/scopes/presentation/scope_create_screen.dart
@@ -1,0 +1,255 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../core/result/result.dart';
+import '../../../shared/layout/app_shell.dart';
+import '../../../shared/widgets/failure_banner.dart';
+import 'scope_create_controller.dart';
+import 'scope_list_controller.dart';
+
+/// UI-11 — the create-scope form.
+///
+/// Owners are named by their person identifier. The API has no endpoint that
+/// lists the Scope Admins an anonymous new scope could choose from, so the
+/// identifiers are typed and the API judges them (AF-11c).
+class ScopeCreateScreen extends ConsumerStatefulWidget {
+  const ScopeCreateScreen({super.key});
+
+  @override
+  ConsumerState<ScopeCreateScreen> createState() => _ScopeCreateScreenState();
+}
+
+class _ScopeCreateScreenState extends ConsumerState<ScopeCreateScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _name = TextEditingController();
+  final _description = TextEditingController();
+  final _owner = TextEditingController();
+  final List<String> _ownerIds = <String>[];
+
+  @override
+  void dispose() {
+    _name.dispose();
+    _description.dispose();
+    _owner.dispose();
+    super.dispose();
+  }
+
+  /// Whether anything has been entered, which is what AF-11d asks about before
+  /// letting the form go.
+  bool get _isDirty =>
+      _name.text.trim().isNotEmpty ||
+      _description.text.trim().isNotEmpty ||
+      _owner.text.trim().isNotEmpty ||
+      _ownerIds.isNotEmpty;
+
+  void _addOwner() {
+    final id = _owner.text.trim();
+
+    if (id.isEmpty || _ownerIds.contains(id)) {
+      return;
+    }
+
+    setState(() {
+      _ownerIds.add(id);
+      _owner.clear();
+    });
+  }
+
+  Future<void> _submit() async {
+    // AF-11a: an empty name never reaches the API.
+    if (!(_formKey.currentState?.validate() ?? false)) {
+      return;
+    }
+
+    // AF-11a: neither does a scope with nobody to own it. The unadded text in
+    // the owner field counts, so a user who typed one and did not press add is
+    // not told they forgot.
+    _addOwner();
+
+    if (_ownerIds.isEmpty) {
+      setState(() {});
+
+      return;
+    }
+
+    await ref
+        .read(scopeCreateControllerProvider.notifier)
+        .create(
+          name: _name.text.trim(),
+          description: _description.text.trim(),
+          ownerIds: List<String>.unmodifiable(_ownerIds),
+        );
+  }
+
+  /// AF-11d — leaving a modified form asks first.
+  Future<bool> _confirmLeave() async {
+    if (!_isDirty) {
+      return true;
+    }
+
+    final leave = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Discard this scope?'),
+        content: const Text(
+          'What you have entered has not been saved and will be lost.',
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Keep editing'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Discard'),
+          ),
+        ],
+      ),
+    );
+
+    return leave ?? false;
+  }
+
+  Future<void> _cancel() async {
+    if (await _confirmLeave() && mounted) {
+      context.go('/scopes');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final state = ref.watch(scopeCreateControllerProvider);
+    final sending = state is ScopeCreateSending;
+
+    // The new scope's detail is where the flow ends. Listening rather than
+    // reacting in the build keeps the navigation out of a widget build.
+    ref.listen<ScopeCreateState>(scopeCreateControllerProvider, (
+      previous,
+      next,
+    ) {
+      if (next case ScopeCreated(:final scope)) {
+        // The listing behind this form is now stale.
+        ref.read(scopeListControllerProvider.notifier).load();
+        context.go('/scopes/${scope.id}');
+      }
+    });
+
+    return AppShell(
+      currentRoute: '/scopes',
+      title: const Text('New scope'),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 560),
+            child: Form(
+              key: _formKey,
+              onChanged: () => setState(() {}),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  Text('Create a scope', style: theme.textTheme.headlineSmall),
+                  const SizedBox(height: 8),
+                  Text(
+                    'A scope is one tenant. It needs a name and at least one '
+                    'Scope Admin to own it.',
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                  const SizedBox(height: 24),
+                  if (state is ScopeCreateRejected) ...<Widget>[
+                    if (state.failure.kind == FailureKind.network)
+                      // AF-11e: nothing was created, so the same submission is
+                      // worth making again against what is still on screen.
+                      RetryBanner(onRetry: sending ? null : _submit)
+                    else
+                      // AF-11b and AF-11c: the API's own strings, as returned.
+                      ErrorBanner(failure: state.failure),
+                    const SizedBox(height: 16),
+                  ],
+                  TextFormField(
+                    controller: _name,
+                    decoration: const InputDecoration(labelText: 'Name'),
+                    validator: (value) => (value?.trim().isEmpty ?? true)
+                        ? 'Enter a name for the scope.'
+                        : null,
+                  ),
+                  const SizedBox(height: 16),
+                  TextFormField(
+                    controller: _description,
+                    minLines: 2,
+                    maxLines: 4,
+                    decoration: const InputDecoration(labelText: 'Description'),
+                  ),
+                  const SizedBox(height: 24),
+                  Text('Owners', style: theme.textTheme.titleMedium),
+                  const SizedBox(height: 8),
+                  Row(
+                    children: <Widget>[
+                      Expanded(
+                        child: TextField(
+                          controller: _owner,
+                          decoration: const InputDecoration(
+                            labelText: 'Scope Admin identifier',
+                            helperText:
+                                'The person id of an existing Scope '
+                                'Admin.',
+                          ),
+                          onSubmitted: (_) => _addOwner(),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      IconButton.filledTonal(
+                        tooltip: 'Add owner',
+                        icon: const Icon(Icons.add),
+                        onPressed: sending ? null : _addOwner,
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
+                  if (_ownerIds.isEmpty)
+                    Text(
+                      'No owners added yet.',
+                      style: theme.textTheme.bodySmall,
+                    )
+                  else
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      children: <Widget>[
+                        for (final id in _ownerIds)
+                          InputChip(
+                            label: Text(id),
+                            deleteIcon: const Icon(Icons.close),
+                            deleteButtonTooltipMessage: 'Remove owner',
+                            onDeleted: sending
+                                ? null
+                                : () => setState(() => _ownerIds.remove(id)),
+                          ),
+                      ],
+                    ),
+                  const SizedBox(height: 24),
+                  FilledButton(
+                    onPressed: sending ? null : _submit,
+                    child: sending
+                        ? const SizedBox.square(
+                            dimension: 20,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Text('Create scope'),
+                  ),
+                  const SizedBox(height: 8),
+                  TextButton(
+                    onPressed: sending ? null : _cancel,
+                    child: const Text('Cancel'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/scopes/presentation/scope_create_controller_test.dart
+++ b/test/features/scopes/presentation/scope_create_controller_test.dart
@@ -1,0 +1,227 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/features/scopes/domain/scope.dart';
+import 'package:heimdall_ui/features/scopes/domain/scope_repository.dart';
+import 'package:heimdall_ui/features/scopes/presentation/scope_create_controller.dart';
+import 'package:heimdall_ui/features/scopes/presentation/scope_list_controller.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockScopeRepository extends Mock implements ScopeRepository {}
+
+const _created = Scope(
+  id: 'scope-9',
+  name: 'Acme',
+  description: 'The first tenant',
+  ownerIds: <String>['person-1'],
+);
+
+void main() {
+  late _MockScopeRepository repository;
+  late ProviderContainer container;
+
+  ScopeCreateController controllerUnderTest() {
+    container = ProviderContainer(
+      overrides: <Override>[
+        scopeRepositoryProvider.overrideWithValue(repository),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    return container.read(scopeCreateControllerProvider.notifier);
+  }
+
+  void answerWith(Result<Scope> result) {
+    when(
+      () => repository.create(
+        name: any(named: 'name'),
+        description: any(named: 'description'),
+        ownerIds: any(named: 'ownerIds'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  setUp(() {
+    repository = _MockScopeRepository();
+  });
+
+  test('GivenAValidForm_WhenCreated_ThenTheScopeIsReturned', () async {
+    // Given
+    answerWith(const Success<Scope>(_created));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.create(
+      name: 'Acme',
+      description: 'The first tenant',
+      ownerIds: const <String>['person-1'],
+    );
+
+    // Then
+    final state = container.read(scopeCreateControllerProvider);
+    expect((state as ScopeCreated).scope.id, 'scope-9');
+  });
+
+  test('GivenAValidForm_WhenCreated_ThenTheValuesAreSent', () async {
+    // Given
+    answerWith(const Success<Scope>(_created));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.create(
+      name: 'Acme',
+      description: 'The first tenant',
+      ownerIds: const <String>['person-1', 'person-2'],
+    );
+
+    // Then
+    verify(
+      () => repository.create(
+        name: 'Acme',
+        description: 'The first tenant',
+        ownerIds: <String>['person-1', 'person-2'],
+      ),
+    ).called(1);
+  });
+
+  // AF-11b — a duplicate name, reported in the API's own words.
+  test('GivenADuplicateName_WhenCreated_ThenApiErrorsAreKept', () async {
+    // Given
+    answerWith(
+      const FailureResult<Scope>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['A scope with that name already exists.'],
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.create(
+      name: 'Acme',
+      description: '',
+      ownerIds: const <String>['person-1'],
+    );
+
+    // Then
+    final state = container.read(scopeCreateControllerProvider);
+    expect((state as ScopeCreateRejected).failure.errors, <String>[
+      'A scope with that name already exists.',
+    ]);
+  });
+
+  // AF-11c — an owner the API will not accept.
+  test('GivenARejectedOwner_WhenCreated_ThenApiErrorsAreKept', () async {
+    // Given
+    answerWith(
+      const FailureResult<Scope>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['person-9 is not a Scope Admin.'],
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.create(
+      name: 'Acme',
+      description: '',
+      ownerIds: const <String>['person-9'],
+    );
+
+    // Then
+    final state = container.read(scopeCreateControllerProvider);
+    expect((state as ScopeCreateRejected).failure.errors, <String>[
+      'person-9 is not a Scope Admin.',
+    ]);
+  });
+
+  // AF-11e — nothing reached the API.
+  test('GivenATransportFailure_WhenCreated_ThenStateIsRejected', () async {
+    // Given
+    answerWith(
+      const FailureResult<Scope>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.create(
+      name: 'Acme',
+      description: '',
+      ownerIds: const <String>['person-1'],
+    );
+
+    // Then
+    final state = container.read(scopeCreateControllerProvider);
+    expect((state as ScopeCreateRejected).failure.kind, FailureKind.network);
+  });
+
+  test(
+    'GivenARejectedAttempt_WhenReturnedToEditing_ThenStateIsEditing',
+    () async {
+      // Given
+      answerWith(
+        const FailureResult<Scope>(
+          Failure(kind: FailureKind.network, errors: <String>[]),
+        ),
+      );
+      final controller = controllerUnderTest();
+      await controller.create(
+        name: 'Acme',
+        description: '',
+        ownerIds: const <String>['person-1'],
+      );
+
+      // When
+      controller.backToEditing();
+
+      // Then
+      expect(
+        container.read(scopeCreateControllerProvider),
+        isA<ScopeCreateEditing>(),
+      );
+    },
+  );
+
+  test('GivenARequestInFlight_WhenSubmittedAgain_ThenOnlyOneIsSent', () async {
+    // Given
+    final pending = Completer<Result<Scope>>();
+    when(
+      () => repository.create(
+        name: any(named: 'name'),
+        description: any(named: 'description'),
+        ownerIds: any(named: 'ownerIds'),
+      ),
+    ).thenAnswer((_) => pending.future);
+    final controller = controllerUnderTest();
+
+    // When
+    final first = controller.create(
+      name: 'Acme',
+      description: '',
+      ownerIds: const <String>['person-1'],
+    );
+    final second = controller.create(
+      name: 'Acme',
+      description: '',
+      ownerIds: const <String>['person-1'],
+    );
+    pending.complete(const Success<Scope>(_created));
+    await Future.wait<void>(<Future<void>>[first, second]);
+
+    // Then
+    verify(
+      () => repository.create(
+        name: any(named: 'name'),
+        description: any(named: 'description'),
+        ownerIds: any(named: 'ownerIds'),
+      ),
+    ).called(1);
+  });
+}

--- a/test/features/scopes/presentation/scope_create_screen_test.dart
+++ b/test/features/scopes/presentation/scope_create_screen_test.dart
@@ -1,0 +1,454 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:heimdall_ui/app/theme.dart';
+import 'package:heimdall_ui/core/network/envelope.dart' as envelope;
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/core/storage/token_store.dart';
+import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
+import 'package:heimdall_ui/features/scopes/domain/scope.dart';
+import 'package:heimdall_ui/features/scopes/domain/scope_repository.dart';
+import 'package:heimdall_ui/features/scopes/presentation/scope_create_screen.dart';
+import 'package:heimdall_ui/features/scopes/presentation/scope_list_controller.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockScopeRepository extends Mock implements ScopeRepository {}
+
+String _jwt() {
+  final payload = base64Url.encode(
+    utf8.encode(
+      jsonEncode(<String, dynamic>{
+        'sub': 'person-1',
+        'email': 'admin@example.com',
+        'role': 1,
+      }),
+    ),
+  );
+
+  return 'header.$payload.signature';
+}
+
+const _created = Scope(
+  id: 'scope-9',
+  name: 'Acme',
+  description: 'The first tenant',
+  ownerIds: <String>['person-1'],
+);
+
+const Size _compact = Size(400, 900);
+const Size _medium = Size(800, 900);
+const Size _expanded = Size(1400, 900);
+
+void main() {
+  late _MockScopeRepository repository;
+  late InMemoryTokenStore store;
+  late ProviderContainer container;
+  late GoRouter router;
+
+  Future<void> pump(
+    WidgetTester tester, {
+    Size size = _expanded,
+    ThemeData? theme,
+  }) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await store.write(AuthToken(value: _jwt(), expiresAt: DateTime.utc(2030)));
+
+    container = ProviderContainer(
+      overrides: <Override>[
+        scopeRepositoryProvider.overrideWithValue(repository),
+        tokenStoreProvider.overrideWithValue(store),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(sessionControllerProvider.notifier).restore();
+
+    router = GoRouter(
+      initialLocation: '/scopes/new',
+      routes: <RouteBase>[
+        GoRoute(
+          path: '/scopes',
+          builder: (context, state) => const Scaffold(body: Text('listing')),
+        ),
+        GoRoute(
+          path: '/scopes/new',
+          builder: (context, state) => const ScopeCreateScreen(),
+        ),
+        GoRoute(
+          path: '/scopes/:id',
+          builder: (context, state) =>
+              Scaffold(body: Text('detail ${state.pathParameters['id']}')),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(
+          theme: theme ?? buildLightTheme(),
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  void answerCreateWith(Result<Scope> result) {
+    when(
+      () => repository.create(
+        name: any(named: 'name'),
+        description: any(named: 'description'),
+        ownerIds: any(named: 'ownerIds'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  Future<void> fillIn(
+    WidgetTester tester, {
+    String name = 'Acme',
+    String owner = 'person-1',
+  }) async {
+    await tester.enterText(find.widgetWithText(TextFormField, 'Name'), name);
+    await tester.enterText(
+      find.widgetWithText(TextField, 'Scope Admin identifier'),
+      owner,
+    );
+    await tester.pumpAndSettle();
+  }
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    repository = _MockScopeRepository();
+    store = InMemoryTokenStore();
+    when(
+      () => repository.list(
+        name: any(named: 'name'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer(
+      (_) async => const Success<envelope.Page<Scope>>(
+        envelope.Page<Scope>(
+          items: <Scope>[],
+          pageNumber: 1,
+          pageSize: 20,
+          totalItems: 0,
+          totalPages: 1,
+        ),
+      ),
+    );
+  });
+
+  testWidgets('GivenACompleteForm_WhenSubmitted_ThenTheScopeIsCreated', (
+    tester,
+  ) async {
+    // Given
+    answerCreateWith(const Success<Scope>(_created));
+    await pump(tester);
+    await fillIn(tester);
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create scope'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => repository.create(
+        name: 'Acme',
+        description: '',
+        ownerIds: <String>['person-1'],
+      ),
+    ).called(1);
+  });
+
+  testWidgets('GivenACreatedScope_WhenCreated_ThenItsDetailOpens', (
+    tester,
+  ) async {
+    // Given
+    answerCreateWith(const Success<Scope>(_created));
+    await pump(tester);
+    await fillIn(tester);
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create scope'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('detail scope-9'), findsOneWidget);
+  });
+
+  // AF-11a — an empty name never reaches the API.
+  testWidgets('GivenNoName_WhenSubmitted_ThenNoRequestIsMade', (tester) async {
+    // Given
+    answerCreateWith(const Success<Scope>(_created));
+    await pump(tester);
+    await fillIn(tester, name: '');
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create scope'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verifyNever(
+      () => repository.create(
+        name: any(named: 'name'),
+        description: any(named: 'description'),
+        ownerIds: any(named: 'ownerIds'),
+      ),
+    );
+  });
+
+  // AF-11a — nor does a scope with nobody to own it.
+  testWidgets('GivenNoOwner_WhenSubmitted_ThenNoRequestIsMade', (tester) async {
+    // Given
+    answerCreateWith(const Success<Scope>(_created));
+    await pump(tester);
+    await fillIn(tester, owner: '');
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create scope'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verifyNever(
+      () => repository.create(
+        name: any(named: 'name'),
+        description: any(named: 'description'),
+        ownerIds: any(named: 'ownerIds'),
+      ),
+    );
+  });
+
+  testWidgets('GivenNoOwner_WhenSubmitted_ThenTheFormSaysSo', (tester) async {
+    // Given
+    answerCreateWith(const Success<Scope>(_created));
+    await pump(tester);
+    await fillIn(tester, owner: '');
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create scope'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('No owners added yet.'), findsOneWidget);
+  });
+
+  testWidgets('GivenAnOwnerIdentifier_WhenAdded_ThenAChipIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerCreateWith(const Success<Scope>(_created));
+    await pump(tester);
+    await fillIn(tester, owner: 'person-7');
+
+    // When
+    await tester.tap(find.byTooltip('Add owner'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.widgetWithText(InputChip, 'person-7'), findsOneWidget);
+  });
+
+  testWidgets('GivenAnAddedOwner_WhenRemoved_ThenTheChipGoes', (tester) async {
+    // Given
+    answerCreateWith(const Success<Scope>(_created));
+    await pump(tester);
+    await fillIn(tester, owner: 'person-7');
+    await tester.tap(find.byTooltip('Add owner'));
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(find.byTooltip('Remove owner'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.widgetWithText(InputChip, 'person-7'), findsNothing);
+  });
+
+  // AF-11b — the API's own errors, with the form left as it was.
+  testWidgets('GivenADuplicateName_WhenSubmitted_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerCreateWith(
+      const FailureResult<Scope>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['A scope with that name already exists.'],
+        ),
+      ),
+    );
+    await pump(tester);
+    await fillIn(tester);
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create scope'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('A scope with that name already exists.'), findsOneWidget);
+  });
+
+  testWidgets('GivenARejectedCreate_WhenSubmitted_ThenTheInputIsKept', (
+    tester,
+  ) async {
+    // Given
+    answerCreateWith(
+      const FailureResult<Scope>(
+        Failure(kind: FailureKind.validation, errors: <String>['No.']),
+      ),
+    );
+    await pump(tester);
+    await fillIn(tester);
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create scope'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.widgetWithText(TextFormField, 'Acme'), findsOneWidget);
+  });
+
+  // AF-11c — an owner the API will not accept.
+  testWidgets('GivenARejectedOwner_WhenSubmitted_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerCreateWith(
+      const FailureResult<Scope>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['person-1 is not a Scope Admin.'],
+        ),
+      ),
+    );
+    await pump(tester);
+    await fillIn(tester);
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create scope'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('person-1 is not a Scope Admin.'), findsOneWidget);
+  });
+
+  // AF-11e — nothing was created, so the same submission is offered again.
+  testWidgets('GivenATransportFailure_WhenSubmitted_ThenARetryIsOffered', (
+    tester,
+  ) async {
+    // Given
+    answerCreateWith(
+      const FailureResult<Scope>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
+    await pump(tester);
+    await fillIn(tester);
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create scope'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.widgetWithText(TextButton, 'Retry'), findsOneWidget);
+  });
+
+  // AF-11d — leaving a modified form asks first.
+  testWidgets('GivenAModifiedForm_WhenCancelled_ThenConfirmationIsAsked', (
+    tester,
+  ) async {
+    // Given
+    answerCreateWith(const Success<Scope>(_created));
+    await pump(tester);
+    await fillIn(tester);
+
+    // When
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('Discard this scope?'), findsOneWidget);
+  });
+
+  testWidgets('GivenAModifiedForm_WhenDiscardConfirmed_ThenTheListingOpens', (
+    tester,
+  ) async {
+    // Given
+    answerCreateWith(const Success<Scope>(_created));
+    await pump(tester);
+    await fillIn(tester);
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Discard'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('listing'), findsOneWidget);
+  });
+
+  testWidgets('GivenAnUntouchedForm_WhenCancelled_ThenTheListingOpensAtOnce', (
+    tester,
+  ) async {
+    // Given
+    answerCreateWith(const Success<Scope>(_created));
+    await pump(tester);
+
+    // When
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('listing'), findsOneWidget);
+  });
+
+  testWidgets('GivenACompactWindow_WhenRendered_ThenTheFormIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerCreateWith(const Success<Scope>(_created));
+
+    // When
+    await pump(tester, size: _compact);
+
+    // Then
+    expect(find.text('Create a scope'), findsOneWidget);
+  });
+
+  testWidgets('GivenAMediumWindow_WhenRendered_ThenTheFormIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerCreateWith(const Success<Scope>(_created));
+
+    // When
+    await pump(tester, size: _medium);
+
+    // Then
+    expect(find.text('Create a scope'), findsOneWidget);
+  });
+
+  testWidgets('GivenTheDarkTheme_WhenRendered_ThenTheFormIsStillShown', (
+    tester,
+  ) async {
+    // Given
+    answerCreateWith(const Success<Scope>(_created));
+
+    // When
+    await pump(tester, theme: buildDarkTheme());
+
+    // Then
+    expect(find.text('Create a scope'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #11

Implements UI-11 — the create-scope form at `/scopes/new` over `POST /api/scopes` (FR-SC-03), reachable from the listing's create control, which only a System Admin is shown.

## Flows

| Flow | How it is handled |
| --- | --- |
| Main | Name, description, and at least one owner; on success the new scope's detail opens. |
| AF-11a | An empty name, or no owner, blocks submission. |
| AF-11b | A duplicate name comes back as the API's own strings, with the form untouched. |
| AF-11c | An owner the API rejects comes back the same way. |
| AF-11d | Leaving a modified form asks for confirmation first. |
| AF-11e | A transport failure offers a retry of the same submission. |

## A note on owner selection

The specification says the user "selects at least one owner", but the API publishes no endpoint that lists the Scope Admins a not-yet-existing scope could choose among: `GET /api/scopes/{scopeId}/owners` needs the scope, and there is no unscoped person listing. Owners are therefore named by person identifier, entered as chips, and the API judges each one — which is exactly what AF-11c describes happening. If a candidate-listing endpoint is added later, the field becomes a picker without changing anything else.

## Verification

`dart format --set-exit-if-changed .`, `flutter analyze`, and `flutter test` all pass — **415 tests**, 24 of them new. Unit tests cover the controller over a fake repository and the create path of the repository; widget tests cover the form at all three breakpoints and under the dark theme. No presentation file imports `package:heimdall_api_client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)