### PR TITLE
feat(ui-13): delete a scope, logically and permanently

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ the board is where an item's status changes as it moves.
 | UI-10: Browse and search scopes | ✅ | [#10](https://github.com/artur-rios/heimdall-ui/issues/10) |
 | UI-11: Create a scope | ✅ | [#11](https://github.com/artur-rios/heimdall-ui/issues/11) |
 | UI-12: View and update a scope | ✅ | [#12](https://github.com/artur-rios/heimdall-ui/issues/12) |
-| UI-13: Delete a scope, logically and permanently | ⬜ | [#13](https://github.com/artur-rios/heimdall-ui/issues/13) |
+| UI-13: Delete a scope, logically and permanently | ✅ | [#13](https://github.com/artur-rios/heimdall-ui/issues/13) |
 | UI-14: Manage scope owners | ⬜ | [#14](https://github.com/artur-rios/heimdall-ui/issues/14) |
 | UI-15: Toggle Google Sign-In for a scope | ⬜ | [#15](https://github.com/artur-rios/heimdall-ui/issues/15) |
 

--- a/lib/features/scopes/data/scope_repository_impl.dart
+++ b/lib/features/scopes/data/scope_repository_impl.dart
@@ -187,6 +187,43 @@ class ApiScopeRepository implements ScopeRepository {
       return FailureResult<Scope>(failureFromDioException(error));
     }
   }
+
+  @override
+  Future<Result<void>> delete(String id) async {
+    try {
+      final response = await _client.scopeDelete(id: id);
+
+      return _deletionOutcome(response.success, response.errors);
+    } on DioException catch (error) {
+      // AF-13d: a `404` means somebody already deleted it, and the screen
+      // treats that as done rather than as a failure — which it can only do
+      // because the kind survives.
+      return FailureResult<void>(failureFromDioException(error));
+    }
+  }
+
+  @override
+  Future<Result<void>> hardDelete(String id) async {
+    try {
+      final response = await _client.scopeHardDelete(id: id);
+
+      return _deletionOutcome(response.success, response.errors);
+    } on DioException catch (error) {
+      return FailureResult<void>(failureFromDioException(error));
+    }
+  }
+
+  /// AF-13b: the API refuses a scope it will not delete — one that still holds
+  /// users, for instance — and its own strings are what say why.
+  Result<void> _deletionOutcome(bool? success, List<String>? errors) =>
+      success == true
+      ? const Success<void>(null)
+      : FailureResult<void>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: errors ?? const <String>[],
+          ),
+        );
 }
 
 /// A successful envelope that nonetheless lacks what the flow needs. It should

--- a/lib/features/scopes/domain/scope_repository.dart
+++ b/lib/features/scopes/domain/scope_repository.dart
@@ -43,4 +43,11 @@ abstract interface class ScopeRepository {
     required String name,
     required String description,
   });
+
+  /// Logically deletes a scope. The record is kept and the API can restore it.
+  Future<Result<void>> delete(String id);
+
+  /// Permanently deletes a scope and everything it holds. Nothing survives it,
+  /// which is why UI-13 makes the user type the scope's name first.
+  Future<Result<void>> hardDelete(String id);
 }

--- a/lib/features/scopes/presentation/scope_detail_controller.dart
+++ b/lib/features/scopes/presentation/scope_detail_controller.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/result/result.dart';
 import '../domain/scope.dart';
+import '../domain/scope_repository.dart';
 import 'scope_list_controller.dart';
 
 /// How far the scope detail has got.
@@ -27,6 +28,14 @@ final class ScopeDetailUnavailable extends ScopeDetailState {
   bool get isForbidden => failure.kind == FailureKind.forbidden;
 }
 
+/// The scope is gone, and the screen returns to the listing.
+///
+/// AF-13d lands here too: a `404` means somebody already deleted it, which is
+/// the outcome that was asked for rather than a failure.
+final class ScopeDeleted extends ScopeDetailState {
+  const ScopeDeleted();
+}
+
 /// The record is on screen.
 final class ScopeDetailLoaded extends ScopeDetailState {
   const ScopeDetailLoaded(
@@ -34,12 +43,21 @@ final class ScopeDetailLoaded extends ScopeDetailState {
     this.saving = false,
     this.saveFailure,
     this.saved = false,
+    this.deleting = false,
+    this.deleteFailure,
   });
 
   final Scope scope;
   final bool saving;
   final Failure? saveFailure;
   final bool saved;
+
+  /// A deletion is on its way. Both controls are disabled while it is, so a
+  /// second tap cannot send a second request.
+  final bool deleting;
+
+  /// AF-13b — the API refused to delete, and the scope stays open.
+  final Failure? deleteFailure;
 
   /// AF-12d — a logically deleted scope is shown, but nothing about it may be
   /// changed from here.
@@ -51,11 +69,18 @@ final class ScopeDetailLoaded extends ScopeDetailState {
     Failure? saveFailure,
     bool clearSaveFailure = false,
     bool? saved,
+    bool? deleting,
+    Failure? deleteFailure,
+    bool clearDeleteFailure = false,
   }) => ScopeDetailLoaded(
     scope ?? this.scope,
     saving: saving ?? this.saving,
     saveFailure: clearSaveFailure ? null : (saveFailure ?? this.saveFailure),
     saved: saved ?? this.saved,
+    deleting: deleting ?? this.deleting,
+    deleteFailure: clearDeleteFailure
+        ? null
+        : (deleteFailure ?? this.deleteFailure),
   );
 }
 
@@ -127,6 +152,40 @@ class ScopeDetailController extends FamilyNotifier<ScopeDetailState, String> {
   void acknowledgeSave() {
     if (state case final ScopeDetailLoaded loaded) {
       state = loaded.copyWith(saved: false);
+    }
+  }
+
+  /// Logically deletes the scope. The record is kept and the API can restore
+  /// it, which is what the confirmation says before this is called.
+  Future<void> delete() => _delete((repository) => repository.delete(arg));
+
+  /// Permanently deletes the scope and everything it holds.
+  Future<void> deletePermanently() =>
+      _delete((repository) => repository.hardDelete(arg));
+
+  Future<void> _delete(
+    Future<Result<void>> Function(ScopeRepository repository) send,
+  ) async {
+    final current = state;
+
+    if (current is! ScopeDetailLoaded || current.deleting) {
+      return;
+    }
+
+    state = current.copyWith(deleting: true, clearDeleteFailure: true);
+
+    final result = await send(ref.read(scopeRepositoryProvider));
+
+    switch (result) {
+      case Success<void>():
+        state = const ScopeDeleted();
+      case FailureResult<void>(:final failure):
+        // AF-13d: the scope is already gone, which is the outcome that was
+        // asked for. Reporting it as a failure would ask the user to delete
+        // something that no longer exists.
+        state = failure.kind == FailureKind.notFound
+            ? const ScopeDeleted()
+            : current.copyWith(deleting: false, deleteFailure: failure);
     }
   }
 }

--- a/lib/features/scopes/presentation/scope_detail_screen.dart
+++ b/lib/features/scopes/presentation/scope_detail_screen.dart
@@ -5,9 +5,13 @@ import 'package:go_router/go_router.dart';
 import '../../../core/result/result.dart';
 import '../../../shared/layout/app_shell.dart';
 import '../../../shared/widgets/collection_states.dart';
+import '../../../shared/widgets/confirm_dialog.dart';
 import '../../../shared/widgets/failure_banner.dart';
+import '../../auth/domain/session.dart';
+import '../../auth/presentation/session_controller.dart';
 import '../domain/scope.dart';
 import 'scope_detail_controller.dart';
+import 'scope_list_controller.dart';
 
 /// UI-12 — one scope: what it is, who owns it, and what it contains.
 class ScopeDetailScreen extends ConsumerStatefulWidget {
@@ -63,6 +67,52 @@ class _ScopeDetailScreenState extends ConsumerState<ScopeDetailScreen> {
       _name.text.trim() != scope.name ||
       _description.text.trim() != scope.description;
 
+  /// AF-13e — only a System Admin deletes a scope.
+  bool get _maySeeDeletion {
+    final session = ref.watch(sessionControllerProvider);
+
+    return session is Authenticated && session.principal.isSystemAdmin;
+  }
+
+  /// AF-13a — a dialog the user closes sends nothing.
+  Future<void> _confirmDelete(Scope scope) async {
+    final confirmed = await showConfirm(
+      context: context,
+      title: 'Delete this scope?',
+      message:
+          '${scope.name} will be marked deleted. The record is kept and '
+          'the API can restore it.',
+      confirmLabel: 'Delete',
+    );
+
+    if (confirmed && mounted) {
+      await ref
+          .read(scopeDetailControllerProvider(widget.scopeId).notifier)
+          .delete();
+    }
+  }
+
+  /// AF-13c — the confirm control stays disabled until the name matches.
+  Future<void> _confirmDeletePermanently(Scope scope) async {
+    final confirmed = await showTypeToConfirm(
+      context: context,
+      title: 'Delete this scope permanently?',
+      message:
+          'The scope and everything in it — its persons, applications, '
+          'permissions, and Google users — are erased. This cannot be undone. '
+          'Type the name to confirm:',
+      confirmationValue: scope.name,
+      fieldLabel: 'Scope name',
+      confirmLabel: 'Delete permanently',
+    );
+
+    if (confirmed && mounted) {
+      await ref
+          .read(scopeDetailControllerProvider(widget.scopeId).notifier)
+          .deletePermanently();
+    }
+  }
+
   Future<void> _save() async {
     if (!(_formKey.currentState?.validate() ?? false)) {
       return;
@@ -78,6 +128,17 @@ class _ScopeDetailScreenState extends ConsumerState<ScopeDetailScreen> {
     final state = ref.watch(scopeDetailControllerProvider(widget.scopeId));
     final controller = ref.read(
       scopeDetailControllerProvider(widget.scopeId).notifier,
+    );
+
+    // A deleted scope returns to the listing, which is now stale.
+    ref.listen<ScopeDetailState>(
+      scopeDetailControllerProvider(widget.scopeId),
+      (previous, next) {
+        if (next is ScopeDeleted) {
+          ref.read(scopeListControllerProvider.notifier).load();
+          context.go('/scopes');
+        }
+      },
     );
 
     return AppShell(
@@ -115,6 +176,9 @@ class _ScopeDetailScreenState extends ConsumerState<ScopeDetailScreen> {
           failure: failure,
           onRetry: controller.load,
         ),
+        // The listing is where a deleted scope leaves the user; this is the
+        // frame in between.
+        ScopeDeleted() => const Center(child: CircularProgressIndicator()),
         final ScopeDetailLoaded loaded => _detail(loaded),
       },
     );
@@ -221,6 +285,19 @@ class _ScopeDetailScreenState extends ConsumerState<ScopeDetailScreen> {
               Text('In this scope', style: theme.textTheme.titleMedium),
               const SizedBox(height: 8),
               _Links(scopeId: scope.id),
+              // AF-13e — a Scope Admin never sees either control. The API
+              // refuses them either way; showing them would only promise
+              // something that cannot happen.
+              if (_maySeeDeletion && !state.isReadOnly) ...<Widget>[
+                const SizedBox(height: 24),
+                _DangerZone(
+                  scope: scope,
+                  deleting: state.deleting,
+                  failure: state.deleteFailure,
+                  onDelete: _confirmDelete,
+                  onDeletePermanently: _confirmDeletePermanently,
+                ),
+              ],
             ],
           ),
         ),
@@ -313,6 +390,75 @@ class _SavedNotice extends StatelessWidget {
       child: Text(
         'Saved.',
         style: TextStyle(color: scheme.onSecondaryContainer),
+      ),
+    );
+  }
+}
+
+/// The two deletions, kept apart from everything else on the screen because
+/// neither is an ordinary edit.
+class _DangerZone extends StatelessWidget {
+  const _DangerZone({
+    required this.scope,
+    required this.deleting,
+    required this.failure,
+    required this.onDelete,
+    required this.onDeletePermanently,
+  });
+
+  final Scope scope;
+  final bool deleting;
+  final Failure? failure;
+  final Future<void> Function(Scope scope) onDelete;
+  final Future<void> Function(Scope scope) onDeletePermanently;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Card(
+      color: theme.colorScheme.errorContainer,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              'Delete this scope',
+              style: theme.textTheme.titleMedium?.copyWith(
+                color: theme.colorScheme.onErrorContainer,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Deleting keeps the record and can be undone by the API. '
+              'Deleting permanently erases the scope and everything in it.',
+              style: TextStyle(color: theme.colorScheme.onErrorContainer),
+            ),
+            // AF-13b — the API refused, and the scope is still open.
+            if (failure case final Failure refusal) ...<Widget>[
+              const SizedBox(height: 16),
+              ErrorBanner(failure: refusal),
+            ],
+            const SizedBox(height: 16),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: <Widget>[
+                OutlinedButton.icon(
+                  onPressed: deleting ? null : () => onDelete(scope),
+                  icon: const Icon(Icons.delete_outline),
+                  label: const Text('Delete scope'),
+                ),
+                FilledButton.icon(
+                  onPressed: deleting ? null : () => onDeletePermanently(scope),
+                  icon: const Icon(Icons.delete_forever_outlined),
+                  label: const Text('Delete permanently'),
+                ),
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/shared/widgets/confirm_dialog.dart
+++ b/lib/shared/widgets/confirm_dialog.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+
+/// Asks before something that cannot simply be undone.
+///
+/// Returns `true` only when the user confirmed; dismissing the dialog any
+/// other way is a "no", which is what the cancelled alternative flows of the
+/// deletion use cases require.
+Future<bool> showConfirm({
+  required BuildContext context,
+  required String title,
+  required String message,
+  required String confirmLabel,
+  String cancelLabel = 'Cancel',
+}) async {
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: Text(title),
+      content: Text(message),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: Text(cancelLabel),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(context).pop(true),
+          child: Text(confirmLabel),
+        ),
+      ],
+    ),
+  );
+
+  return confirmed ?? false;
+}
+
+/// Asks before something irreversible, and will not let the user agree until
+/// they have typed [confirmationValue] exactly.
+///
+/// The typing is the point: it is what stops a permanent deletion from being
+/// one careless tap, and it is why the confirm control stays disabled until the
+/// value matches.
+Future<bool> showTypeToConfirm({
+  required BuildContext context,
+  required String title,
+  required String message,
+  required String confirmationValue,
+  required String fieldLabel,
+  required String confirmLabel,
+  String cancelLabel = 'Cancel',
+}) async {
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (context) => _TypeToConfirmDialog(
+      title: title,
+      message: message,
+      confirmationValue: confirmationValue,
+      fieldLabel: fieldLabel,
+      confirmLabel: confirmLabel,
+      cancelLabel: cancelLabel,
+    ),
+  );
+
+  return confirmed ?? false;
+}
+
+class _TypeToConfirmDialog extends StatefulWidget {
+  const _TypeToConfirmDialog({
+    required this.title,
+    required this.message,
+    required this.confirmationValue,
+    required this.fieldLabel,
+    required this.confirmLabel,
+    required this.cancelLabel,
+  });
+
+  final String title;
+  final String message;
+  final String confirmationValue;
+  final String fieldLabel;
+  final String confirmLabel;
+  final String cancelLabel;
+
+  @override
+  State<_TypeToConfirmDialog> createState() => _TypeToConfirmDialogState();
+}
+
+class _TypeToConfirmDialogState extends State<_TypeToConfirmDialog> {
+  final _typed = TextEditingController();
+
+  @override
+  void dispose() {
+    _typed.dispose();
+    super.dispose();
+  }
+
+  /// An exact match, not a trimmed or case-folded one. A confirmation that
+  /// accepts nearly the right value is not much of a confirmation.
+  bool get _matches => _typed.text == widget.confirmationValue;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return AlertDialog(
+      title: Text(widget.title),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(widget.message),
+          const SizedBox(height: 16),
+          Text(widget.confirmationValue, style: theme.textTheme.titleMedium),
+          const SizedBox(height: 8),
+          TextField(
+            controller: _typed,
+            autofocus: true,
+            decoration: InputDecoration(labelText: widget.fieldLabel),
+            onChanged: (_) => setState(() {}),
+          ),
+        ],
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: Text(widget.cancelLabel),
+        ),
+        FilledButton(
+          onPressed: _matches ? () => Navigator.of(context).pop(true) : null,
+          child: Text(widget.confirmLabel),
+        ),
+      ],
+    );
+  }
+}

--- a/test/features/scopes/presentation/scope_detail_controller_test.dart
+++ b/test/features/scopes/presentation/scope_detail_controller_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:heimdall_ui/core/result/result.dart';
@@ -48,6 +50,14 @@ void main() {
         includeDeleted: any(named: 'includeDeleted'),
       ),
     ).thenAnswer((_) async => result);
+  }
+
+  void answerDeleteWith(Result<void> result) {
+    when(() => repository.delete(any())).thenAnswer((_) async => result);
+  }
+
+  void answerHardDeleteWith(Result<void> result) {
+    when(() => repository.hardDelete(any())).thenAnswer((_) async => result);
   }
 
   void answerUpdateWith(Result<Scope> result) {
@@ -261,5 +271,99 @@ void main() {
     final state = currentState() as ScopeDetailUnavailable;
     expect(state.isNotFound, isFalse);
     expect(state.isForbidden, isFalse);
+  });
+
+  test('GivenAnOpenScope_WhenDeleted_ThenTheScopeIsDeleted', () async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    answerDeleteWith(const Success<void>(null));
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.delete();
+
+    // Then
+    verify(() => repository.delete('scope-1')).called(1);
+    expect(currentState(), isA<ScopeDeleted>());
+  });
+
+  test(
+    'GivenAnOpenScope_WhenDeletedPermanently_ThenTheHardEndpointIsUsed',
+    () async {
+      // Given
+      answerGetWith(const Success<Scope>(_acme));
+      answerHardDeleteWith(const Success<void>(null));
+      final controller = controllerUnderTest();
+      await controller.load();
+
+      // When
+      await controller.deletePermanently();
+
+      // Then
+      verify(() => repository.hardDelete('scope-1')).called(1);
+    },
+  );
+
+  // AF-13b — the API refused, and the scope stays open.
+  test('GivenARefusedDeletion_WhenDeleted_ThenTheScopeStaysOpen', () async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    answerDeleteWith(
+      const FailureResult<void>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['The scope still holds users.'],
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.delete();
+
+    // Then
+    final state = currentState() as ScopeDetailLoaded;
+    expect(state.deleteFailure?.errors, <String>[
+      'The scope still holds users.',
+    ]);
+  });
+
+  // AF-13d — already deleted is the outcome that was asked for.
+  test('GivenAnAlreadyDeletedScope_WhenDeleted_ThenItCountsAsDone', () async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    answerDeleteWith(
+      const FailureResult<void>(
+        Failure(kind: FailureKind.notFound, errors: <String>[]),
+      ),
+    );
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.delete();
+
+    // Then
+    expect(currentState(), isA<ScopeDeleted>());
+  });
+
+  test('GivenADeletionInFlight_WhenAskedAgain_ThenOnlyOneIsSent', () async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    final pending = Completer<Result<void>>();
+    when(() => repository.delete(any())).thenAnswer((_) => pending.future);
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    final first = controller.delete();
+    final second = controller.delete();
+    pending.complete(const Success<void>(null));
+    await Future.wait<void>(<Future<void>>[first, second]);
+
+    // Then
+    verify(() => repository.delete('scope-1')).called(1);
   });
 }

--- a/test/features/scopes/presentation/scope_detail_screen_test.dart
+++ b/test/features/scopes/presentation/scope_detail_screen_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:heimdall_ui/app/theme.dart';
+import 'package:heimdall_ui/core/network/envelope.dart' as envelope;
 import 'package:heimdall_ui/core/result/result.dart';
 import 'package:heimdall_ui/core/storage/token_store.dart';
 import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
@@ -17,13 +18,14 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockScopeRepository extends Mock implements ScopeRepository {}
 
-String _jwt() {
+/// A token naming a person of [role]: 1 System Admin, 2 Scope Admin.
+String _jwt({int role = 1}) {
   final payload = base64Url.encode(
     utf8.encode(
       jsonEncode(<String, dynamic>{
         'sub': 'person-1',
         'email': 'admin@example.com',
-        'role': 1,
+        'role': role,
       }),
     ),
   );
@@ -60,12 +62,18 @@ void main() {
     WidgetTester tester, {
     Size size = _expanded,
     ThemeData? theme,
+    int role = 1,
   }) async {
     tester.view.physicalSize = size;
     tester.view.devicePixelRatio = 1;
     addTearDown(tester.view.reset);
 
-    await store.write(AuthToken(value: _jwt(), expiresAt: DateTime.utc(2030)));
+    await store.write(
+      AuthToken(
+        value: _jwt(role: role),
+        expiresAt: DateTime.utc(2030),
+      ),
+    );
 
     container = ProviderContainer(
       overrides: <Override>[
@@ -115,6 +123,40 @@ void main() {
         includeDeleted: any(named: 'includeDeleted'),
       ),
     ).thenAnswer((_) async => result);
+  }
+
+  /// The deletion controls sit at the bottom of a scrolling detail, so they
+  /// are not on screen until the view is brought to them.
+  Future<void> tapAfterScrolling(WidgetTester tester, Finder finder) async {
+    await tester.ensureVisible(finder);
+    await tester.pumpAndSettle();
+    await tester.tap(finder);
+    await tester.pumpAndSettle();
+  }
+
+  void answerDeleteWith(Result<void> result) {
+    when(() => repository.delete(any())).thenAnswer((_) async => result);
+  }
+
+  void answerHardDeleteWith(Result<void> result) {
+    when(() => repository.hardDelete(any())).thenAnswer((_) async => result);
+  }
+
+  /// The listing behind the detail is reloaded after a deletion; what it
+  /// answers does not matter here, only that it answers.
+  void answerListWith() {
+    when(
+      () => repository.list(
+        name: any(named: 'name'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer(
+      (_) async => const FailureResult<envelope.Page<Scope>>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
   }
 
   void answerUpdateWith(Result<Scope> result) {
@@ -430,5 +472,268 @@ void main() {
 
     // Then
     expect(find.widgetWithText(TextFormField, 'Acme'), findsOneWidget);
+  });
+
+  // AF-13e — a Scope Admin never sees either control.
+  testWidgets('GivenAScopeAdmin_WhenOpened_ThenDeletionIsNotOffered', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+
+    // When
+    await pump(tester, role: 2);
+
+    // Then
+    expect(find.widgetWithText(OutlinedButton, 'Delete scope'), findsNothing);
+    expect(
+      find.widgetWithText(FilledButton, 'Delete permanently'),
+      findsNothing,
+    );
+  });
+
+  testWidgets('GivenASystemAdmin_WhenOpened_ThenDeletionIsOffered', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.widgetWithText(OutlinedButton, 'Delete scope'), findsOneWidget);
+  });
+
+  testWidgets('GivenADeletedScope_WhenOpened_ThenDeletionIsNotOffered', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Scope>(_deleted));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.widgetWithText(OutlinedButton, 'Delete scope'), findsNothing);
+  });
+
+  testWidgets('GivenTheDeleteControl_WhenTapped_ThenConfirmationIsAsked', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    await pump(tester);
+
+    // When
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(OutlinedButton, 'Delete scope'),
+    );
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('Delete this scope?'), findsOneWidget);
+  });
+
+  testWidgets('GivenAConfirmedDeletion_WhenConfirmed_ThenTheScopeIsDeleted', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    answerDeleteWith(const Success<void>(null));
+    answerListWith();
+    await pump(tester);
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(OutlinedButton, 'Delete scope'),
+    );
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(() => repository.delete('scope-1')).called(1);
+  });
+
+  testWidgets('GivenADeletedScope_WhenDeleted_ThenTheListingOpens', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    answerDeleteWith(const Success<void>(null));
+    answerListWith();
+    await pump(tester);
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(OutlinedButton, 'Delete scope'),
+    );
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('listing'), findsOneWidget);
+  });
+
+  // AF-13a — the dialog closes and nothing is sent.
+  testWidgets('GivenTheDeleteDialog_WhenCancelled_ThenNothingIsSent', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    answerDeleteWith(const Success<void>(null));
+    await pump(tester);
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(OutlinedButton, 'Delete scope'),
+    );
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verifyNever(() => repository.delete(any()));
+  });
+
+  // AF-13b — the API refused, and the scope stays open.
+  testWidgets('GivenARefusedDeletion_WhenConfirmed_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    answerDeleteWith(
+      const FailureResult<void>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['The scope still holds users.'],
+        ),
+      ),
+    );
+    await pump(tester);
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(OutlinedButton, 'Delete scope'),
+    );
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('The scope still holds users.'), findsOneWidget);
+  });
+
+  // AF-13c — the confirm control stays disabled until the name matches.
+  testWidgets('GivenTheHardDeleteDialog_WhenOpened_ThenConfirmIsDisabled', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    await pump(tester);
+
+    // When
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(FilledButton, 'Delete permanently'),
+    );
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(
+      tester
+          .widget<FilledButton>(
+            find.widgetWithText(FilledButton, 'Delete permanently').last,
+          )
+          .onPressed,
+      isNull,
+    );
+  });
+
+  testWidgets('GivenAMistypedName_WhenTyped_ThenConfirmStaysDisabled', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    await pump(tester);
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(FilledButton, 'Delete permanently'),
+    );
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.enterText(find.byType(TextField).last, 'acme');
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(
+      tester
+          .widget<FilledButton>(
+            find.widgetWithText(FilledButton, 'Delete permanently').last,
+          )
+          .onPressed,
+      isNull,
+    );
+  });
+
+  testWidgets('GivenTheTypedName_WhenItMatches_ThenTheScopeIsErased', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    answerHardDeleteWith(const Success<void>(null));
+    answerListWith();
+    await pump(tester);
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(FilledButton, 'Delete permanently'),
+    );
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField).last, 'Acme');
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(
+      find.widgetWithText(FilledButton, 'Delete permanently').last,
+    );
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(() => repository.hardDelete('scope-1')).called(1);
+  });
+
+  // AF-13d — already deleted is the outcome that was asked for.
+  testWidgets('GivenAnAlreadyDeletedScope_WhenDeleted_ThenTheListingOpens', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    answerDeleteWith(
+      const FailureResult<void>(
+        Failure(kind: FailureKind.notFound, errors: <String>[]),
+      ),
+    );
+    answerListWith();
+    await pump(tester);
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(OutlinedButton, 'Delete scope'),
+    );
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('listing'), findsOneWidget);
   });
 }


### PR DESCRIPTION
Closes #13

Implements UI-13 — both deletions from the scope detail, over `DELETE /api/scopes/{id}` (FR-SC-06) and `DELETE /api/scopes/{id}/hard` (FR-SC-07).

## Flows

| Flow | How it is handled |
| --- | --- |
| Main — logical | A dialog names the scope and says the record is kept; on success the listing reopens, refreshed. |
| Main — permanent | A dialog states that everything is erased and requires the scope's name to be typed. |
| AF-13a | Closing either dialog sends nothing. |
| AF-13b | A refusal shows the API's strings and leaves the scope open. |
| AF-13c | The permanent-deletion confirm control stays disabled until the name matches exactly. |
| AF-13d | A `404` is treated as done and returns to a refreshed listing. |
| AF-13e | Neither control is shown to a Scope Admin. |

## Shared widget

`confirm_dialog.dart` — a plain confirmation and a type-the-value-to-confirm dialog. UI-19, UI-23, UI-27 and UI-29 each need exactly this pair (typed email, name, name, email respectively), so it lands here rather than four times over.

The match is exact, not trimmed or case-folded: a confirmation that accepts nearly the right value is not much of a confirmation, and a widget test covers the mistyped case.

## Verification

`dart format --set-exit-if-changed .`, `flutter analyze`, and `flutter test` all pass — **460 tests**, 17 of them new. No presentation file imports `package:heimdall_api_client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)