### PR TITLE
feat(ui-15): toggle Google Sign-In for a scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ the board is where an item's status changes as it moves.
 | UI-12: View and update a scope | ✅ | [#12](https://github.com/artur-rios/heimdall-ui/issues/12) |
 | UI-13: Delete a scope, logically and permanently | ✅ | [#13](https://github.com/artur-rios/heimdall-ui/issues/13) |
 | UI-14: Manage scope owners | ✅ | [#14](https://github.com/artur-rios/heimdall-ui/issues/14) |
-| UI-15: Toggle Google Sign-In for a scope | ⬜ | [#15](https://github.com/artur-rios/heimdall-ui/issues/15) |
+| UI-15: Toggle Google Sign-In for a scope | ✅ | [#15](https://github.com/artur-rios/heimdall-ui/issues/15) |
 
 ### Person Management
 

--- a/lib/features/google_users/data/google_user_repository_impl.dart
+++ b/lib/features/google_users/data/google_user_repository_impl.dart
@@ -1,0 +1,39 @@
+import 'package:dio/dio.dart';
+import 'package:heimdall_api_client/export.dart';
+
+import '../../../core/network/envelope.dart';
+import '../../../core/result/result.dart';
+import '../domain/google_user_repository.dart';
+
+/// [GoogleUserRepository] over the generated client.
+class ApiGoogleUserRepository implements GoogleUserRepository {
+  const ApiGoogleUserRepository(this._client);
+
+  final GoogleUserClient _client;
+
+  @override
+  Future<Result<int>> countIn(String scopeId) async {
+    try {
+      final response = await _client.googleUserList(
+        scopeId: scopeId,
+        pageNumber: 1,
+        // One item is enough: the count comes from the envelope's own total,
+        // not from how many rows came back.
+        pageSize: 1,
+      );
+
+      if (response.success != true) {
+        return FailureResult<int>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: response.errors ?? const <String>[],
+          ),
+        );
+      }
+
+      return Success<int>(response.totalItems ?? response.data?.length ?? 0);
+    } on DioException catch (error) {
+      return FailureResult<int>(failureFromDioException(error));
+    }
+  }
+}

--- a/lib/features/google_users/domain/google_user_repository.dart
+++ b/lib/features/google_users/domain/google_user_repository.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/result/result.dart';
+
+/// The Google User operations the interface depends on.
+///
+/// UI-15 asks it one question — how many a scope holds — because disabling
+/// Google Sign-In is a different warning when there are accounts that will
+/// stop working. UI-28 and UI-29 extend it with the listing and the deletions.
+abstract interface class GoogleUserRepository {
+  /// How many Google Users the scope holds.
+  ///
+  /// Reads one page of one item and takes the API's own total, so the answer
+  /// costs the same whether the scope holds none or thousands.
+  Future<Result<int>> countIn(String scopeId);
+}
+
+/// Overridden at start-up with the client-backed implementation, and in tests
+/// with a fake.
+final Provider<GoogleUserRepository> googleUserRepositoryProvider =
+    Provider<GoogleUserRepository>(
+      (ref) => throw UnimplementedError(
+        'googleUserRepositoryProvider must be overridden',
+      ),
+    );

--- a/lib/features/scopes/data/scope_repository_impl.dart
+++ b/lib/features/scopes/data/scope_repository_impl.dart
@@ -189,6 +189,49 @@ class ApiScopeRepository implements ScopeRepository {
   }
 
   @override
+  Future<Result<Scope>> setGoogleSignIn({
+    required String id,
+    required bool enabled,
+  }) async {
+    try {
+      final response = await _client.scopeSetGoogleSignIn(
+        id: id,
+        body: SetGoogleSignInCommand(enabled: enabled),
+      );
+
+      if (response.success != true) {
+        // AF-15a: the API refused, and its own strings say why.
+        return FailureResult<Scope>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: response.errors ?? const <String>[],
+          ),
+        );
+      }
+
+      final data = response.data;
+
+      if (data == null) {
+        return const FailureResult<Scope>(_incompleteResponse);
+      }
+
+      return Success<Scope>(
+        Scope(
+          id: data.id ?? id,
+          name: data.name ?? '',
+          description: data.description ?? '',
+          googleSignInEnabled: data.googleSignInEnabled ?? enabled,
+          ownerIds: data.ownerIds ?? const <String>[],
+          createdAt: data.createdAt,
+          updatedAt: data.updatedAt,
+        ),
+      );
+    } on DioException catch (error) {
+      return FailureResult<Scope>(failureFromDioException(error));
+    }
+  }
+
+  @override
   Future<Result<void>> delete(String id) async {
     try {
       final response = await _client.scopeDelete(id: id);

--- a/lib/features/scopes/domain/scope_repository.dart
+++ b/lib/features/scopes/domain/scope_repository.dart
@@ -44,6 +44,15 @@ abstract interface class ScopeRepository {
     required String description,
   });
 
+  /// Turns Google Sign-In on or off for a scope.
+  ///
+  /// Returns the scope as the API now holds it, so the control settles on the
+  /// confirmed state rather than on the one it was moved to.
+  Future<Result<Scope>> setGoogleSignIn({
+    required String id,
+    required bool enabled,
+  });
+
   /// Logically deletes a scope. The record is kept and the API can restore it.
   Future<Result<void>> delete(String id);
 

--- a/lib/features/scopes/presentation/scope_detail_controller.dart
+++ b/lib/features/scopes/presentation/scope_detail_controller.dart
@@ -45,6 +45,8 @@ final class ScopeDetailLoaded extends ScopeDetailState {
     this.saved = false,
     this.deleting = false,
     this.deleteFailure,
+    this.togglingGoogleSignIn = false,
+    this.googleSignInFailure,
   });
 
   final Scope scope;
@@ -59,6 +61,13 @@ final class ScopeDetailLoaded extends ScopeDetailState {
   /// AF-13b — the API refused to delete, and the scope stays open.
   final Failure? deleteFailure;
 
+  /// AF-15c — the Google Sign-In request is outstanding, so the control is
+  /// disabled and cannot be toggled twice.
+  final bool togglingGoogleSignIn;
+
+  /// AF-15a — the API refused the toggle, and the control went back.
+  final Failure? googleSignInFailure;
+
   /// AF-12d — a logically deleted scope is shown, but nothing about it may be
   /// changed from here.
   bool get isReadOnly => scope.isDeleted;
@@ -72,6 +81,9 @@ final class ScopeDetailLoaded extends ScopeDetailState {
     bool? deleting,
     Failure? deleteFailure,
     bool clearDeleteFailure = false,
+    bool? togglingGoogleSignIn,
+    Failure? googleSignInFailure,
+    bool clearGoogleSignInFailure = false,
   }) => ScopeDetailLoaded(
     scope ?? this.scope,
     saving: saving ?? this.saving,
@@ -81,6 +93,10 @@ final class ScopeDetailLoaded extends ScopeDetailState {
     deleteFailure: clearDeleteFailure
         ? null
         : (deleteFailure ?? this.deleteFailure),
+    togglingGoogleSignIn: togglingGoogleSignIn ?? this.togglingGoogleSignIn,
+    googleSignInFailure: clearGoogleSignInFailure
+        ? null
+        : (googleSignInFailure ?? this.googleSignInFailure),
   );
 }
 
@@ -153,6 +169,39 @@ class ScopeDetailController extends FamilyNotifier<ScopeDetailState, String> {
     if (state case final ScopeDetailLoaded loaded) {
       state = loaded.copyWith(saved: false);
     }
+  }
+
+  /// UI-15 — turns Google Sign-In on or off.
+  ///
+  /// The control settles on what the API confirmed, not on what it was moved
+  /// to: a refusal leaves the scope exactly as the API still holds it
+  /// (AF-15a), and the request in flight disables the control (AF-15c).
+  Future<void> setGoogleSignIn(bool enabled) async {
+    final current = state;
+
+    if (current is! ScopeDetailLoaded ||
+        current.togglingGoogleSignIn ||
+        current.isReadOnly) {
+      return;
+    }
+
+    state = current.copyWith(
+      togglingGoogleSignIn: true,
+      clearGoogleSignInFailure: true,
+    );
+
+    final result = await ref
+        .read(scopeRepositoryProvider)
+        .setGoogleSignIn(id: arg, enabled: enabled);
+
+    state = result.fold(
+      onSuccess: (scope) =>
+          current.copyWith(scope: scope, togglingGoogleSignIn: false),
+      onFailure: (failure) => current.copyWith(
+        togglingGoogleSignIn: false,
+        googleSignInFailure: failure,
+      ),
+    );
   }
 
   /// Logically deletes the scope. The record is kept and the API can restore

--- a/lib/features/scopes/presentation/scope_detail_screen.dart
+++ b/lib/features/scopes/presentation/scope_detail_screen.dart
@@ -9,6 +9,7 @@ import '../../../shared/widgets/confirm_dialog.dart';
 import '../../../shared/widgets/failure_banner.dart';
 import '../../auth/domain/session.dart';
 import '../../auth/presentation/session_controller.dart';
+import '../../google_users/domain/google_user_repository.dart';
 import '../domain/scope.dart';
 import 'scope_detail_controller.dart';
 import 'scope_list_controller.dart';
@@ -66,6 +67,49 @@ class _ScopeDetailScreenState extends ConsumerState<ScopeDetailScreen> {
   bool _differsFrom(Scope scope) =>
       _name.text.trim() != scope.name ||
       _description.text.trim() != scope.description;
+
+  /// UI-15 — turns Google Sign-In on or off.
+  ///
+  /// AF-15b: switching it off is explained before anything is sent, because
+  /// the Google Users already in the scope stop being able to sign in. How
+  /// many there are is read first so the warning can say; a count that cannot
+  /// be read warns anyway rather than staying quiet about it.
+  Future<void> _toggleGoogleSignIn(bool enabled) async {
+    if (!enabled) {
+      final count = await ref
+          .read(googleUserRepositoryProvider)
+          .countIn(widget.scopeId);
+      final present = count.valueOrNull;
+
+      if (!mounted) {
+        return;
+      }
+
+      if (present == null || present > 0) {
+        final confirmed = await showConfirm(
+          context: context,
+          title: 'Turn Google Sign-In off?',
+          message: present == null
+              ? 'Any Google accounts already in this scope will no longer be '
+                    'able to sign in.'
+              : present == 1
+              ? 'The 1 Google account already in this scope will no longer be '
+                    'able to sign in.'
+              : 'The $present Google accounts already in this scope will no '
+                    'longer be able to sign in.',
+          confirmLabel: 'Turn off',
+        );
+
+        if (!confirmed || !mounted) {
+          return;
+        }
+      }
+    }
+
+    await ref
+        .read(scopeDetailControllerProvider(widget.scopeId).notifier)
+        .setGoogleSignIn(enabled);
+  }
 
   /// AF-13e — only a System Admin deletes a scope.
   bool get _maySeeDeletion {
@@ -266,9 +310,30 @@ class _ScopeDetailScreenState extends ConsumerState<ScopeDetailScreen> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
-                      Text('Google Sign-In', style: theme.textTheme.labelLarge),
-                      const SizedBox(height: 4),
-                      Text(scope.googleSignInEnabled ? 'On' : 'Off'),
+                      // UI-15 — the control reflects the confirmed state, and
+                      // a refusal leaves it where the API still has it.
+                      SwitchListTile(
+                        contentPadding: EdgeInsets.zero,
+                        title: const Text('Google Sign-In'),
+                        subtitle: Text(
+                          scope.googleSignInEnabled
+                              ? 'People may sign in to this scope with Google.'
+                              : 'Google sign-in is off for this scope.',
+                        ),
+                        value: scope.googleSignInEnabled,
+                        // AF-15c: disabled while the request is outstanding,
+                        // so it cannot be toggled twice.
+                        onChanged:
+                            (state.togglingGoogleSignIn || state.isReadOnly)
+                            ? null
+                            : _toggleGoogleSignIn,
+                      ),
+                      // AF-15a: the API refused; its own strings say why.
+                      if (state.googleSignInFailure
+                          case final refusal?) ...<Widget>[
+                        const SizedBox(height: 8),
+                        ErrorBanner(failure: refusal),
+                      ],
                       const SizedBox(height: 16),
                       Text('Owners', style: theme.textTheme.labelLarge),
                       const SizedBox(height: 4),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,8 @@ import 'core/storage/token_store.dart';
 import 'features/auth/data/auth_repository_impl.dart';
 import 'features/auth/data/google_sign_in_gateway_impl.dart';
 import 'features/auth/presentation/session_controller.dart';
+import 'features/google_users/data/google_user_repository_impl.dart';
+import 'features/google_users/domain/google_user_repository.dart';
 import 'features/persons/data/person_repository_impl.dart';
 import 'features/profile/presentation/profile_controller.dart';
 import 'features/scopes/data/scope_repository_impl.dart';
@@ -41,6 +43,10 @@ void main() {
         ),
         personRepositoryProvider.overrideWith(
           (ref) => ApiPersonRepository(PersonClient(ref.watch(dioProvider))),
+        ),
+        googleUserRepositoryProvider.overrideWith(
+          (ref) =>
+              ApiGoogleUserRepository(GoogleUserClient(ref.watch(dioProvider))),
         ),
         scopeRepositoryProvider.overrideWith(
           (ref) => ApiScopeRepository(ScopeClient(ref.watch(dioProvider))),

--- a/test/features/google_users/data/google_user_repository_impl_test.dart
+++ b/test/features/google_users/data/google_user_repository_impl_test.dart
@@ -1,0 +1,167 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdall_api_client/export.dart';
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/features/google_users/data/google_user_repository_impl.dart';
+
+void main() {
+  late Dio dio;
+  late _StubAdapter adapter;
+
+  ApiGoogleUserRepository repositoryAnswering(_Answer answer) {
+    adapter = _StubAdapter(answer);
+    dio.httpClientAdapter = adapter;
+
+    return ApiGoogleUserRepository(GoogleUserClient(dio));
+  }
+
+  setUp(() {
+    dio = Dio(BaseOptions(baseUrl: 'https://example.invalid'));
+  });
+
+  test(
+    'GivenAScopeWithGoogleUsers_WhenCounted_ThenTheTotalIsReturned',
+    () async {
+      // Given
+      final repository = repositoryAnswering(
+        const _Answer(
+          status: 200,
+          body: <String, dynamic>{
+            'success': true,
+            'errors': <String>[],
+            'data': <Map<String, dynamic>>[
+              <String, dynamic>{'id': 'google-1'},
+            ],
+            'totalItems': 12,
+            'totalPages': 12,
+          },
+        ),
+      );
+
+      // When
+      final result = await repository.countIn('scope-1');
+
+      // Then
+      expect(result.valueOrNull, 12);
+    },
+  );
+
+  // The count is the envelope's own total, not how many rows came back.
+  test('GivenAScopeWithGoogleUsers_WhenCounted_ThenOneRowIsAskedFor', () async {
+    // Given
+    final repository = repositoryAnswering(
+      const _Answer(
+        status: 200,
+        body: <String, dynamic>{
+          'success': true,
+          'errors': <String>[],
+          'data': <Map<String, dynamic>>[],
+          'totalItems': 12,
+        },
+      ),
+    );
+
+    // When
+    await repository.countIn('scope-1');
+
+    // Then
+    expect(adapter.queries.single, containsPair('PageSize', 1));
+  });
+
+  test('GivenAScopeWithNoGoogleUsers_WhenCounted_ThenZeroIsReturned', () async {
+    // Given
+    final repository = repositoryAnswering(
+      const _Answer(
+        status: 200,
+        body: <String, dynamic>{
+          'success': true,
+          'errors': <String>[],
+          'data': <Map<String, dynamic>>[],
+          'totalItems': 0,
+        },
+      ),
+    );
+
+    // When
+    final result = await repository.countIn('scope-1');
+
+    // Then
+    expect(result.valueOrNull, 0);
+  });
+
+  test('GivenARefusedListing_WhenCounted_ThenApiErrorsAreReturned', () async {
+    // Given
+    final repository = repositoryAnswering(
+      const _Answer(
+        status: 200,
+        body: <String, dynamic>{
+          'success': false,
+          'errors': <String>['That scope is not yours.'],
+        },
+      ),
+    );
+
+    // When
+    final result = await repository.countIn('scope-1');
+
+    // Then
+    expect(result.failureOrNull?.errors, <String>['That scope is not yours.']);
+  });
+
+  test('GivenNoConnection_WhenCounted_ThenNetworkFailureIsReturned', () async {
+    // Given
+    final repository = repositoryAnswering(const _Answer(status: 0));
+
+    // When
+    final result = await repository.countIn('scope-1');
+
+    // Then
+    expect(result.failureOrNull?.kind, FailureKind.network);
+  });
+}
+
+class _Answer {
+  const _Answer({required this.status, this.body});
+
+  final int status;
+  final Map<String, dynamic>? body;
+}
+
+/// Answers from memory, so no test reaches the network.
+class _StubAdapter implements HttpClientAdapter {
+  _StubAdapter(this._answer);
+
+  final _Answer _answer;
+
+  final List<Map<String, dynamic>> queries = <Map<String, dynamic>>[];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    queries.add(options.queryParameters);
+
+    if (_answer.status == 0) {
+      throw DioException.connectionError(
+        requestOptions: options,
+        reason: 'No route to host',
+      );
+    }
+
+    return ResponseBody.fromString(
+      jsonEncode(_answer.body),
+      _answer.status,
+      headers: <String, List<String>>{
+        Headers.contentTypeHeader: <String>[Headers.jsonContentType],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}

--- a/test/features/scopes/presentation/scope_detail_controller_test.dart
+++ b/test/features/scopes/presentation/scope_detail_controller_test.dart
@@ -60,6 +60,15 @@ void main() {
     when(() => repository.hardDelete(any())).thenAnswer((_) async => result);
   }
 
+  void answerToggleWith(Result<Scope> result) {
+    when(
+      () => repository.setGoogleSignIn(
+        id: any(named: 'id'),
+        enabled: any(named: 'enabled'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
   void answerUpdateWith(Result<Scope> result) {
     when(
       () => repository.update(
@@ -365,5 +374,134 @@ void main() {
 
     // Then
     verify(() => repository.delete('scope-1')).called(1);
+  });
+
+  test('GivenGoogleSignInOff_WhenTurnedOn_ThenTheApiIsAsked', () async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    answerToggleWith(
+      const Success<Scope>(
+        Scope(
+          id: 'scope-1',
+          name: 'Acme',
+          description: 'The first tenant',
+          googleSignInEnabled: true,
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.setGoogleSignIn(true);
+
+    // Then
+    verify(
+      () => repository.setGoogleSignIn(id: 'scope-1', enabled: true),
+    ).called(1);
+  });
+
+  test(
+    'GivenAConfirmedToggle_WhenItReturns_ThenTheControlSettlesOnIt',
+    () async {
+      // Given
+      answerGetWith(const Success<Scope>(_acme));
+      answerToggleWith(
+        const Success<Scope>(
+          Scope(
+            id: 'scope-1',
+            name: 'Acme',
+            description: 'The first tenant',
+            googleSignInEnabled: true,
+          ),
+        ),
+      );
+      final controller = controllerUnderTest();
+      await controller.load();
+
+      // When
+      await controller.setGoogleSignIn(true);
+
+      // Then
+      final state = currentState() as ScopeDetailLoaded;
+      expect(state.scope.googleSignInEnabled, isTrue);
+      expect(state.togglingGoogleSignIn, isFalse);
+    },
+  );
+
+  // AF-15a — the control returns to where the API still has it.
+  test('GivenARefusedToggle_WhenAttempted_ThenTheStateIsUnchanged', () async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    answerToggleWith(
+      const FailureResult<Scope>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['That scope is not active.'],
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.setGoogleSignIn(true);
+
+    // Then
+    final state = currentState() as ScopeDetailLoaded;
+    expect(state.scope.googleSignInEnabled, isFalse);
+    expect(state.googleSignInFailure?.errors, <String>[
+      'That scope is not active.',
+    ]);
+  });
+
+  // AF-15c — a request in flight is not joined by a second one.
+  test('GivenAToggleInFlight_WhenToggledAgain_ThenOnlyOneIsSent', () async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    final pending = Completer<Result<Scope>>();
+    when(
+      () => repository.setGoogleSignIn(
+        id: any(named: 'id'),
+        enabled: any(named: 'enabled'),
+      ),
+    ).thenAnswer((_) => pending.future);
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    final first = controller.setGoogleSignIn(true);
+    final second = controller.setGoogleSignIn(false);
+    pending.complete(const Success<Scope>(_acme));
+    await Future.wait<void>(<Future<void>>[first, second]);
+
+    // Then
+    verify(
+      () => repository.setGoogleSignIn(
+        id: any(named: 'id'),
+        enabled: any(named: 'enabled'),
+      ),
+    ).called(1);
+  });
+
+  // AF-12d — a deleted scope cannot be changed from here, and that includes
+  // this control.
+  test('GivenADeletedScope_WhenToggled_ThenNoRequestIsMade', () async {
+    // Given
+    answerGetWith(const Success<Scope>(_deleted));
+    answerToggleWith(const Success<Scope>(_deleted));
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.setGoogleSignIn(true);
+
+    // Then
+    verifyNever(
+      () => repository.setGoogleSignIn(
+        id: any(named: 'id'),
+        enabled: any(named: 'enabled'),
+      ),
+    );
   });
 }

--- a/test/features/scopes/presentation/scope_detail_screen_test.dart
+++ b/test/features/scopes/presentation/scope_detail_screen_test.dart
@@ -9,6 +9,7 @@ import 'package:heimdall_ui/core/network/envelope.dart' as envelope;
 import 'package:heimdall_ui/core/result/result.dart';
 import 'package:heimdall_ui/core/storage/token_store.dart';
 import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
+import 'package:heimdall_ui/features/google_users/domain/google_user_repository.dart';
 import 'package:heimdall_ui/features/scopes/domain/scope.dart';
 import 'package:heimdall_ui/features/scopes/domain/scope_repository.dart';
 import 'package:heimdall_ui/features/scopes/presentation/scope_detail_screen.dart';
@@ -17,6 +18,8 @@ import 'package:mocktail/mocktail.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockScopeRepository extends Mock implements ScopeRepository {}
+
+class _MockGoogleUserRepository extends Mock implements GoogleUserRepository {}
 
 /// A token naming a person of [role]: 1 System Admin, 2 Scope Admin.
 String _jwt({int role = 1}) {
@@ -41,6 +44,13 @@ const _acme = Scope(
   ownerIds: <String>['person-1'],
 );
 
+const _googleOff = Scope(
+  id: 'scope-1',
+  name: 'Acme',
+  description: 'The first tenant',
+  ownerIds: <String>['person-1'],
+);
+
 const _deleted = Scope(
   id: 'scope-1',
   name: 'Acme',
@@ -54,6 +64,7 @@ const Size _expanded = Size(1400, 900);
 
 void main() {
   late _MockScopeRepository repository;
+  late _MockGoogleUserRepository googleUsers;
   late InMemoryTokenStore store;
   late ProviderContainer container;
   late GoRouter router;
@@ -78,6 +89,7 @@ void main() {
     container = ProviderContainer(
       overrides: <Override>[
         scopeRepositoryProvider.overrideWithValue(repository),
+        googleUserRepositoryProvider.overrideWithValue(googleUsers),
         tokenStoreProvider.overrideWithValue(store),
       ],
     );
@@ -134,6 +146,19 @@ void main() {
     await tester.pumpAndSettle();
   }
 
+  void answerToggleWith(Result<Scope> result) {
+    when(
+      () => repository.setGoogleSignIn(
+        id: any(named: 'id'),
+        enabled: any(named: 'enabled'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  void answerCountWith(Result<int> result) {
+    when(() => googleUsers.countIn(any())).thenAnswer((_) async => result);
+  }
+
   void answerDeleteWith(Result<void> result) {
     when(() => repository.delete(any())).thenAnswer((_) async => result);
   }
@@ -172,7 +197,9 @@ void main() {
   setUp(() {
     SharedPreferences.setMockInitialValues(<String, Object>{});
     repository = _MockScopeRepository();
+    googleUsers = _MockGoogleUserRepository();
     store = InMemoryTokenStore();
+    answerCountWith(const Success<int>(0));
   });
 
   testWidgets('GivenAScope_WhenOpened_ThenTheRecordIsShown', (tester) async {
@@ -184,19 +211,6 @@ void main() {
 
     // Then
     expect(find.widgetWithText(TextFormField, 'Acme'), findsOneWidget);
-  });
-
-  testWidgets('GivenAScope_WhenOpened_ThenItsGoogleStateIsShown', (
-    tester,
-  ) async {
-    // Given
-    answerGetWith(const Success<Scope>(_acme));
-
-    // When
-    await pump(tester);
-
-    // Then
-    expect(find.text('On'), findsOneWidget);
   });
 
   testWidgets('GivenAScope_WhenOpened_ThenItsContentsAreLinked', (
@@ -735,5 +749,205 @@ void main() {
 
     // Then
     expect(find.text('listing'), findsOneWidget);
+  });
+
+  testWidgets('GivenAScope_WhenOpened_ThenTheGoogleControlReflectsIt', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(
+      tester.widget<SwitchListTile>(find.byType(SwitchListTile)).value,
+      isTrue,
+    );
+  });
+
+  testWidgets('GivenGoogleSignInOff_WhenTurnedOn_ThenTheApiIsAsked', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Scope>(_googleOff));
+    answerToggleWith(const Success<Scope>(_acme));
+    await pump(tester);
+
+    // When
+    await tapAfterScrolling(tester, find.byType(SwitchListTile));
+
+    // Then
+    verify(
+      () => repository.setGoogleSignIn(id: 'scope-1', enabled: true),
+    ).called(1);
+  });
+
+  // AF-15b — the accounts already in the scope are named before anything is
+  // sent.
+  testWidgets('GivenGoogleUsersPresent_WhenTurnedOff_ThenTheLossIsExplained', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    answerToggleWith(const Success<Scope>(_googleOff));
+    answerCountWith(const Success<int>(3));
+    await pump(tester);
+
+    // When
+    await tapAfterScrolling(tester, find.byType(SwitchListTile));
+
+    // Then
+    expect(
+      find.textContaining('3 Google accounts already in this scope'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('GivenOneGoogleUser_WhenTurnedOff_ThenTheWarningIsSingular', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    answerToggleWith(const Success<Scope>(_googleOff));
+    answerCountWith(const Success<int>(1));
+    await pump(tester);
+
+    // When
+    await tapAfterScrolling(tester, find.byType(SwitchListTile));
+
+    // Then
+    expect(
+      find.textContaining('1 Google account already in this scope'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('GivenTheWarning_WhenConfirmed_ThenTheApiIsAsked', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    answerToggleWith(const Success<Scope>(_googleOff));
+    answerCountWith(const Success<int>(3));
+    await pump(tester);
+    await tapAfterScrolling(tester, find.byType(SwitchListTile));
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Turn off'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => repository.setGoogleSignIn(id: 'scope-1', enabled: false),
+    ).called(1);
+  });
+
+  testWidgets('GivenTheWarning_WhenCancelled_ThenNothingIsSent', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    answerToggleWith(const Success<Scope>(_googleOff));
+    answerCountWith(const Success<int>(3));
+    await pump(tester);
+    await tapAfterScrolling(tester, find.byType(SwitchListTile));
+
+    // When
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verifyNever(
+      () => repository.setGoogleSignIn(
+        id: any(named: 'id'),
+        enabled: any(named: 'enabled'),
+      ),
+    );
+  });
+
+  // Nothing will stop working, so nothing needs explaining.
+  testWidgets('GivenNoGoogleUsers_WhenTurnedOff_ThenNoWarningIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    answerToggleWith(const Success<Scope>(_googleOff));
+    answerCountWith(const Success<int>(0));
+    await pump(tester);
+
+    // When
+    await tapAfterScrolling(tester, find.byType(SwitchListTile));
+
+    // Then
+    verify(
+      () => repository.setGoogleSignIn(id: 'scope-1', enabled: false),
+    ).called(1);
+  });
+
+  // A count that cannot be read warns anyway rather than staying quiet.
+  testWidgets('GivenAnUnreadableCount_WhenTurnedOff_ThenTheWarningStillShows', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Scope>(_acme));
+    answerToggleWith(const Success<Scope>(_googleOff));
+    answerCountWith(
+      const FailureResult<int>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await tapAfterScrolling(tester, find.byType(SwitchListTile));
+
+    // Then
+    expect(find.text('Turn Google Sign-In off?'), findsOneWidget);
+  });
+
+  // AF-15a — the refusal is shown and the control stays where the API has it.
+  testWidgets('GivenARefusedToggle_WhenAttempted_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Scope>(_googleOff));
+    answerToggleWith(
+      const FailureResult<Scope>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['That scope is not active.'],
+        ),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await tapAfterScrolling(tester, find.byType(SwitchListTile));
+
+    // Then
+    expect(find.text('That scope is not active.'), findsOneWidget);
+    expect(
+      tester.widget<SwitchListTile>(find.byType(SwitchListTile)).value,
+      isFalse,
+    );
+  });
+
+  // AF-12d — a deleted scope cannot be changed from here.
+  testWidgets('GivenADeletedScope_WhenRendered_ThenTheControlIsDisabled', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Scope>(_deleted));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(
+      tester.widget<SwitchListTile>(find.byType(SwitchListTile)).onChanged,
+      isNull,
+    );
   });
 }


### PR DESCRIPTION
Closes #15

Implements UI-15 — the scope detail's Google Sign-In line becomes a control over `PUT /api/scopes/{id}/google-signin` (FR-SC-12).

## Flows

| Flow | How it is handled |
| --- | --- |
| Main | The switch reflects `googleSignInEnabled` and settles on the state the API confirmed. |
| AF-15a | A refusal shows the returned errors and leaves the switch where the API still has it. |
| AF-15b | Turning it off explains that the Google accounts already in the scope stop working — before anything is sent. |
| AF-15c | The switch is disabled while the request is outstanding. |

## AF-15b and the count

The flow says the confirmation appears "with Google users present", so the count is read before the warning: a scope with none is not warned at all, one with some is told how many, and a count that cannot be read is warned about anyway rather than passed over. That is the whole of `GoogleUserRepository` for now — a single `countIn`, over one page of one item, taking the envelope's own total so the cost does not grow with the scope. UI-28 and UI-29 extend it.

## Note on a replaced test

`GivenAScope_WhenOpened_ThenItsGoogleStateIsShown` from UI-12 asserted the state as the text "On". That text no longer exists — it is a switch now — so the test is replaced by `GivenAScope_WhenOpened_ThenTheGoogleControlReflectsIt`, which asserts the control's value. Nothing was disabled to reach green.

## Verification

`dart format --set-exit-if-changed .`, `flutter analyze`, and `flutter test` all pass — **514 tests**, 20 of them new. No presentation file imports `package:heimdall_api_client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)