### PR TITLE
feat(ui-12): view and update a scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ the board is where an item's status changes as it moves.
 | --- | --- | --- |
 | UI-10: Browse and search scopes | ✅ | [#10](https://github.com/artur-rios/heimdall-ui/issues/10) |
 | UI-11: Create a scope | ✅ | [#11](https://github.com/artur-rios/heimdall-ui/issues/11) |
-| UI-12: View and update a scope | ⬜ | [#12](https://github.com/artur-rios/heimdall-ui/issues/12) |
+| UI-12: View and update a scope | ✅ | [#12](https://github.com/artur-rios/heimdall-ui/issues/12) |
 | UI-13: Delete a scope, logically and permanently | ⬜ | [#13](https://github.com/artur-rios/heimdall-ui/issues/13) |
 | UI-14: Manage scope owners | ⬜ | [#14](https://github.com/artur-rios/heimdall-ui/issues/14) |
 | UI-15: Toggle Google Sign-In for a scope | ⬜ | [#15](https://github.com/artur-rios/heimdall-ui/issues/15) |

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -12,6 +12,7 @@ import '../features/auth/presentation/verify_email_screen.dart';
 import '../features/home/presentation/home_screen.dart';
 import '../features/profile/presentation/profile_screen.dart';
 import '../features/scopes/presentation/scope_create_screen.dart';
+import '../features/scopes/presentation/scope_detail_screen.dart';
 import '../features/scopes/presentation/scope_list_screen.dart';
 import 'route_access.dart';
 
@@ -123,6 +124,11 @@ final Provider<GoRouter> routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/scopes/new',
         builder: (context, state) => const ScopeCreateScreen(),
+      ),
+      GoRoute(
+        path: '/scopes/:scopeId',
+        builder: (context, state) =>
+            ScopeDetailScreen(scopeId: state.pathParameters['scopeId']!),
       ),
       GoRoute(
         path: '/not-available',

--- a/lib/features/scopes/data/scope_repository_impl.dart
+++ b/lib/features/scopes/data/scope_repository_impl.dart
@@ -91,12 +91,7 @@ class ApiScopeRepository implements ScopeRepository {
       final data = response.data;
 
       if (data == null) {
-        return const FailureResult<Scope>(
-          Failure(
-            kind: FailureKind.unknown,
-            errors: <String>['The API returned an incomplete response.'],
-          ),
-        );
+        return const FailureResult<Scope>(_incompleteResponse);
       }
 
       // The create endpoint answers with its own output type, which carries no
@@ -115,7 +110,91 @@ class ApiScopeRepository implements ScopeRepository {
       return FailureResult<Scope>(failureFromDioException(error));
     }
   }
+
+  @override
+  Future<Result<Scope>> getById(String id, {bool includeDeleted = true}) async {
+    try {
+      final response = await _client.scopeGetById(
+        id: id,
+        includeDeleted: includeDeleted,
+      );
+
+      if (response.success != true) {
+        return FailureResult<Scope>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: response.errors ?? const <String>[],
+          ),
+        );
+      }
+
+      final data = response.data;
+
+      if (data == null) {
+        return const FailureResult<Scope>(_incompleteResponse);
+      }
+
+      return Success<Scope>(scopeFromOutput(data));
+    } on DioException catch (error) {
+      // AF-12a and AF-12b depend on this: a `404` and a `403` are different
+      // panels, and only the kind tells them apart.
+      return FailureResult<Scope>(failureFromDioException(error));
+    }
+  }
+
+  @override
+  Future<Result<Scope>> update({
+    required String id,
+    required String name,
+    required String description,
+  }) async {
+    try {
+      final response = await _client.scopeUpdate(
+        id: id,
+        body: UpdateScopeCommand(name: name, description: description),
+      );
+
+      if (response.success != true) {
+        // AF-12c: a duplicate name arrives here, in the API's own words.
+        return FailureResult<Scope>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: response.errors ?? const <String>[],
+          ),
+        );
+      }
+
+      final data = response.data;
+
+      if (data == null) {
+        return const FailureResult<Scope>(_incompleteResponse);
+      }
+
+      // The update endpoint answers with its own output type, which carries no
+      // `isDeleted`: a scope the API just updated is not a deleted one.
+      return Success<Scope>(
+        Scope(
+          id: data.id ?? id,
+          name: data.name ?? name,
+          description: data.description ?? description,
+          googleSignInEnabled: data.googleSignInEnabled ?? false,
+          ownerIds: data.ownerIds ?? const <String>[],
+          createdAt: data.createdAt,
+          updatedAt: data.updatedAt,
+        ),
+      );
+    } on DioException catch (error) {
+      return FailureResult<Scope>(failureFromDioException(error));
+    }
+  }
 }
+
+/// A successful envelope that nonetheless lacks what the flow needs. It should
+/// not happen; saying so plainly beats a null dereference if it ever does.
+const Failure _incompleteResponse = Failure(
+  kind: FailureKind.unknown,
+  errors: <String>['The API returned an incomplete response.'],
+);
 
 /// Maps the generated output onto the domain entity.
 Scope scopeFromOutput(ScopeOutput output) => Scope(

--- a/lib/features/scopes/domain/scope_repository.dart
+++ b/lib/features/scopes/domain/scope_repository.dart
@@ -29,4 +29,18 @@ abstract interface class ScopeRepository {
     required String description,
     required List<String> ownerIds,
   });
+
+  /// Reads one scope.
+  ///
+  /// [includeDeleted] is on by default for the detail screen: AF-12d shows a
+  /// logically deleted scope read-only, and it cannot do that if the API is
+  /// asked to pretend the scope is gone.
+  Future<Result<Scope>> getById(String id, {bool includeDeleted = true});
+
+  /// Updates a scope's name and description.
+  Future<Result<Scope>> update({
+    required String id,
+    required String name,
+    required String description,
+  });
 }

--- a/lib/features/scopes/presentation/scope_detail_controller.dart
+++ b/lib/features/scopes/presentation/scope_detail_controller.dart
@@ -1,0 +1,132 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/result/result.dart';
+import '../domain/scope.dart';
+import 'scope_list_controller.dart';
+
+/// How far the scope detail has got.
+sealed class ScopeDetailState {
+  const ScopeDetailState();
+}
+
+/// The record is being read.
+final class ScopeDetailLoading extends ScopeDetailState {
+  const ScopeDetailLoading();
+}
+
+/// AF-12a and AF-12b — the record could not be read.
+///
+/// The [failure]'s kind is what separates "no such scope" from "not yours",
+/// and the screen shows a different panel for each.
+final class ScopeDetailUnavailable extends ScopeDetailState {
+  const ScopeDetailUnavailable(this.failure);
+
+  final Failure failure;
+
+  bool get isNotFound => failure.kind == FailureKind.notFound;
+  bool get isForbidden => failure.kind == FailureKind.forbidden;
+}
+
+/// The record is on screen.
+final class ScopeDetailLoaded extends ScopeDetailState {
+  const ScopeDetailLoaded(
+    this.scope, {
+    this.saving = false,
+    this.saveFailure,
+    this.saved = false,
+  });
+
+  final Scope scope;
+  final bool saving;
+  final Failure? saveFailure;
+  final bool saved;
+
+  /// AF-12d — a logically deleted scope is shown, but nothing about it may be
+  /// changed from here.
+  bool get isReadOnly => scope.isDeleted;
+
+  ScopeDetailLoaded copyWith({
+    Scope? scope,
+    bool? saving,
+    Failure? saveFailure,
+    bool clearSaveFailure = false,
+    bool? saved,
+  }) => ScopeDetailLoaded(
+    scope ?? this.scope,
+    saving: saving ?? this.saving,
+    saveFailure: clearSaveFailure ? null : (saveFailure ?? this.saveFailure),
+    saved: saved ?? this.saved,
+  );
+}
+
+/// Family-keyed on the scope's identifier, so two detail screens opened from
+/// two tabs do not share one state.
+final NotifierProviderFamily<ScopeDetailController, ScopeDetailState, String>
+scopeDetailControllerProvider =
+    NotifierProvider.family<ScopeDetailController, ScopeDetailState, String>(
+      ScopeDetailController.new,
+    );
+
+/// Owns one scope's detail: reading it, and saving edits to it.
+class ScopeDetailController extends FamilyNotifier<ScopeDetailState, String> {
+  @override
+  ScopeDetailState build(String scopeId) => const ScopeDetailLoading();
+
+  /// Reads the scope.
+  ///
+  /// Deleted scopes are included: AF-12d shows one read-only, and it cannot do
+  /// that if the API is asked to pretend it is gone.
+  Future<void> load() async {
+    state = const ScopeDetailLoading();
+
+    final result = await ref.read(scopeRepositoryProvider).getById(arg);
+
+    state = result.fold(
+      onSuccess: ScopeDetailLoaded.new,
+      onFailure: ScopeDetailUnavailable.new,
+    );
+  }
+
+  /// Saves [name] and [description].
+  ///
+  /// AF-12e is enforced by the screen, which keeps the control disabled until
+  /// something differs; the same comparison is repeated here so a submission
+  /// from the keyboard obeys it too.
+  Future<void> save({required String name, required String description}) async {
+    final current = state;
+
+    if (current is! ScopeDetailLoaded || current.saving || current.isReadOnly) {
+      return;
+    }
+
+    if (name == current.scope.name &&
+        description == current.scope.description) {
+      return;
+    }
+
+    state = current.copyWith(
+      saving: true,
+      clearSaveFailure: true,
+      saved: false,
+    );
+
+    final result = await ref
+        .read(scopeRepositoryProvider)
+        .update(id: arg, name: name, description: description);
+
+    state = result.fold(
+      onSuccess: (scope) => ScopeDetailLoaded(scope, saved: true),
+      // AF-12c: the refusal is kept as it came back, and the record on screen
+      // is still the one the API last confirmed.
+      onFailure: (failure) =>
+          current.copyWith(saving: false, saveFailure: failure),
+    );
+  }
+
+  /// Drops the "saved" acknowledgement so a later edit starts clean.
+  void acknowledgeSave() {
+    if (state case final ScopeDetailLoaded loaded) {
+      state = loaded.copyWith(saved: false);
+    }
+  }
+}

--- a/lib/features/scopes/presentation/scope_detail_screen.dart
+++ b/lib/features/scopes/presentation/scope_detail_screen.dart
@@ -1,0 +1,319 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../core/result/result.dart';
+import '../../../shared/layout/app_shell.dart';
+import '../../../shared/widgets/collection_states.dart';
+import '../../../shared/widgets/failure_banner.dart';
+import '../domain/scope.dart';
+import 'scope_detail_controller.dart';
+
+/// UI-12 — one scope: what it is, who owns it, and what it contains.
+class ScopeDetailScreen extends ConsumerStatefulWidget {
+  const ScopeDetailScreen({required this.scopeId, super.key});
+
+  final String scopeId;
+
+  @override
+  ConsumerState<ScopeDetailScreen> createState() => _ScopeDetailScreenState();
+}
+
+class _ScopeDetailScreenState extends ConsumerState<ScopeDetailScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _name = TextEditingController();
+  final _description = TextEditingController();
+
+  /// The record the fields were last seeded from, which is what AF-12e
+  /// compares against to decide whether anything actually differs.
+  Scope? _seeded;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => ref
+          .read(scopeDetailControllerProvider(widget.scopeId).notifier)
+          .load(),
+    );
+  }
+
+  @override
+  void dispose() {
+    _name.dispose();
+    _description.dispose();
+    super.dispose();
+  }
+
+  /// Copies a freshly read or freshly saved record into the fields.
+  ///
+  /// AF-12c is why this only runs when the record itself changed: a refused
+  /// save must leave what the user typed exactly where it was.
+  void _seed(Scope scope) {
+    if (identical(_seeded, scope)) {
+      return;
+    }
+
+    _seeded = scope;
+    _name.text = scope.name;
+    _description.text = scope.description;
+  }
+
+  bool _differsFrom(Scope scope) =>
+      _name.text.trim() != scope.name ||
+      _description.text.trim() != scope.description;
+
+  Future<void> _save() async {
+    if (!(_formKey.currentState?.validate() ?? false)) {
+      return;
+    }
+
+    await ref
+        .read(scopeDetailControllerProvider(widget.scopeId).notifier)
+        .save(name: _name.text.trim(), description: _description.text.trim());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(scopeDetailControllerProvider(widget.scopeId));
+    final controller = ref.read(
+      scopeDetailControllerProvider(widget.scopeId).notifier,
+    );
+
+    return AppShell(
+      currentRoute: '/scopes',
+      title: Text(switch (state) {
+        ScopeDetailLoaded(:final scope) => scope.name,
+        _ => 'Scope',
+      }),
+      body: switch (state) {
+        ScopeDetailLoading() => const Center(
+          child: CircularProgressIndicator(),
+        ),
+        // AF-12a — no such scope.
+        ScopeDetailUnavailable(isNotFound: true) => CollectionEmpty(
+          title: 'Scope not found',
+          message:
+              'There is no scope with that identifier. It may have been '
+              'permanently deleted.',
+          icon: Icons.search_off_outlined,
+          actionLabel: 'Back to scopes',
+          onAction: () => context.go('/scopes'),
+        ),
+        // AF-12b — the API says this scope is not this caller's, which is the
+        // same answer UI-07 gives for a screen a role is not offered.
+        ScopeDetailUnavailable(isForbidden: true) => CollectionEmpty(
+          title: 'Not available for your role',
+          message:
+              'This scope is not one you administer. Nothing is wrong '
+              'with your session.',
+          icon: Icons.lock_person_outlined,
+          actionLabel: 'Back to scopes',
+          onAction: () => context.go('/scopes'),
+        ),
+        ScopeDetailUnavailable(:final failure) => CollectionFailed(
+          failure: failure,
+          onRetry: controller.load,
+        ),
+        final ScopeDetailLoaded loaded => _detail(loaded),
+      },
+    );
+  }
+
+  Widget _detail(ScopeDetailLoaded state) {
+    final theme = Theme.of(context);
+    _seed(state.scope);
+    final scope = state.scope;
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(24),
+      child: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 720),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              // AF-12d — a deleted scope says so before anything else, since
+              // everything below it is read-only because of it.
+              if (state.isReadOnly) ...<Widget>[
+                const _DeletedNotice(),
+                const SizedBox(height: 16),
+              ],
+              Form(
+                key: _formKey,
+                onChanged: () => setState(() {}),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: <Widget>[
+                    if (state.saveFailure
+                        case final Failure failure) ...<Widget>[
+                      if (failure.kind == FailureKind.network)
+                        RetryBanner(onRetry: state.saving ? null : _save)
+                      else
+                        // AF-12c: the API's own strings, as returned.
+                        ErrorBanner(failure: failure),
+                      const SizedBox(height: 16),
+                    ],
+                    if (state.saved) ...<Widget>[
+                      const _SavedNotice(),
+                      const SizedBox(height: 16),
+                    ],
+                    TextFormField(
+                      controller: _name,
+                      readOnly: state.isReadOnly,
+                      decoration: const InputDecoration(labelText: 'Name'),
+                      validator: (value) => (value?.trim().isEmpty ?? true)
+                          ? 'Enter a name for the scope.'
+                          : null,
+                    ),
+                    const SizedBox(height: 16),
+                    TextFormField(
+                      controller: _description,
+                      readOnly: state.isReadOnly,
+                      minLines: 2,
+                      maxLines: 4,
+                      decoration: const InputDecoration(
+                        labelText: 'Description',
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    if (!state.isReadOnly)
+                      FilledButton(
+                        // AF-12e: nothing to save is not an action.
+                        onPressed: (state.saving || !_differsFrom(scope))
+                            ? null
+                            : _save,
+                        child: state.saving
+                            ? const SizedBox.square(
+                                dimension: 20,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
+                              )
+                            : const Text('Save changes'),
+                      ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 24),
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Text('Google Sign-In', style: theme.textTheme.labelLarge),
+                      const SizedBox(height: 4),
+                      Text(scope.googleSignInEnabled ? 'On' : 'Off'),
+                      const SizedBox(height: 16),
+                      Text('Owners', style: theme.textTheme.labelLarge),
+                      const SizedBox(height: 4),
+                      Text(
+                        scope.ownerIds.isEmpty
+                            ? 'No owners recorded.'
+                            : scope.ownerIds.join(', '),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 24),
+              Text('In this scope', style: theme.textTheme.titleMedium),
+              const SizedBox(height: 8),
+              _Links(scopeId: scope.id),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Where the scope's contents live. Each target arrives with its own use case;
+/// until then the router says so rather than throwing.
+class _Links extends StatelessWidget {
+  const _Links({required this.scopeId});
+
+  final String scopeId;
+
+  @override
+  Widget build(BuildContext context) => Card(
+    child: Column(
+      children: <Widget>[
+        for (final link in <({String label, IconData icon, String path})>[
+          (label: 'Owners', icon: Icons.shield_outlined, path: 'owners'),
+          (label: 'Persons', icon: Icons.people_outline, path: 'persons'),
+          (
+            label: 'Applications',
+            icon: Icons.apps_outlined,
+            path: 'applications',
+          ),
+          (label: 'Permissions', icon: Icons.key_outlined, path: 'permissions'),
+          (
+            label: 'Google users',
+            icon: Icons.account_circle_outlined,
+            path: 'google-users',
+          ),
+        ])
+          ListTile(
+            leading: Icon(link.icon),
+            title: Text(link.label),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => context.go('/scopes/$scopeId/${link.path}'),
+          ),
+      ],
+    ),
+  );
+}
+
+/// AF-12d — what a logically deleted scope says about itself.
+class _DeletedNotice extends StatelessWidget {
+  const _DeletedNotice();
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: scheme.errorContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: <Widget>[
+          Icon(Icons.delete_outline, color: scheme.onErrorContainer),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              'This scope is deleted. It is shown for reference and cannot be '
+              'changed from here.',
+              style: TextStyle(color: scheme.onErrorContainer),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SavedNotice extends StatelessWidget {
+  const _SavedNotice();
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: scheme.secondaryContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        'Saved.',
+        style: TextStyle(color: scheme.onSecondaryContainer),
+      ),
+    );
+  }
+}

--- a/test/features/scopes/presentation/scope_detail_controller_test.dart
+++ b/test/features/scopes/presentation/scope_detail_controller_test.dart
@@ -1,0 +1,265 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/features/scopes/domain/scope.dart';
+import 'package:heimdall_ui/features/scopes/domain/scope_repository.dart';
+import 'package:heimdall_ui/features/scopes/presentation/scope_detail_controller.dart';
+import 'package:heimdall_ui/features/scopes/presentation/scope_list_controller.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockScopeRepository extends Mock implements ScopeRepository {}
+
+const _acme = Scope(
+  id: 'scope-1',
+  name: 'Acme',
+  description: 'The first tenant',
+  ownerIds: <String>['person-1'],
+);
+
+const _deleted = Scope(
+  id: 'scope-1',
+  name: 'Acme',
+  description: 'The first tenant',
+  isDeleted: true,
+);
+
+void main() {
+  late _MockScopeRepository repository;
+  late ProviderContainer container;
+
+  ScopeDetailController controllerUnderTest() {
+    container = ProviderContainer(
+      overrides: <Override>[
+        scopeRepositoryProvider.overrideWithValue(repository),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    return container.read(scopeDetailControllerProvider('scope-1').notifier);
+  }
+
+  ScopeDetailState currentState() =>
+      container.read(scopeDetailControllerProvider('scope-1'));
+
+  void answerGetWith(Result<Scope> result) {
+    when(
+      () => repository.getById(
+        any(),
+        includeDeleted: any(named: 'includeDeleted'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  void answerUpdateWith(Result<Scope> result) {
+    when(
+      () => repository.update(
+        id: any(named: 'id'),
+        name: any(named: 'name'),
+        description: any(named: 'description'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  setUp(() {
+    repository = _MockScopeRepository();
+  });
+
+  test('GivenAScope_WhenLoaded_ThenTheRecordIsShown', () async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    expect((currentState() as ScopeDetailLoaded).scope.name, 'Acme');
+  });
+
+  test('GivenAScope_WhenLoaded_ThenTheIdentifierIsRead', () async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    verify(() => repository.getById('scope-1')).called(1);
+  });
+
+  // AF-12a — no such scope.
+  test('GivenAMissingScope_WhenLoaded_ThenStateIsNotFound', () async {
+    // Given
+    answerGetWith(
+      const FailureResult<Scope>(
+        Failure(kind: FailureKind.notFound, errors: <String>[]),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    expect((currentState() as ScopeDetailUnavailable).isNotFound, isTrue);
+  });
+
+  // AF-12b — the scope is not this caller's.
+  test('GivenAForbiddenScope_WhenLoaded_ThenStateIsForbidden', () async {
+    // Given
+    answerGetWith(
+      const FailureResult<Scope>(
+        Failure(kind: FailureKind.forbidden, errors: <String>[]),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    expect((currentState() as ScopeDetailUnavailable).isForbidden, isTrue);
+  });
+
+  test('GivenAChangedName_WhenSaved_ThenTheNewValuesAreSent', () async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    answerUpdateWith(
+      const Success<Scope>(
+        Scope(id: 'scope-1', name: 'Acme Ltd', description: 'The first tenant'),
+      ),
+    );
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.save(name: 'Acme Ltd', description: 'The first tenant');
+
+    // Then
+    verify(
+      () => repository.update(
+        id: 'scope-1',
+        name: 'Acme Ltd',
+        description: 'The first tenant',
+      ),
+    ).called(1);
+  });
+
+  // AF-12c — a refusal keeps the record and carries the API's own errors.
+  test('GivenARejectedUpdate_WhenSaved_ThenApiErrorsAreKept', () async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    answerUpdateWith(
+      const FailureResult<Scope>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['A scope with that name already exists.'],
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.save(name: 'Globex', description: 'The first tenant');
+
+    // Then
+    final state = currentState() as ScopeDetailLoaded;
+    expect(state.saveFailure?.errors, <String>[
+      'A scope with that name already exists.',
+    ]);
+    expect(state.scope.name, 'Acme');
+  });
+
+  // AF-12d — a deleted scope is read-only.
+  test('GivenADeletedScope_WhenLoaded_ThenItIsReadOnly', () async {
+    // Given
+    answerGetWith(const Success<Scope>(_deleted));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    expect((currentState() as ScopeDetailLoaded).isReadOnly, isTrue);
+  });
+
+  test('GivenADeletedScope_WhenSaved_ThenNoRequestIsMade', () async {
+    // Given
+    answerGetWith(const Success<Scope>(_deleted));
+    answerUpdateWith(const Success<Scope>(_deleted));
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.save(name: 'Anything', description: 'Anything');
+
+    // Then
+    verifyNever(
+      () => repository.update(
+        id: any(named: 'id'),
+        name: any(named: 'name'),
+        description: any(named: 'description'),
+      ),
+    );
+  });
+
+  // AF-12e — saving with nothing changed is a no-op.
+  test('GivenNoChange_WhenSaved_ThenNoRequestIsMade', () async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    answerUpdateWith(const Success<Scope>(_acme));
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.save(name: 'Acme', description: 'The first tenant');
+
+    // Then
+    verifyNever(
+      () => repository.update(
+        id: any(named: 'id'),
+        name: any(named: 'name'),
+        description: any(named: 'description'),
+      ),
+    );
+  });
+
+  test('GivenASavedScope_WhenAcknowledged_ThenTheNoticeClears', () async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    answerUpdateWith(
+      const Success<Scope>(
+        Scope(id: 'scope-1', name: 'Acme Ltd', description: 'The first tenant'),
+      ),
+    );
+    final controller = controllerUnderTest();
+    await controller.load();
+    await controller.save(name: 'Acme Ltd', description: 'The first tenant');
+
+    // When
+    controller.acknowledgeSave();
+
+    // Then
+    expect((currentState() as ScopeDetailLoaded).saved, isFalse);
+  });
+
+  test('GivenATransportFailure_WhenLoaded_ThenStateIsUnavailable', () async {
+    // Given
+    answerGetWith(
+      const FailureResult<Scope>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    final state = currentState() as ScopeDetailUnavailable;
+    expect(state.isNotFound, isFalse);
+    expect(state.isForbidden, isFalse);
+  });
+}

--- a/test/features/scopes/presentation/scope_detail_screen_test.dart
+++ b/test/features/scopes/presentation/scope_detail_screen_test.dart
@@ -1,0 +1,434 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:heimdall_ui/app/theme.dart';
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/core/storage/token_store.dart';
+import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
+import 'package:heimdall_ui/features/scopes/domain/scope.dart';
+import 'package:heimdall_ui/features/scopes/domain/scope_repository.dart';
+import 'package:heimdall_ui/features/scopes/presentation/scope_detail_screen.dart';
+import 'package:heimdall_ui/features/scopes/presentation/scope_list_controller.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockScopeRepository extends Mock implements ScopeRepository {}
+
+String _jwt() {
+  final payload = base64Url.encode(
+    utf8.encode(
+      jsonEncode(<String, dynamic>{
+        'sub': 'person-1',
+        'email': 'admin@example.com',
+        'role': 1,
+      }),
+    ),
+  );
+
+  return 'header.$payload.signature';
+}
+
+const _acme = Scope(
+  id: 'scope-1',
+  name: 'Acme',
+  description: 'The first tenant',
+  googleSignInEnabled: true,
+  ownerIds: <String>['person-1'],
+);
+
+const _deleted = Scope(
+  id: 'scope-1',
+  name: 'Acme',
+  description: 'The first tenant',
+  isDeleted: true,
+);
+
+const Size _compact = Size(400, 900);
+const Size _medium = Size(800, 900);
+const Size _expanded = Size(1400, 900);
+
+void main() {
+  late _MockScopeRepository repository;
+  late InMemoryTokenStore store;
+  late ProviderContainer container;
+  late GoRouter router;
+
+  Future<void> pump(
+    WidgetTester tester, {
+    Size size = _expanded,
+    ThemeData? theme,
+  }) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await store.write(AuthToken(value: _jwt(), expiresAt: DateTime.utc(2030)));
+
+    container = ProviderContainer(
+      overrides: <Override>[
+        scopeRepositoryProvider.overrideWithValue(repository),
+        tokenStoreProvider.overrideWithValue(store),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(sessionControllerProvider.notifier).restore();
+
+    router = GoRouter(
+      initialLocation: '/scopes/scope-1',
+      routes: <RouteBase>[
+        GoRoute(
+          path: '/scopes',
+          builder: (context, state) => const Scaffold(body: Text('listing')),
+        ),
+        GoRoute(
+          path: '/scopes/:scopeId',
+          builder: (context, state) =>
+              ScopeDetailScreen(scopeId: state.pathParameters['scopeId']!),
+        ),
+        GoRoute(
+          path: '/scopes/:scopeId/persons',
+          builder: (context, state) => const Scaffold(body: Text('persons')),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(
+          theme: theme ?? buildLightTheme(),
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  void answerGetWith(Result<Scope> result) {
+    when(
+      () => repository.getById(
+        any(),
+        includeDeleted: any(named: 'includeDeleted'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  void answerUpdateWith(Result<Scope> result) {
+    when(
+      () => repository.update(
+        id: any(named: 'id'),
+        name: any(named: 'name'),
+        description: any(named: 'description'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    repository = _MockScopeRepository();
+    store = InMemoryTokenStore();
+  });
+
+  testWidgets('GivenAScope_WhenOpened_ThenTheRecordIsShown', (tester) async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.widgetWithText(TextFormField, 'Acme'), findsOneWidget);
+  });
+
+  testWidgets('GivenAScope_WhenOpened_ThenItsGoogleStateIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('On'), findsOneWidget);
+  });
+
+  testWidgets('GivenAScope_WhenOpened_ThenItsContentsAreLinked', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.widgetWithText(ListTile, 'Persons'), findsOneWidget);
+    expect(find.widgetWithText(ListTile, 'Applications'), findsOneWidget);
+    expect(find.widgetWithText(ListTile, 'Permissions'), findsOneWidget);
+    expect(find.widgetWithText(ListTile, 'Google users'), findsOneWidget);
+  });
+
+  testWidgets('GivenALinkedSection_WhenTapped_ThenItOpens', (tester) async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    await pump(tester);
+
+    // When
+    await tester.tap(find.widgetWithText(ListTile, 'Persons'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('persons'), findsOneWidget);
+  });
+
+  testWidgets('GivenAnEdit_WhenSaved_ThenTheNewValuesAreSent', (tester) async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    answerUpdateWith(
+      const Success<Scope>(
+        Scope(id: 'scope-1', name: 'Acme Ltd', description: 'The first tenant'),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Acme'),
+      'Acme Ltd',
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, 'Save changes'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => repository.update(
+        id: 'scope-1',
+        name: 'Acme Ltd',
+        description: 'The first tenant',
+      ),
+    ).called(1);
+  });
+
+  // AF-12a — no such scope.
+  testWidgets('GivenAMissingScope_WhenOpened_ThenNotFoundIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(
+      const FailureResult<Scope>(
+        Failure(kind: FailureKind.notFound, errors: <String>[]),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Scope not found'), findsOneWidget);
+  });
+
+  testWidgets('GivenAMissingScope_WhenBackTapped_ThenTheListingOpens', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(
+      const FailureResult<Scope>(
+        Failure(kind: FailureKind.notFound, errors: <String>[]),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Back to scopes'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('listing'), findsOneWidget);
+  });
+
+  // AF-12b — the scope is not this caller's.
+  testWidgets('GivenAForbiddenScope_WhenOpened_ThenTheRolePanelIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(
+      const FailureResult<Scope>(
+        Failure(kind: FailureKind.forbidden, errors: <String>[]),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Not available for your role'), findsOneWidget);
+  });
+
+  // AF-12c — the API's own errors, with the record left as it was.
+  testWidgets('GivenARejectedUpdate_WhenSaved_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    answerUpdateWith(
+      const FailureResult<Scope>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['A scope with that name already exists.'],
+        ),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Acme'),
+      'Globex',
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, 'Save changes'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('A scope with that name already exists.'), findsOneWidget);
+  });
+
+  testWidgets('GivenARejectedUpdate_WhenSaved_ThenTheInputIsKept', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    answerUpdateWith(
+      const FailureResult<Scope>(
+        Failure(kind: FailureKind.validation, errors: <String>['No.']),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Acme'),
+      'Globex',
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, 'Save changes'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.widgetWithText(TextFormField, 'Globex'), findsOneWidget);
+  });
+
+  // AF-12d — a deleted scope is shown, marked, and read-only.
+  testWidgets('GivenADeletedScope_WhenOpened_ThenItIsMarkedDeleted', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Scope>(_deleted));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.textContaining('This scope is deleted'), findsOneWidget);
+  });
+
+  testWidgets('GivenADeletedScope_WhenOpened_ThenSavingIsNotOffered', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Scope>(_deleted));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.widgetWithText(FilledButton, 'Save changes'), findsNothing);
+  });
+
+  // AF-12e — nothing changed, so there is nothing to save.
+  testWidgets('GivenNoEdit_WhenRendered_ThenSaveIsDisabled', (tester) async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(
+      tester
+          .widget<FilledButton>(
+            find.widgetWithText(FilledButton, 'Save changes'),
+          )
+          .onPressed,
+      isNull,
+    );
+  });
+
+  testWidgets('GivenAnEdit_WhenTyped_ThenSaveIsEnabled', (tester) async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    await pump(tester);
+
+    // When
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Acme'),
+      'Acme Ltd',
+    );
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(
+      tester
+          .widget<FilledButton>(
+            find.widgetWithText(FilledButton, 'Save changes'),
+          )
+          .onPressed,
+      isNotNull,
+    );
+  });
+
+  testWidgets('GivenACompactWindow_WhenRendered_ThenTheDetailIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+
+    // When
+    await pump(tester, size: _compact);
+
+    // Then
+    expect(find.widgetWithText(TextFormField, 'Acme'), findsOneWidget);
+  });
+
+  testWidgets('GivenAMediumWindow_WhenRendered_ThenTheDetailIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+
+    // When
+    await pump(tester, size: _medium);
+
+    // Then
+    expect(find.widgetWithText(TextFormField, 'Acme'), findsOneWidget);
+  });
+
+  testWidgets('GivenTheDarkTheme_WhenRendered_ThenTheDetailIsStillShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+
+    // When
+    await pump(tester, theme: buildDarkTheme());
+
+    // Then
+    expect(find.widgetWithText(TextFormField, 'Acme'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #12

Implements UI-12 — the scope detail at `/scopes/:scopeId` over `GET /api/scopes/{id}` (FR-SC-04) and `PUT /api/scopes/{id}` (FR-SC-05), reached from the listing or directly by URL.

## Flows

| Flow | How it is handled |
| --- | --- |
| Main | The scope is read on open, with its owners, Google Sign-In state, and links to its contents. |
| AF-12a | A `404` shows a not-found panel with a way back to the listing. |
| AF-12b | A `403` shows the same not-for-your-role answer UI-07 gives. |
| AF-12c | A refused update shows the API's strings; the record and the typed input are untouched. |
| AF-12d | A deleted scope is shown, marked, and read-only — the read passes `includeDeleted`. |
| AF-12e | The save control is disabled until a field differs, and the controller repeats the check. |

The controller is keyed by scope identifier, so two detail screens open in two tabs do not share one state.

The links to persons, applications, permissions, and Google users point at routes that UI-16, UI-20, UI-24 and UI-28 will add; until then the router's own "not built yet" screen answers, which is what it is for.

## Verification

`dart format --set-exit-if-changed .`, `flutter analyze`, and `flutter test` all pass — **443 tests**, 28 of them new. Unit tests cover the controller over a fake repository; widget tests cover the screen at all three breakpoints and under the dark theme. No presentation file imports `package:heimdall_api_client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)