### PR TITLE
feat(ui-14): manage scope owners

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ the board is where an item's status changes as it moves.
 | UI-11: Create a scope | ✅ | [#11](https://github.com/artur-rios/heimdall-ui/issues/11) |
 | UI-12: View and update a scope | ✅ | [#12](https://github.com/artur-rios/heimdall-ui/issues/12) |
 | UI-13: Delete a scope, logically and permanently | ✅ | [#13](https://github.com/artur-rios/heimdall-ui/issues/13) |
-| UI-14: Manage scope owners | ⬜ | [#14](https://github.com/artur-rios/heimdall-ui/issues/14) |
+| UI-14: Manage scope owners | ✅ | [#14](https://github.com/artur-rios/heimdall-ui/issues/14) |
 | UI-15: Toggle Google Sign-In for a scope | ⬜ | [#15](https://github.com/artur-rios/heimdall-ui/issues/15) |
 
 ### Person Management

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -14,6 +14,7 @@ import '../features/profile/presentation/profile_screen.dart';
 import '../features/scopes/presentation/scope_create_screen.dart';
 import '../features/scopes/presentation/scope_detail_screen.dart';
 import '../features/scopes/presentation/scope_list_screen.dart';
+import '../features/scopes/presentation/scope_owners_screen.dart';
 import 'route_access.dart';
 
 /// Routes an unauthenticated caller may reach.
@@ -129,6 +130,11 @@ final Provider<GoRouter> routerProvider = Provider<GoRouter>((ref) {
         path: '/scopes/:scopeId',
         builder: (context, state) =>
             ScopeDetailScreen(scopeId: state.pathParameters['scopeId']!),
+      ),
+      GoRoute(
+        path: '/scopes/:scopeId/owners',
+        builder: (context, state) =>
+            ScopeOwnersScreen(scopeId: state.pathParameters['scopeId']!),
       ),
       GoRoute(
         path: '/not-available',

--- a/lib/features/persons/data/person_repository_impl.dart
+++ b/lib/features/persons/data/person_repository_impl.dart
@@ -100,6 +100,204 @@ class ApiPersonRepository implements PersonRepository {
       return FailureResult<Person>(failureFromDioException(error));
     }
   }
+
+  @override
+  Future<Result<Page<Person>>> listScopeOwners({
+    required String scopeId,
+    String? name,
+    String? email,
+    bool includeDeleted = false,
+    int pageNumber = 1,
+    int pageSize = 20,
+  }) => _listing(
+    () => _client.personListScopeOwners(
+      scopeId: scopeId,
+      name: _filter(name),
+      email: _filter(email),
+      includeDeleted: includeDeleted,
+      pageNumber: pageNumber,
+      pageSize: pageSize,
+    ),
+    pageNumber: pageNumber,
+    pageSize: pageSize,
+  );
+
+  @override
+  Future<Result<Page<Person>>> listScopePersons({
+    required String scopeId,
+    String? name,
+    String? email,
+    bool includeDeleted = false,
+    int pageNumber = 1,
+    int pageSize = 20,
+  }) => _listing(
+    () => _client.personListScopePersons(
+      scopeId: scopeId,
+      name: _filter(name),
+      email: _filter(email),
+      includeDeleted: includeDeleted,
+      pageNumber: pageNumber,
+      pageSize: pageSize,
+    ),
+    pageNumber: pageNumber,
+    pageSize: pageSize,
+  );
+
+  @override
+  Future<Result<void>> addScopeOwner({
+    required String scopeId,
+    required String personId,
+  }) async {
+    try {
+      final response = await _client.personAddScopeOwner(
+        scopeId: scopeId,
+        personId: personId,
+      );
+
+      // AF-14b and AF-14c: not a Scope Admin, and already an owner, both
+      // arrive here in the API's own words.
+      return _acknowledgement(response.success, response.errors);
+    } on DioException catch (error) {
+      return FailureResult<void>(failureFromDioException(error));
+    }
+  }
+
+  @override
+  Future<Result<Person>> createScopeOwner({
+    required String scopeId,
+    required String name,
+    required String email,
+    required String password,
+  }) async {
+    try {
+      final response = await _client.personCreateScopeOwner(
+        scopeId: scopeId,
+        body: CreateScopeOwnerCommand(
+          name: name,
+          email: email,
+          password: password,
+        ),
+      );
+
+      if (response.success != true) {
+        // AF-14d: a rejected name, address, or password.
+        return FailureResult<Person>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: response.errors ?? const <String>[],
+          ),
+        );
+      }
+
+      final data = response.data;
+
+      if (data == null) {
+        return const FailureResult<Person>(incompleteResponse);
+      }
+
+      return Success<Person>(
+        Person(
+          id: data.id ?? '',
+          name: data.name ?? name,
+          email: data.email ?? email,
+          role: roleFromValue(data.role ?? Role.scopeAdmin.value),
+          emailVerified: data.emailVerified ?? false,
+          scopeId: data.scopeId,
+          createdAt: data.createdAt,
+        ),
+      );
+    } on DioException catch (error) {
+      return FailureResult<Person>(failureFromDioException(error));
+    }
+  }
+
+  @override
+  Future<Result<void>> removeScopeOwner({
+    required String scopeId,
+    required String personId,
+  }) async {
+    try {
+      final response = await _client.personRemoveScopeOwner(
+        scopeId: scopeId,
+        personId: personId,
+      );
+
+      // AF-14a: a scope may not be left without an owner, and the API is the
+      // only party that knows whether this removal would do that.
+      return _acknowledgement(response.success, response.errors);
+    } on DioException catch (error) {
+      return FailureResult<void>(failureFromDioException(error));
+    }
+  }
+
+  @override
+  Future<Result<void>> promoteScopeUser({
+    required String scopeId,
+    required String personId,
+  }) async {
+    try {
+      final response = await _client.personPromoteScopeUser(
+        scopeId: scopeId,
+        personId: personId,
+      );
+
+      return _acknowledgement(response.success, response.errors);
+    } on DioException catch (error) {
+      return FailureResult<void>(failureFromDioException(error));
+    }
+  }
+
+  /// An empty filter is no filter: sending it would ask the API to match the
+  /// empty string rather than to stop filtering.
+  static String? _filter(String? value) =>
+      (value?.trim().isEmpty ?? true) ? null : value!.trim();
+
+  /// Runs a paginated person listing and maps its envelope.
+  Future<Result<Page<Person>>> _listing(
+    Future<PersonOutputPaginatedOutput> Function() send, {
+    required int pageNumber,
+    required int pageSize,
+  }) async {
+    try {
+      final response = await send();
+
+      if (response.success != true) {
+        return FailureResult<Page<Person>>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: response.errors ?? const <String>[],
+          ),
+        );
+      }
+
+      final items = (response.data ?? const <PersonOutput>[])
+          .map(personFromOutput)
+          .toList(growable: false);
+
+      return Success<Page<Person>>(
+        Page<Person>(
+          items: items,
+          pageNumber: response.pageNumber ?? pageNumber,
+          pageSize: response.pageSize ?? pageSize,
+          totalItems: response.totalItems ?? items.length,
+          totalPages: response.totalPages ?? 1,
+        ),
+      );
+    } on DioException catch (error) {
+      return FailureResult<Page<Person>>(failureFromDioException(error));
+    }
+  }
+
+  /// A command whose only interesting answer is whether it worked.
+  Result<void> _acknowledgement(bool? success, List<String>? errors) =>
+      success == true
+      ? const Success<void>(null)
+      : FailureResult<void>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: errors ?? const <String>[],
+          ),
+        );
 }
 
 /// Maps the generated output onto the domain entity.

--- a/lib/features/persons/domain/person_repository.dart
+++ b/lib/features/persons/domain/person_repository.dart
@@ -1,3 +1,4 @@
+import '../../../core/network/envelope.dart';
 import '../../../core/result/result.dart';
 import 'person.dart';
 
@@ -21,5 +22,61 @@ abstract interface class PersonRepository {
     required String name,
     required String email,
     int? roleId,
+  });
+
+  /// Lists the Scope Admins who own a scope.
+  Future<Result<Page<Person>>> listScopeOwners({
+    required String scopeId,
+    String? name,
+    String? email,
+    bool includeDeleted = false,
+    int pageNumber = 1,
+    int pageSize = 20,
+  });
+
+  /// Lists the User persons of a scope.
+  ///
+  /// UI-14 reads it to offer the promotion, and UI-16 lists it in its own
+  /// right.
+  Future<Result<Page<Person>>> listScopePersons({
+    required String scopeId,
+    String? name,
+    String? email,
+    bool includeDeleted = false,
+    int pageNumber = 1,
+    int pageSize = 20,
+  });
+
+  /// Adds an existing Scope Admin as a co-owner of a scope.
+  ///
+  /// Whether that person is a usable Scope Admin, and whether they already own
+  /// the scope, are the API's questions — AF-14b and AF-14c are what its
+  /// answers look like.
+  Future<Result<void>> addScopeOwner({
+    required String scopeId,
+    required String personId,
+  });
+
+  /// Creates a brand-new Scope Admin directly as a co-owner of a scope.
+  Future<Result<Person>> createScopeOwner({
+    required String scopeId,
+    required String name,
+    required String email,
+    required String password,
+  });
+
+  /// Removes a person's ownership of a scope.
+  ///
+  /// AF-14a: the API refuses to leave a scope with no owner, and says so in
+  /// its own words.
+  Future<Result<void>> removeScopeOwner({
+    required String scopeId,
+    required String personId,
+  });
+
+  /// Promotes a User of the scope to Scope Admin, making them a co-owner.
+  Future<Result<void>> promoteScopeUser({
+    required String scopeId,
+    required String personId,
   });
 }

--- a/lib/features/scopes/presentation/scope_owners_controller.dart
+++ b/lib/features/scopes/presentation/scope_owners_controller.dart
@@ -1,0 +1,167 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/network/envelope.dart';
+import '../../../core/result/result.dart';
+import '../../persons/domain/person.dart';
+import '../../persons/domain/person_repository.dart';
+import '../../profile/presentation/profile_controller.dart';
+
+/// How far the owners section has got.
+sealed class ScopeOwnersState {
+  const ScopeOwnersState();
+}
+
+/// The owners are being read.
+final class ScopeOwnersLoading extends ScopeOwnersState {
+  const ScopeOwnersLoading();
+}
+
+/// The owners could not be read.
+final class ScopeOwnersUnavailable extends ScopeOwnersState {
+  const ScopeOwnersUnavailable(this.failure);
+
+  final Failure failure;
+}
+
+/// The owners are on screen.
+///
+/// [users] are the scope's User persons, which is what the promotion offers;
+/// they are read alongside the owners because the promotion is one of the four
+/// things this screen does.
+final class ScopeOwnersLoaded extends ScopeOwnersState {
+  const ScopeOwnersLoaded({
+    required this.owners,
+    required this.users,
+    this.busy = false,
+    this.failure,
+  });
+
+  final List<Person> owners;
+  final List<Person> users;
+
+  /// A command is on its way. Every control is disabled while it is.
+  final bool busy;
+
+  /// The API's refusal of the last command — AF-14a, AF-14b, AF-14c, AF-14d.
+  final Failure? failure;
+
+  /// AF-14a — a scope with one owner cannot lose it, so the control does not
+  /// offer to. The API refuses regardless; this is what stops the interface
+  /// promising otherwise.
+  bool get canRemove => owners.length > 1;
+
+  /// AF-14c — someone who already owns the scope is not offered again.
+  Set<String> get ownerIds => owners.map((owner) => owner.id).toSet();
+
+  /// The users who could be promoted: the scope's users, minus anyone already
+  /// owning it.
+  List<Person> get promotable => users
+      .where((user) => !ownerIds.contains(user.id))
+      .toList(growable: false);
+
+  ScopeOwnersLoaded copyWith({
+    List<Person>? owners,
+    List<Person>? users,
+    bool? busy,
+    Failure? failure,
+    bool clearFailure = false,
+  }) => ScopeOwnersLoaded(
+    owners: owners ?? this.owners,
+    users: users ?? this.users,
+    busy: busy ?? this.busy,
+    failure: clearFailure ? null : (failure ?? this.failure),
+  );
+}
+
+final NotifierProviderFamily<ScopeOwnersController, ScopeOwnersState, String>
+scopeOwnersControllerProvider =
+    NotifierProvider.family<ScopeOwnersController, ScopeOwnersState, String>(
+      ScopeOwnersController.new,
+    );
+
+/// Owns one scope's owner list and the four things that can be done to it.
+class ScopeOwnersController extends FamilyNotifier<ScopeOwnersState, String> {
+  @override
+  ScopeOwnersState build(String scopeId) => const ScopeOwnersLoading();
+
+  PersonRepository get _repository => ref.read(personRepositoryProvider);
+
+  /// Reads the owners, and the scope's users the promotion draws on.
+  ///
+  /// The users are not what this screen is about, so a listing that fails does
+  /// not take the owners down with it: the promotion is simply not offered.
+  Future<void> load() async {
+    final owners = await _repository.listScopeOwners(scopeId: arg);
+
+    switch (owners) {
+      case FailureResult<Page<Person>>(:final failure):
+        state = ScopeOwnersUnavailable(failure);
+      case Success<Page<Person>>(:final value):
+        final users = await _repository.listScopePersons(scopeId: arg);
+
+        state = ScopeOwnersLoaded(
+          owners: value.items,
+          users: users.valueOrNull?.items ?? const <Person>[],
+        );
+    }
+  }
+
+  /// Adds a person who is already a Scope Admin as a co-owner.
+  Future<void> addOwner(String personId) => _command(
+    () => _repository.addScopeOwner(scopeId: arg, personId: personId),
+  );
+
+  /// Removes an owner.
+  ///
+  /// AF-14f: the caller removing themselves is warned by the screen before
+  /// this is reached; afterwards the reload is what shows them the scope is no
+  /// longer theirs.
+  Future<void> removeOwner(String personId) => _command(
+    () => _repository.removeScopeOwner(scopeId: arg, personId: personId),
+  );
+
+  /// Promotes a User of the scope to Scope Admin and co-owner.
+  Future<void> promote(String personId) => _command(
+    () => _repository.promoteScopeUser(scopeId: arg, personId: personId),
+  );
+
+  /// Creates a brand-new Scope Admin directly as a co-owner.
+  Future<void> createOwner({
+    required String name,
+    required String email,
+    required String password,
+  }) => _command(() async {
+    final created = await _repository.createScopeOwner(
+      scopeId: arg,
+      name: name,
+      email: email,
+      password: password,
+    );
+
+    return created.fold(
+      onSuccess: (_) => const Success<void>(null),
+      onFailure: FailureResult<void>.new,
+    );
+  });
+
+  /// Runs one command and reloads, so what is on screen is always what the API
+  /// last confirmed rather than a guess about what the command did.
+  Future<void> _command(Future<Result<void>> Function() send) async {
+    final current = state;
+
+    if (current is! ScopeOwnersLoaded || current.busy) {
+      return;
+    }
+
+    state = current.copyWith(busy: true, clearFailure: true);
+
+    final result = await send();
+
+    switch (result) {
+      case Success<void>():
+        await load();
+      case FailureResult<void>(:final failure):
+        state = current.copyWith(busy: false, failure: failure);
+    }
+  }
+}

--- a/lib/features/scopes/presentation/scope_owners_screen.dart
+++ b/lib/features/scopes/presentation/scope_owners_screen.dart
@@ -1,0 +1,382 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../shared/layout/app_shell.dart';
+import '../../../shared/widgets/collection_states.dart';
+import '../../../shared/widgets/confirm_dialog.dart';
+import '../../../shared/widgets/failure_banner.dart';
+import '../../auth/domain/session.dart';
+import '../../auth/presentation/session_controller.dart';
+import '../../persons/domain/person.dart';
+import 'scope_owners_controller.dart';
+
+/// UI-14 — the owners of one scope, and the four ways the list changes.
+class ScopeOwnersScreen extends ConsumerStatefulWidget {
+  const ScopeOwnersScreen({required this.scopeId, super.key});
+
+  final String scopeId;
+
+  @override
+  ConsumerState<ScopeOwnersScreen> createState() => _ScopeOwnersScreenState();
+}
+
+class _ScopeOwnersScreenState extends ConsumerState<ScopeOwnersScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => ref
+          .read(scopeOwnersControllerProvider(widget.scopeId).notifier)
+          .load(),
+    );
+  }
+
+  ScopeOwnersController get _controller =>
+      ref.read(scopeOwnersControllerProvider(widget.scopeId).notifier);
+
+  /// Who is signed in, which AF-14f needs in order to warn them about
+  /// themselves.
+  String? get _signedInPersonId {
+    final session = ref.watch(sessionControllerProvider);
+
+    return session is Authenticated ? session.principal.id : null;
+  }
+
+  Future<void> _addExisting() async {
+    final personId = await showDialog<String>(
+      context: context,
+      builder: (context) => const _AddOwnerDialog(),
+    );
+
+    if (personId != null && personId.isNotEmpty && mounted) {
+      await _controller.addOwner(personId);
+    }
+  }
+
+  Future<void> _createNew() async {
+    final draft = await showDialog<_OwnerDraft>(
+      context: context,
+      builder: (context) => const _CreateOwnerDialog(),
+    );
+
+    if (draft != null && mounted) {
+      await _controller.createOwner(
+        name: draft.name,
+        email: draft.email,
+        password: draft.password,
+      );
+    }
+  }
+
+  /// AF-14e — the dialog closes and nothing is sent.
+  Future<void> _promote(Person user) async {
+    final confirmed = await showConfirm(
+      context: context,
+      title: 'Promote ${user.name}?',
+      message:
+          '${user.name} becomes a Scope Admin and a co-owner of this '
+          'scope, and stops being one of its users.',
+      confirmLabel: 'Promote',
+    );
+
+    if (confirmed && mounted) {
+      await _controller.promote(user.id);
+    }
+  }
+
+  Future<void> _remove(Person owner) async {
+    // AF-14f — removing your own ownership is a different warning, because the
+    // thing you lose is your own access.
+    final isSelf = owner.id == _signedInPersonId;
+
+    final confirmed = await showConfirm(
+      context: context,
+      title: isSelf ? 'Remove your own ownership?' : 'Remove ${owner.name}?',
+      message: isSelf
+          ? 'You will stop owning this scope and lose access to it. Another '
+                'owner would have to add you back.'
+          : '${owner.name} will stop owning this scope. Their account is not '
+                'deleted.',
+      confirmLabel: 'Remove',
+    );
+
+    if (confirmed && mounted) {
+      await _controller.removeOwner(owner.id);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(scopeOwnersControllerProvider(widget.scopeId));
+
+    return AppShell(
+      currentRoute: '/scopes',
+      title: const Text('Scope owners'),
+      actions: <Widget>[
+        IconButton(
+          tooltip: 'Back to the scope',
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.go('/scopes/${widget.scopeId}'),
+        ),
+      ],
+      body: switch (state) {
+        ScopeOwnersLoading() => const CollectionLoading(rows: 4),
+        ScopeOwnersUnavailable(:final failure) => CollectionFailed(
+          failure: failure,
+          onRetry: _controller.load,
+        ),
+        final ScopeOwnersLoaded loaded => _owners(loaded),
+      },
+    );
+  }
+
+  Widget _owners(ScopeOwnersLoaded state) {
+    final theme = Theme.of(context);
+
+    return ListView(
+      padding: const EdgeInsets.all(24),
+      children: <Widget>[
+        // AF-14a to AF-14d: whatever the API refused, in its own words.
+        if (state.failure case final failure?) ...<Widget>[
+          ErrorBanner(failure: failure),
+          const SizedBox(height: 16),
+        ],
+        // A Wrap rather than a Row: on a narrow window the heading and the two
+        // controls do not fit on one line, and an overflowing header hides the
+        // control that adds an owner.
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: <Widget>[
+            Text('Owners', style: theme.textTheme.titleLarge),
+            TextButton.icon(
+              onPressed: state.busy ? null : _addExisting,
+              icon: const Icon(Icons.person_add_alt),
+              label: const Text('Add existing'),
+            ),
+            FilledButton.icon(
+              onPressed: state.busy ? null : _createNew,
+              icon: const Icon(Icons.person_add),
+              label: const Text('Create owner'),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        if (state.owners.isEmpty)
+          const CollectionEmpty(
+            title: 'No owners recorded',
+            message: 'The API reports no owners for this scope.',
+            icon: Icons.shield_outlined,
+          )
+        else
+          Card(
+            child: Column(
+              children: <Widget>[
+                for (final owner in state.owners)
+                  ListTile(
+                    leading: const Icon(Icons.shield_outlined),
+                    title: Text(owner.name),
+                    subtitle: Text(owner.email),
+                    trailing: IconButton(
+                      tooltip: state.canRemove
+                          ? 'Remove owner'
+                          : 'A scope must keep at least one owner',
+                      icon: const Icon(Icons.person_remove_outlined),
+                      // AF-14a: the only owner cannot be removed.
+                      onPressed: (state.busy || !state.canRemove)
+                          ? null
+                          : () => _remove(owner),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        const SizedBox(height: 24),
+        Text('Promote a user', style: theme.textTheme.titleLarge),
+        const SizedBox(height: 4),
+        Text(
+          'A user of this scope can be promoted to Scope Admin, which makes '
+          'them a co-owner.',
+          style: theme.textTheme.bodyMedium,
+        ),
+        const SizedBox(height: 8),
+        if (state.promotable.isEmpty)
+          const CollectionEmpty(
+            title: 'Nobody to promote',
+            message: 'This scope has no users who are not already owners.',
+            icon: Icons.people_outline,
+          )
+        else
+          Card(
+            child: Column(
+              children: <Widget>[
+                for (final user in state.promotable)
+                  ListTile(
+                    leading: const Icon(Icons.person_outline),
+                    title: Text(user.name),
+                    subtitle: Text(user.email),
+                    trailing: TextButton(
+                      onPressed: state.busy ? null : () => _promote(user),
+                      child: const Text('Promote'),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+/// Names an existing Scope Admin to add.
+///
+/// As in UI-11, the API publishes no listing of Scope Admins outside a scope,
+/// so the identifier is typed and the API judges it (AF-14b, AF-14c).
+class _AddOwnerDialog extends StatefulWidget {
+  const _AddOwnerDialog();
+
+  @override
+  State<_AddOwnerDialog> createState() => _AddOwnerDialogState();
+}
+
+class _AddOwnerDialogState extends State<_AddOwnerDialog> {
+  final _personId = TextEditingController();
+
+  @override
+  void dispose() {
+    _personId.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => AlertDialog(
+    title: const Text('Add an existing Scope Admin'),
+    content: TextField(
+      controller: _personId,
+      autofocus: true,
+      decoration: const InputDecoration(
+        labelText: 'Person identifier',
+        helperText: 'The person id of an existing Scope Admin.',
+      ),
+      onChanged: (_) => setState(() {}),
+      onSubmitted: (value) => Navigator.of(context).pop(value.trim()),
+    ),
+    actions: <Widget>[
+      TextButton(
+        onPressed: () => Navigator.of(context).pop(),
+        child: const Text('Cancel'),
+      ),
+      FilledButton(
+        onPressed: _personId.text.trim().isEmpty
+            ? null
+            : () => Navigator.of(context).pop(_personId.text.trim()),
+        child: const Text('Add owner'),
+      ),
+    ],
+  );
+}
+
+/// What the create-a-co-owner dialog collects.
+class _OwnerDraft {
+  const _OwnerDraft({
+    required this.name,
+    required this.email,
+    required this.password,
+  });
+
+  final String name;
+  final String email;
+  final String password;
+}
+
+class _CreateOwnerDialog extends StatefulWidget {
+  const _CreateOwnerDialog();
+
+  @override
+  State<_CreateOwnerDialog> createState() => _CreateOwnerDialogState();
+}
+
+class _CreateOwnerDialogState extends State<_CreateOwnerDialog> {
+  final _formKey = GlobalKey<FormState>();
+  final _name = TextEditingController();
+  final _email = TextEditingController();
+  final _password = TextEditingController();
+
+  @override
+  void dispose() {
+    _name.dispose();
+    _email.dispose();
+    _password.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    // AF-14d: what the client can tell is wrong never reaches the API. What it
+    // cannot — a password the API's own rules reject — comes back as an error.
+    if (!(_formKey.currentState?.validate() ?? false)) {
+      return;
+    }
+
+    Navigator.of(context).pop(
+      _OwnerDraft(
+        name: _name.text.trim(),
+        email: _email.text.trim(),
+        password: _password.text,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) => AlertDialog(
+    title: const Text('Create a co-owner'),
+    content: Form(
+      key: _formKey,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          TextFormField(
+            controller: _name,
+            autofocus: true,
+            decoration: const InputDecoration(labelText: 'Name'),
+            validator: (value) =>
+                (value?.trim().isEmpty ?? true) ? 'Enter a name.' : null,
+          ),
+          const SizedBox(height: 12),
+          TextFormField(
+            controller: _email,
+            keyboardType: TextInputType.emailAddress,
+            decoration: const InputDecoration(labelText: 'Email'),
+            validator: (value) {
+              final email = value?.trim() ?? '';
+
+              if (email.isEmpty) {
+                return 'Enter an email address.';
+              }
+
+              return email.contains('@')
+                  ? null
+                  : 'Enter a valid email address.';
+            },
+          ),
+          const SizedBox(height: 12),
+          TextFormField(
+            controller: _password,
+            obscureText: true,
+            decoration: const InputDecoration(labelText: 'Password'),
+            validator: (value) =>
+                (value?.isEmpty ?? true) ? 'Enter a password.' : null,
+          ),
+        ],
+      ),
+    ),
+    actions: <Widget>[
+      TextButton(
+        onPressed: () => Navigator.of(context).pop(),
+        child: const Text('Cancel'),
+      ),
+      FilledButton(onPressed: _submit, child: const Text('Create')),
+    ],
+  );
+}

--- a/test/features/scopes/presentation/scope_owners_controller_test.dart
+++ b/test/features/scopes/presentation/scope_owners_controller_test.dart
@@ -1,0 +1,409 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdall_ui/core/network/envelope.dart';
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/features/auth/domain/session.dart';
+import 'package:heimdall_ui/features/persons/domain/person.dart';
+import 'package:heimdall_ui/features/persons/domain/person_repository.dart';
+import 'package:heimdall_ui/features/profile/presentation/profile_controller.dart';
+import 'package:heimdall_ui/features/scopes/presentation/scope_owners_controller.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockPersonRepository extends Mock implements PersonRepository {}
+
+const _ada = Person(
+  id: 'person-1',
+  name: 'Ada',
+  email: 'ada@example.com',
+  role: Role.scopeAdmin,
+);
+
+const _grace = Person(
+  id: 'person-2',
+  name: 'Grace',
+  email: 'grace@example.com',
+  role: Role.scopeAdmin,
+);
+
+const _user = Person(
+  id: 'person-3',
+  name: 'Alan',
+  email: 'alan@example.com',
+  role: Role.user,
+);
+
+Page<Person> _page(List<Person> items) => Page<Person>(
+  items: items,
+  pageNumber: 1,
+  pageSize: 20,
+  totalItems: items.length,
+  totalPages: 1,
+);
+
+void main() {
+  late _MockPersonRepository repository;
+  late ProviderContainer container;
+
+  ScopeOwnersController controllerUnderTest() {
+    container = ProviderContainer(
+      overrides: <Override>[
+        personRepositoryProvider.overrideWithValue(repository),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    return container.read(scopeOwnersControllerProvider('scope-1').notifier);
+  }
+
+  ScopeOwnersState currentState() =>
+      container.read(scopeOwnersControllerProvider('scope-1'));
+
+  void answerOwnersWith(Result<Page<Person>> result) {
+    when(
+      () => repository.listScopeOwners(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  void answerUsersWith(Result<Page<Person>> result) {
+    when(
+      () => repository.listScopePersons(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  setUp(() {
+    repository = _MockPersonRepository();
+    answerOwnersWith(Success<Page<Person>>(_page(<Person>[_ada, _grace])));
+    answerUsersWith(Success<Page<Person>>(_page(<Person>[_user])));
+  });
+
+  test('GivenAScope_WhenLoaded_ThenItsOwnersAreShown', () async {
+    // Given
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    final state = currentState() as ScopeOwnersLoaded;
+    expect(state.owners.map((owner) => owner.name), <String>['Ada', 'Grace']);
+  });
+
+  test('GivenAScope_WhenLoaded_ThenItsUsersAreOfferedForPromotion', () async {
+    // Given
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    final state = currentState() as ScopeOwnersLoaded;
+    expect(state.promotable.single.name, 'Alan');
+  });
+
+  // The users are not what this screen is about, so their listing failing does
+  // not take the owners down with it.
+  test('GivenAFailedUserListing_WhenLoaded_ThenTheOwnersStillShow', () async {
+    // Given
+    answerUsersWith(
+      const FailureResult<Page<Person>>(
+        Failure(kind: FailureKind.forbidden, errors: <String>[]),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    final state = currentState() as ScopeOwnersLoaded;
+    expect(state.owners, hasLength(2));
+    expect(state.promotable, isEmpty);
+  });
+
+  test('GivenAFailedOwnerListing_WhenLoaded_ThenStateIsUnavailable', () async {
+    // Given
+    answerOwnersWith(
+      const FailureResult<Page<Person>>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    expect(currentState(), isA<ScopeOwnersUnavailable>());
+  });
+
+  test('GivenAScopeAdminId_WhenAdded_ThenTheApiIsAsked', () async {
+    // Given
+    when(
+      () => repository.addScopeOwner(
+        scopeId: any(named: 'scopeId'),
+        personId: any(named: 'personId'),
+      ),
+    ).thenAnswer((_) async => const Success<void>(null));
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.addOwner('person-9');
+
+    // Then
+    verify(
+      () => repository.addScopeOwner(scopeId: 'scope-1', personId: 'person-9'),
+    ).called(1);
+  });
+
+  // AF-14b — the person is not a Scope Admin.
+  test('GivenARejectedOwner_WhenAdded_ThenApiErrorsAreKept', () async {
+    // Given
+    when(
+      () => repository.addScopeOwner(
+        scopeId: any(named: 'scopeId'),
+        personId: any(named: 'personId'),
+      ),
+    ).thenAnswer(
+      (_) async => const FailureResult<void>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['person-9 is not a Scope Admin.'],
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.addOwner('person-9');
+
+    // Then
+    final state = currentState() as ScopeOwnersLoaded;
+    expect(state.failure?.errors, <String>['person-9 is not a Scope Admin.']);
+  });
+
+  // AF-14c — someone already owning the scope is not offered again.
+  test(
+    'GivenAnExistingOwner_WhenPromotionOffered_ThenTheyAreExcluded',
+    () async {
+      // Given
+      answerUsersWith(Success<Page<Person>>(_page(<Person>[_ada, _user])));
+      final controller = controllerUnderTest();
+
+      // When
+      await controller.load();
+
+      // Then
+      final state = currentState() as ScopeOwnersLoaded;
+      expect(state.promotable.map((person) => person.id), <String>['person-3']);
+    },
+  );
+
+  // AF-14a — a scope with one owner is not offered the removal.
+  test('GivenASingleOwner_WhenLoaded_ThenRemovalIsNotOffered', () async {
+    // Given
+    answerOwnersWith(Success<Page<Person>>(_page(<Person>[_ada])));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    expect((currentState() as ScopeOwnersLoaded).canRemove, isFalse);
+  });
+
+  test('GivenTwoOwners_WhenLoaded_ThenRemovalIsOffered', () async {
+    // Given
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    expect((currentState() as ScopeOwnersLoaded).canRemove, isTrue);
+  });
+
+  test('GivenAnOwner_WhenRemoved_ThenTheApiIsAsked', () async {
+    // Given
+    when(
+      () => repository.removeScopeOwner(
+        scopeId: any(named: 'scopeId'),
+        personId: any(named: 'personId'),
+      ),
+    ).thenAnswer((_) async => const Success<void>(null));
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.removeOwner('person-2');
+
+    // Then
+    verify(
+      () =>
+          repository.removeScopeOwner(scopeId: 'scope-1', personId: 'person-2'),
+    ).called(1);
+  });
+
+  // AF-14a — the API refuses to leave a scope without an owner.
+  test('GivenTheLastOwner_WhenRemovalRefused_ThenApiErrorsAreKept', () async {
+    // Given
+    when(
+      () => repository.removeScopeOwner(
+        scopeId: any(named: 'scopeId'),
+        personId: any(named: 'personId'),
+      ),
+    ).thenAnswer(
+      (_) async => const FailureResult<void>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['A scope must keep at least one owner.'],
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.removeOwner('person-1');
+
+    // Then
+    final state = currentState() as ScopeOwnersLoaded;
+    expect(state.failure?.errors, <String>[
+      'A scope must keep at least one owner.',
+    ]);
+  });
+
+  test('GivenAUser_WhenPromoted_ThenTheApiIsAsked', () async {
+    // Given
+    when(
+      () => repository.promoteScopeUser(
+        scopeId: any(named: 'scopeId'),
+        personId: any(named: 'personId'),
+      ),
+    ).thenAnswer((_) async => const Success<void>(null));
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.promote('person-3');
+
+    // Then
+    verify(
+      () =>
+          repository.promoteScopeUser(scopeId: 'scope-1', personId: 'person-3'),
+    ).called(1);
+  });
+
+  test('GivenADraftOwner_WhenCreated_ThenTheValuesAreSent', () async {
+    // Given
+    when(
+      () => repository.createScopeOwner(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        password: any(named: 'password'),
+      ),
+    ).thenAnswer((_) async => const Success<Person>(_grace));
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.createOwner(
+      name: 'Grace',
+      email: 'grace@example.com',
+      password: 'secret',
+    );
+
+    // Then
+    verify(
+      () => repository.createScopeOwner(
+        scopeId: 'scope-1',
+        name: 'Grace',
+        email: 'grace@example.com',
+        password: 'secret',
+      ),
+    ).called(1);
+  });
+
+  // AF-14d — the API's own rejection of a name, address, or password.
+  test('GivenARejectedDraft_WhenCreated_ThenApiErrorsAreKept', () async {
+    // Given
+    when(
+      () => repository.createScopeOwner(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        password: any(named: 'password'),
+      ),
+    ).thenAnswer(
+      (_) async => const FailureResult<Person>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['That email address is already taken.'],
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.createOwner(
+      name: 'Grace',
+      email: 'taken@example.com',
+      password: 'secret',
+    );
+
+    // Then
+    final state = currentState() as ScopeOwnersLoaded;
+    expect(state.failure?.errors, <String>[
+      'That email address is already taken.',
+    ]);
+  });
+
+  // What is on screen after a command is what the API last confirmed, not a
+  // guess about what the command did.
+  test(
+    'GivenASuccessfulCommand_WhenItCompletes_ThenTheOwnersAreReread',
+    () async {
+      // Given
+      when(
+        () => repository.addScopeOwner(
+          scopeId: any(named: 'scopeId'),
+          personId: any(named: 'personId'),
+        ),
+      ).thenAnswer((_) async => const Success<void>(null));
+      final controller = controllerUnderTest();
+      await controller.load();
+
+      // When
+      await controller.addOwner('person-9');
+
+      // Then
+      verify(
+        () => repository.listScopeOwners(
+          scopeId: 'scope-1',
+          name: any(named: 'name'),
+          email: any(named: 'email'),
+          includeDeleted: any(named: 'includeDeleted'),
+          pageNumber: any(named: 'pageNumber'),
+          pageSize: any(named: 'pageSize'),
+        ),
+      ).called(2);
+    },
+  );
+}

--- a/test/features/scopes/presentation/scope_owners_screen_test.dart
+++ b/test/features/scopes/presentation/scope_owners_screen_test.dart
@@ -1,0 +1,583 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:heimdall_ui/app/theme.dart';
+import 'package:heimdall_ui/core/network/envelope.dart' as envelope;
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/core/storage/token_store.dart';
+import 'package:heimdall_ui/features/auth/domain/session.dart';
+import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
+import 'package:heimdall_ui/features/persons/domain/person.dart';
+import 'package:heimdall_ui/features/persons/domain/person_repository.dart';
+import 'package:heimdall_ui/features/profile/presentation/profile_controller.dart';
+import 'package:heimdall_ui/features/scopes/presentation/scope_owners_screen.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockPersonRepository extends Mock implements PersonRepository {}
+
+/// A token naming the signed-in person, which AF-14f compares against.
+String _jwt({String sub = 'person-9'}) {
+  final payload = base64Url.encode(
+    utf8.encode(
+      jsonEncode(<String, dynamic>{
+        'sub': sub,
+        'email': 'admin@example.com',
+        'role': 1,
+      }),
+    ),
+  );
+
+  return 'header.$payload.signature';
+}
+
+const _ada = Person(
+  id: 'person-1',
+  name: 'Ada',
+  email: 'ada@example.com',
+  role: Role.scopeAdmin,
+);
+
+const _grace = Person(
+  id: 'person-2',
+  name: 'Grace',
+  email: 'grace@example.com',
+  role: Role.scopeAdmin,
+);
+
+const _alan = Person(
+  id: 'person-3',
+  name: 'Alan',
+  email: 'alan@example.com',
+  role: Role.user,
+);
+
+envelope.Page<Person> _page(List<Person> items) => envelope.Page<Person>(
+  items: items,
+  pageNumber: 1,
+  pageSize: 20,
+  totalItems: items.length,
+  totalPages: 1,
+);
+
+const Size _compact = Size(400, 900);
+const Size _medium = Size(800, 900);
+const Size _expanded = Size(1400, 900);
+
+void main() {
+  late _MockPersonRepository repository;
+  late InMemoryTokenStore store;
+  late ProviderContainer container;
+  late GoRouter router;
+
+  Future<void> pump(
+    WidgetTester tester, {
+    Size size = _expanded,
+    ThemeData? theme,
+    String signedInAs = 'person-9',
+  }) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await store.write(
+      AuthToken(
+        value: _jwt(sub: signedInAs),
+        expiresAt: DateTime.utc(2030),
+      ),
+    );
+
+    container = ProviderContainer(
+      overrides: <Override>[
+        personRepositoryProvider.overrideWithValue(repository),
+        tokenStoreProvider.overrideWithValue(store),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(sessionControllerProvider.notifier).restore();
+
+    router = GoRouter(
+      initialLocation: '/scopes/scope-1/owners',
+      routes: <RouteBase>[
+        GoRoute(
+          path: '/scopes/:scopeId',
+          builder: (context, state) => const Scaffold(body: Text('detail')),
+        ),
+        GoRoute(
+          path: '/scopes/:scopeId/owners',
+          builder: (context, state) =>
+              ScopeOwnersScreen(scopeId: state.pathParameters['scopeId']!),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(
+          theme: theme ?? buildLightTheme(),
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  void answerOwnersWith(Result<envelope.Page<Person>> result) {
+    when(
+      () => repository.listScopeOwners(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  void answerUsersWith(Result<envelope.Page<Person>> result) {
+    when(
+      () => repository.listScopePersons(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    repository = _MockPersonRepository();
+    store = InMemoryTokenStore();
+    answerOwnersWith(
+      Success<envelope.Page<Person>>(_page(<Person>[_ada, _grace])),
+    );
+    answerUsersWith(Success<envelope.Page<Person>>(_page(<Person>[_alan])));
+    when(
+      () => repository.addScopeOwner(
+        scopeId: any(named: 'scopeId'),
+        personId: any(named: 'personId'),
+      ),
+    ).thenAnswer((_) async => const Success<void>(null));
+    when(
+      () => repository.removeScopeOwner(
+        scopeId: any(named: 'scopeId'),
+        personId: any(named: 'personId'),
+      ),
+    ).thenAnswer((_) async => const Success<void>(null));
+    when(
+      () => repository.promoteScopeUser(
+        scopeId: any(named: 'scopeId'),
+        personId: any(named: 'personId'),
+      ),
+    ).thenAnswer((_) async => const Success<void>(null));
+    when(
+      () => repository.createScopeOwner(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        password: any(named: 'password'),
+      ),
+    ).thenAnswer((_) async => const Success<Person>(_grace));
+  });
+
+  testWidgets('GivenAScope_WhenOpened_ThenItsOwnersAreListed', (tester) async {
+    // Given / When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Ada'), findsOneWidget);
+    expect(find.text('Grace'), findsOneWidget);
+  });
+
+  testWidgets('GivenAScope_WhenOpened_ThenItsUsersAreOfferedForPromotion', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Alan'), findsOneWidget);
+    expect(find.widgetWithText(TextButton, 'Promote'), findsOneWidget);
+  });
+
+  testWidgets('GivenAnIdentifier_WhenAdded_ThenTheApiIsAsked', (tester) async {
+    // Given
+    await pump(tester);
+    await tester.tap(find.widgetWithText(TextButton, 'Add existing'));
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.enterText(find.byType(TextField), 'person-7');
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, 'Add owner'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => repository.addScopeOwner(scopeId: 'scope-1', personId: 'person-7'),
+    ).called(1);
+  });
+
+  testWidgets('GivenTheAddDialog_WhenCancelled_ThenNothingIsSent', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+    await tester.tap(find.widgetWithText(TextButton, 'Add existing'));
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verifyNever(
+      () => repository.addScopeOwner(
+        scopeId: any(named: 'scopeId'),
+        personId: any(named: 'personId'),
+      ),
+    );
+  });
+
+  // AF-14b — the API refuses a person who is not a Scope Admin.
+  testWidgets('GivenARejectedOwner_WhenAdded_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    when(
+      () => repository.addScopeOwner(
+        scopeId: any(named: 'scopeId'),
+        personId: any(named: 'personId'),
+      ),
+    ).thenAnswer(
+      (_) async => const FailureResult<void>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['person-7 is not a Scope Admin.'],
+        ),
+      ),
+    );
+    await pump(tester);
+    await tester.tap(find.widgetWithText(TextButton, 'Add existing'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField), 'person-7');
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Add owner'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('person-7 is not a Scope Admin.'), findsOneWidget);
+  });
+
+  // AF-14a — a scope with one owner is not offered the removal.
+  testWidgets('GivenASingleOwner_WhenRendered_ThenRemovalIsDisabled', (
+    tester,
+  ) async {
+    // Given
+    answerOwnersWith(Success<envelope.Page<Person>>(_page(<Person>[_ada])));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(
+      tester
+          .widget<IconButton>(
+            find.ancestor(
+              of: find.byIcon(Icons.person_remove_outlined),
+              matching: find.byType(IconButton),
+            ),
+          )
+          .onPressed,
+      isNull,
+    );
+  });
+
+  testWidgets('GivenAnOwner_WhenRemovalConfirmed_ThenTheApiIsAsked', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+    await tester.tap(find.byTooltip('Remove owner').first);
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Remove'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () =>
+          repository.removeScopeOwner(scopeId: 'scope-1', personId: 'person-1'),
+    ).called(1);
+  });
+
+  testWidgets('GivenTheRemoveDialog_WhenCancelled_ThenNothingIsSent', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+    await tester.tap(find.byTooltip('Remove owner').first);
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verifyNever(
+      () => repository.removeScopeOwner(
+        scopeId: any(named: 'scopeId'),
+        personId: any(named: 'personId'),
+      ),
+    );
+  });
+
+  // AF-14f — removing your own ownership is warned about as your own loss.
+  testWidgets('GivenYourOwnOwnership_WhenRemoved_ThenTheLossIsExplained', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester, signedInAs: 'person-1');
+
+    // When
+    await tester.tap(find.byTooltip('Remove owner').first);
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('Remove your own ownership?'), findsOneWidget);
+  });
+
+  testWidgets('GivenAnotherOwner_WhenRemoved_ThenTheyAreNamed', (tester) async {
+    // Given
+    await pump(tester, signedInAs: 'person-9');
+
+    // When
+    await tester.tap(find.byTooltip('Remove owner').first);
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('Remove Ada?'), findsOneWidget);
+  });
+
+  testWidgets('GivenAUser_WhenPromotionConfirmed_ThenTheApiIsAsked', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+    await tester.tap(find.widgetWithText(TextButton, 'Promote'));
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Promote'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () =>
+          repository.promoteScopeUser(scopeId: 'scope-1', personId: 'person-3'),
+    ).called(1);
+  });
+
+  // AF-14e — the dialog closes and nothing is sent.
+  testWidgets('GivenThePromotionDialog_WhenCancelled_ThenNothingIsSent', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+    await tester.tap(find.widgetWithText(TextButton, 'Promote'));
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verifyNever(
+      () => repository.promoteScopeUser(
+        scopeId: any(named: 'scopeId'),
+        personId: any(named: 'personId'),
+      ),
+    );
+  });
+
+  testWidgets('GivenTheCreateDialog_WhenCompleted_ThenTheOwnerIsCreated', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+    await tester.tap(find.widgetWithText(FilledButton, 'Create owner'));
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.enterText(find.widgetWithText(TextFormField, 'Name'), 'Grace');
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Email'),
+      'grace@example.com',
+    );
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Password'),
+      'secret',
+    );
+    await tester.tap(find.widgetWithText(FilledButton, 'Create'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => repository.createScopeOwner(
+        scopeId: 'scope-1',
+        name: 'Grace',
+        email: 'grace@example.com',
+        password: 'secret',
+      ),
+    ).called(1);
+  });
+
+  // AF-14d — what the client can tell is wrong never reaches the API.
+  testWidgets('GivenAnEmptyName_WhenCreated_ThenNoRequestIsMade', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+    await tester.tap(find.widgetWithText(FilledButton, 'Create owner'));
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verifyNever(
+      () => repository.createScopeOwner(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        password: any(named: 'password'),
+      ),
+    );
+  });
+
+  testWidgets('GivenAMalformedEmail_WhenCreated_ThenTheFieldSaysSo', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+    await tester.tap(find.widgetWithText(FilledButton, 'Create owner'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.widgetWithText(TextFormField, 'Name'), 'Grace');
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Email'),
+      'not-an-address',
+    );
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Password'),
+      'secret',
+    );
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('Enter a valid email address.'), findsOneWidget);
+  });
+
+  // AF-14d — and what only the API can tell comes back as its own words.
+  testWidgets('GivenARejectedDraft_WhenCreated_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    when(
+      () => repository.createScopeOwner(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        password: any(named: 'password'),
+      ),
+    ).thenAnswer(
+      (_) async => const FailureResult<Person>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['That email address is already taken.'],
+        ),
+      ),
+    );
+    await pump(tester);
+    await tester.tap(find.widgetWithText(FilledButton, 'Create owner'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.widgetWithText(TextFormField, 'Name'), 'Grace');
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Email'),
+      'taken@example.com',
+    );
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Password'),
+      'secret',
+    );
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('That email address is already taken.'), findsOneWidget);
+  });
+
+  testWidgets('GivenAFailedListing_WhenOpened_ThenARetryIsOffered', (
+    tester,
+  ) async {
+    // Given
+    answerOwnersWith(
+      const FailureResult<envelope.Page<Person>>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.widgetWithText(TextButton, 'Retry'), findsOneWidget);
+  });
+
+  testWidgets('GivenACompactWindow_WhenRendered_ThenTheOwnersAreListed', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, size: _compact);
+
+    // Then
+    expect(find.text('Ada'), findsOneWidget);
+  });
+
+  testWidgets('GivenAMediumWindow_WhenRendered_ThenTheOwnersAreListed', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, size: _medium);
+
+    // Then
+    expect(find.text('Ada'), findsOneWidget);
+  });
+
+  testWidgets('GivenTheDarkTheme_WhenRendered_ThenTheOwnersAreStillListed', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, theme: buildDarkTheme());
+
+    // Then
+    expect(find.text('Ada'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #14

Implements UI-14 — `/scopes/:scopeId/owners`, listing a scope's owners (FR-SC-08) and carrying the four ways that list changes: adding an existing Scope Admin (FR-SC-09), creating a brand-new one as a co-owner (FR-SC-10), promoting a user of the scope and removing an owner (FR-SC-11).

## Flows

| Flow | How it is handled |
| --- | --- |
| Main | Owners are listed; the scope's users are read alongside, which is what the promotion offers. |
| AF-14a | The remove control is disabled at a single owner; a refusal is shown if the API refuses anyway. |
| AF-14b | A person who is not a Scope Admin comes back as the API's own strings. |
| AF-14c | A duplicate is refused by the API, and existing owners are excluded from the promotion list. |
| AF-14d | Name and address are validated here; whatever only the API can judge is shown as returned. |
| AF-14e | Closing the promotion dialog sends nothing. |
| AF-14f | Removing your own ownership is warned about as your own loss of access. |

Every command re-reads the owners rather than editing the list in place, so what is on screen is what the API last confirmed rather than a guess about what the command did.

The scope's user listing is read alongside the owners but is not what the screen is about: if it fails, the owners still render and the promotion is simply not offered.

As in UI-11, "add an existing Scope Admin" takes a person identifier rather than a picker — the API publishes no listing of Scope Admins outside a scope.

## Verification

`dart format --set-exit-if-changed .`, `flutter analyze`, and `flutter test` all pass — **495 tests**, 35 of them new. No presentation file imports `package:heimdall_api_client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)