### PR TITLE
feat(ui-16): browse and search persons in a scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ the board is where an item's status changes as it moves.
 
 | Use case | Status | Issue |
 | --- | --- | --- |
-| UI-16: Browse and search persons in a scope | ⬜ | [#16](https://github.com/artur-rios/heimdall-ui/issues/16) |
+| UI-16: Browse and search persons in a scope | ✅ | [#16](https://github.com/artur-rios/heimdall-ui/issues/16) |
 | UI-17: Create a person | ⬜ | [#17](https://github.com/artur-rios/heimdall-ui/issues/17) |
 | UI-18: View and update a person | ⬜ | [#18](https://github.com/artur-rios/heimdall-ui/issues/18) |
 | UI-19: Delete a person, logically and permanently | ⬜ | [#19](https://github.com/artur-rios/heimdall-ui/issues/19) |

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -10,6 +10,7 @@ import '../features/auth/presentation/session_controller.dart';
 import '../features/auth/presentation/two_factor_screen.dart';
 import '../features/auth/presentation/verify_email_screen.dart';
 import '../features/home/presentation/home_screen.dart';
+import '../features/persons/presentation/person_list_screen.dart';
 import '../features/profile/presentation/profile_screen.dart';
 import '../features/scopes/presentation/scope_create_screen.dart';
 import '../features/scopes/presentation/scope_detail_screen.dart';
@@ -135,6 +136,11 @@ final Provider<GoRouter> routerProvider = Provider<GoRouter>((ref) {
         path: '/scopes/:scopeId/owners',
         builder: (context, state) =>
             ScopeOwnersScreen(scopeId: state.pathParameters['scopeId']!),
+      ),
+      GoRoute(
+        path: '/scopes/:scopeId/persons',
+        builder: (context, state) =>
+            PersonListScreen(scopeId: state.pathParameters['scopeId']!),
       ),
       GoRoute(
         path: '/not-available',

--- a/lib/features/persons/presentation/person_list_controller.dart
+++ b/lib/features/persons/presentation/person_list_controller.dart
@@ -1,0 +1,142 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/network/envelope.dart';
+import '../../../core/result/result.dart';
+import '../../profile/presentation/profile_controller.dart';
+import '../domain/person.dart';
+
+/// What the listing is currently asking the API for.
+///
+/// Kept whole rather than as loose fields so a failed request can be repeated
+/// with exactly the question that failed (FR-UX-07).
+class PersonQuery {
+  const PersonQuery({
+    this.name = '',
+    this.email = '',
+    this.includeDeleted = false,
+    this.pageNumber = 1,
+  });
+
+  final String name;
+  final String email;
+  final bool includeDeleted;
+  final int pageNumber;
+
+  /// Whether the user has narrowed the listing at all, which is what tells an
+  /// empty result from an unfiltered empty collection (AF-16a).
+  bool get isFiltered =>
+      name.trim().isNotEmpty || email.trim().isNotEmpty || includeDeleted;
+
+  PersonQuery copyWith({
+    String? name,
+    String? email,
+    bool? includeDeleted,
+    int? pageNumber,
+  }) => PersonQuery(
+    name: name ?? this.name,
+    email: email ?? this.email,
+    includeDeleted: includeDeleted ?? this.includeDeleted,
+    pageNumber: pageNumber ?? this.pageNumber,
+  );
+}
+
+/// How far the listing has got. The query travels with every state, so the
+/// filters survive a failure and a retry.
+sealed class PersonListState {
+  const PersonListState(this.query);
+
+  final PersonQuery query;
+}
+
+/// The first page is on its way and the list shows a placeholder.
+final class PersonListLoading extends PersonListState {
+  const PersonListLoading(super.query);
+}
+
+/// A page arrived. [busy] marks a further page or filter in flight, which keeps
+/// the current rows on screen instead of flashing the placeholder again.
+final class PersonListLoaded extends PersonListState {
+  const PersonListLoaded(super.query, this.page, {this.busy = false});
+
+  final Page<Person> page;
+  final bool busy;
+}
+
+/// AF-16b and AF-16c — the request failed, and the query that failed is kept.
+final class PersonListFailed extends PersonListState {
+  const PersonListFailed(super.query, this.failure);
+
+  final Failure failure;
+
+  /// AF-16c — a Scope Admin opening a scope they do not own.
+  bool get isForbidden => failure.kind == FailureKind.forbidden;
+}
+
+final NotifierProviderFamily<PersonListController, PersonListState, String>
+personListControllerProvider =
+    NotifierProvider.family<PersonListController, PersonListState, String>(
+      PersonListController.new,
+    );
+
+/// Owns one scope's person listing: the filters, the page, and the request in
+/// flight.
+class PersonListController extends FamilyNotifier<PersonListState, String> {
+  /// Whether a request is already on its way.
+  ///
+  /// A field rather than a read of [state], because the first load and a later
+  /// page are in different states while being equally in flight.
+  bool _inFlight = false;
+
+  @override
+  PersonListState build(String scopeId) =>
+      const PersonListLoading(PersonQuery());
+
+  Future<void> load() => _fetch(state.query);
+
+  /// AF-16d — a new search starts at the first page.
+  Future<void> search({String? name, String? email}) =>
+      _fetch(state.query.copyWith(name: name, email: email, pageNumber: 1));
+
+  /// AF-16d — as does changing what is included.
+  Future<void> setIncludeDeleted(bool includeDeleted) => _fetch(
+    state.query.copyWith(includeDeleted: includeDeleted, pageNumber: 1),
+  );
+
+  Future<void> goToPage(int pageNumber) =>
+      _fetch(state.query.copyWith(pageNumber: pageNumber));
+
+  /// AF-16a — returns to the unfiltered listing from the empty-result panel.
+  Future<void> clearFilters() => _fetch(const PersonQuery());
+
+  Future<void> _fetch(PersonQuery query) async {
+    if (_inFlight) {
+      return;
+    }
+
+    final current = state;
+    _inFlight = true;
+
+    state = current is PersonListLoaded
+        ? PersonListLoaded(query, current.page, busy: true)
+        : PersonListLoading(query);
+
+    try {
+      final result = await ref
+          .read(personRepositoryProvider)
+          .listScopePersons(
+            scopeId: arg,
+            name: query.name,
+            email: query.email,
+            includeDeleted: query.includeDeleted,
+            pageNumber: query.pageNumber,
+          );
+
+      state = result.fold(
+        onSuccess: (page) => PersonListLoaded(query, page),
+        onFailure: (failure) => PersonListFailed(query, failure),
+      );
+    } finally {
+      _inFlight = false;
+    }
+  }
+}

--- a/lib/features/persons/presentation/person_list_screen.dart
+++ b/lib/features/persons/presentation/person_list_screen.dart
@@ -1,0 +1,225 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../shared/layout/app_shell.dart';
+import '../../../shared/widgets/adaptive_collection.dart';
+import '../../../shared/widgets/collection_states.dart';
+import '../../home/presentation/home_screen.dart';
+import '../domain/person.dart';
+import 'person_list_controller.dart';
+
+/// UI-16 — the persons of one scope.
+class PersonListScreen extends ConsumerStatefulWidget {
+  const PersonListScreen({required this.scopeId, super.key});
+
+  final String scopeId;
+
+  @override
+  ConsumerState<PersonListScreen> createState() => _PersonListScreenState();
+}
+
+class _PersonListScreenState extends ConsumerState<PersonListScreen> {
+  final _name = TextEditingController();
+  final _email = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => ref
+          .read(personListControllerProvider(widget.scopeId).notifier)
+          .load(),
+    );
+  }
+
+  @override
+  void dispose() {
+    _name.dispose();
+    _email.dispose();
+    super.dispose();
+  }
+
+  PersonListController get _controller =>
+      ref.read(personListControllerProvider(widget.scopeId).notifier);
+
+  void _search() => _controller.search(name: _name.text, email: _email.text);
+
+  void _clearFilters() {
+    _name.clear();
+    _email.clear();
+    _controller.clearFilters();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(personListControllerProvider(widget.scopeId));
+
+    return AppShell(
+      currentRoute: '/scopes',
+      title: const Text('Persons'),
+      actions: <Widget>[
+        IconButton(
+          tooltip: 'Back to the scope',
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.go('/scopes/${widget.scopeId}'),
+        ),
+      ],
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () => context.go('/scopes/${widget.scopeId}/persons/new'),
+        icon: const Icon(Icons.add),
+        label: const Text('New person'),
+      ),
+      body: Column(
+        children: <Widget>[
+          _Filters(
+            name: _name,
+            email: _email,
+            includeDeleted: state.query.includeDeleted,
+            onSearch: _search,
+            onIncludeDeletedChanged: _controller.setIncludeDeleted,
+          ),
+          Expanded(
+            child: switch (state) {
+              PersonListLoading() => const CollectionLoading(),
+              // AF-16c — the scope is not one this admin owns.
+              PersonListFailed(isForbidden: true) => CollectionEmpty(
+                title: 'Not available for your role',
+                message:
+                    'This scope is not one you administer. Nothing is '
+                    'wrong with your session.',
+                icon: Icons.lock_person_outlined,
+                actionLabel: 'Back to scopes',
+                onAction: () => context.go('/scopes'),
+              ),
+              // AF-16b — the returned errors, with a retry that keeps the
+              // filters.
+              PersonListFailed(:final failure) => CollectionFailed(
+                failure: failure,
+                onRetry: _controller.load,
+              ),
+              PersonListLoaded(:final page, :final query)
+                  when page.items.isEmpty =>
+                _empty(query),
+              final PersonListLoaded loaded => AdaptiveCollection<Person>(
+                items: loaded.page.items,
+                busy: loaded.busy,
+                reservesFloatingAction: true,
+                pageNumber: loaded.page.pageNumber,
+                totalPages: loaded.page.totalPages,
+                totalItems: loaded.page.totalItems,
+                onPageChanged: _controller.goToPage,
+                onTap: (person) => context.go(
+                  '/scopes/${widget.scopeId}/persons/${person.id}',
+                ),
+                title: (person) => person.name,
+                subtitle: (person) => person.email,
+                columns: <CollectionColumn<Person>>[
+                  CollectionColumn<Person>(
+                    label: 'Role',
+                    cell: (person) => Text(roleLabel(person.role)),
+                  ),
+                  CollectionColumn<Person>(
+                    label: 'Verified',
+                    cell: (person) => Text(person.emailVerified ? 'Yes' : 'No'),
+                  ),
+                  CollectionColumn<Person>(
+                    label: 'State',
+                    cell: (person) =>
+                        Text(person.isDeleted ? 'Deleted' : 'Active'),
+                  ),
+                ],
+              ),
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// AF-16a — an empty scope and an empty search are different situations, and
+  /// each has its own next action.
+  Widget _empty(PersonQuery query) => query.isFiltered
+      ? CollectionEmpty(
+          title: 'No persons matched',
+          message:
+              'Nothing here matches what you searched for. Clearing the '
+              'filters shows everyone in this scope again.',
+          icon: Icons.search_off_outlined,
+          actionLabel: 'Clear filters',
+          onAction: _clearFilters,
+        )
+      : CollectionEmpty(
+          title: 'No persons yet',
+          message:
+              'This scope has nobody in it. Creating the first person '
+              'sends them a verification email.',
+          icon: Icons.people_outline,
+          actionLabel: 'New person',
+          onAction: () => context.go('/scopes/${widget.scopeId}/persons/new'),
+        );
+}
+
+/// The two search fields and the include-deleted switch.
+///
+/// Two fields rather than one: the API filters by name and by email
+/// separately, and collapsing them here would mean guessing which one the user
+/// meant.
+class _Filters extends StatelessWidget {
+  const _Filters({
+    required this.name,
+    required this.email,
+    required this.includeDeleted,
+    required this.onSearch,
+    required this.onIncludeDeletedChanged,
+  });
+
+  final TextEditingController name;
+  final TextEditingController email;
+  final bool includeDeleted;
+  final VoidCallback onSearch;
+  final ValueChanged<bool> onIncludeDeletedChanged;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.fromLTRB(12, 12, 12, 0),
+    child: Wrap(
+      spacing: 16,
+      runSpacing: 8,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: <Widget>[
+        SizedBox(
+          width: 260,
+          child: TextField(
+            controller: name,
+            decoration: const InputDecoration(
+              labelText: 'Search by name',
+              prefixIcon: Icon(Icons.search),
+            ),
+            onSubmitted: (_) => onSearch(),
+          ),
+        ),
+        SizedBox(
+          width: 260,
+          child: TextField(
+            controller: email,
+            decoration: const InputDecoration(
+              labelText: 'Search by email',
+              prefixIcon: Icon(Icons.alternate_email),
+            ),
+            onSubmitted: (_) => onSearch(),
+          ),
+        ),
+        FilledButton.tonal(onPressed: onSearch, child: const Text('Search')),
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Switch(value: includeDeleted, onChanged: onIncludeDeletedChanged),
+            const SizedBox(width: 8),
+            const Text('Include deleted'),
+          ],
+        ),
+      ],
+    ),
+  );
+}

--- a/test/features/persons/presentation/person_list_controller_test.dart
+++ b/test/features/persons/presentation/person_list_controller_test.dart
@@ -1,0 +1,309 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdall_ui/core/network/envelope.dart';
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/features/auth/domain/session.dart';
+import 'package:heimdall_ui/features/persons/domain/person.dart';
+import 'package:heimdall_ui/features/persons/domain/person_repository.dart';
+import 'package:heimdall_ui/features/persons/presentation/person_list_controller.dart';
+import 'package:heimdall_ui/features/profile/presentation/profile_controller.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockPersonRepository extends Mock implements PersonRepository {}
+
+const _ada = Person(
+  id: 'person-1',
+  name: 'Ada',
+  email: 'ada@example.com',
+  role: Role.user,
+);
+
+Page<Person> _page({
+  List<Person> items = const <Person>[_ada],
+  int pageNumber = 1,
+  int totalPages = 1,
+}) => Page<Person>(
+  items: items,
+  pageNumber: pageNumber,
+  pageSize: 20,
+  totalItems: items.length,
+  totalPages: totalPages,
+);
+
+void main() {
+  late _MockPersonRepository repository;
+  late ProviderContainer container;
+
+  PersonListController controllerUnderTest() {
+    container = ProviderContainer(
+      overrides: <Override>[
+        personRepositoryProvider.overrideWithValue(repository),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    return container.read(personListControllerProvider('scope-1').notifier);
+  }
+
+  PersonListState currentState() =>
+      container.read(personListControllerProvider('scope-1'));
+
+  void answerWith(Result<Page<Person>> result) {
+    when(
+      () => repository.listScopePersons(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  setUp(() {
+    repository = _MockPersonRepository();
+  });
+
+  test('GivenAPage_WhenLoaded_ThenThePersonsAreShown', () async {
+    // Given
+    answerWith(Success<Page<Person>>(_page()));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    expect((currentState() as PersonListLoaded).page.items.single.name, 'Ada');
+  });
+
+  test('GivenAScope_WhenLoaded_ThenThatScopeIsRead', () async {
+    // Given
+    answerWith(Success<Page<Person>>(_page()));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    verify(
+      () => repository.listScopePersons(
+        scopeId: 'scope-1',
+        name: '',
+        email: '',
+        includeDeleted: false,
+        pageNumber: 1,
+      ),
+    ).called(1);
+  });
+
+  test('GivenASearch_WhenSubmitted_ThenBothFiltersAreSent', () async {
+    // Given
+    answerWith(Success<Page<Person>>(_page()));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.search(name: 'Ada', email: 'ada@example.com');
+
+    // Then
+    verify(
+      () => repository.listScopePersons(
+        scopeId: 'scope-1',
+        name: 'Ada',
+        email: 'ada@example.com',
+        includeDeleted: false,
+        pageNumber: 1,
+      ),
+    ).called(1);
+  });
+
+  // AF-16d — a new search starts at the first page.
+  test('GivenAPageOtherThanTheFirst_WhenSearched_ThenPagingResets', () async {
+    // Given
+    answerWith(Success<Page<Person>>(_page(totalPages: 5)));
+    final controller = controllerUnderTest();
+    await controller.load();
+    await controller.goToPage(3);
+
+    // When
+    await controller.search(name: 'Ada');
+
+    // Then
+    expect(currentState().query.pageNumber, 1);
+  });
+
+  test(
+    'GivenAPageOtherThanTheFirst_WhenIncludeDeletedToggled_ThenPagingResets',
+    () async {
+      // Given
+      answerWith(Success<Page<Person>>(_page(totalPages: 5)));
+      final controller = controllerUnderTest();
+      await controller.load();
+      await controller.goToPage(3);
+
+      // When
+      await controller.setIncludeDeleted(true);
+
+      // Then
+      expect(currentState().query.pageNumber, 1);
+    },
+  );
+
+  test('GivenAPageChange_WhenRequested_ThenThatPageIsRead', () async {
+    // Given
+    answerWith(Success<Page<Person>>(_page(totalPages: 4)));
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.goToPage(2);
+
+    // Then
+    verify(
+      () => repository.listScopePersons(
+        scopeId: 'scope-1',
+        name: '',
+        email: '',
+        includeDeleted: false,
+        pageNumber: 2,
+      ),
+    ).called(1);
+  });
+
+  // AF-16b — the query that failed is kept, so the retry asks it again.
+  test('GivenAFailedRequest_WhenSearched_ThenTheFiltersSurvive', () async {
+    // Given
+    answerWith(
+      const FailureResult<Page<Person>>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.search(name: 'Ada');
+
+    // Then
+    expect(currentState().query.name, 'Ada');
+  });
+
+  // AF-16c — a Scope Admin opening a scope they do not own.
+  test('GivenAForbiddenScope_WhenLoaded_ThenStateIsForbidden', () async {
+    // Given
+    answerWith(
+      const FailureResult<Page<Person>>(
+        Failure(kind: FailureKind.forbidden, errors: <String>[]),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    expect((currentState() as PersonListFailed).isForbidden, isTrue);
+  });
+
+  test('GivenARefusedListing_WhenLoaded_ThenApiErrorsAreKept', () async {
+    // Given
+    answerWith(
+      const FailureResult<Page<Person>>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['Page size is too large.'],
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    expect((currentState() as PersonListFailed).failure.errors, <String>[
+      'Page size is too large.',
+    ]);
+  });
+
+  // AF-16a — a filtered listing knows it is filtered.
+  test('GivenASearch_WhenApplied_ThenTheQueryIsFiltered', () async {
+    // Given
+    answerWith(Success<Page<Person>>(_page(items: const <Person>[])));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.search(email: 'nobody@example.com');
+
+    // Then
+    expect(currentState().query.isFiltered, isTrue);
+  });
+
+  test('GivenNoFilters_WhenLoaded_ThenTheQueryIsUnfiltered', () async {
+    // Given
+    answerWith(Success<Page<Person>>(_page(items: const <Person>[])));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    expect(currentState().query.isFiltered, isFalse);
+  });
+
+  test('GivenFilters_WhenCleared_ThenTheFullListingIsRead', () async {
+    // Given
+    answerWith(Success<Page<Person>>(_page()));
+    final controller = controllerUnderTest();
+    await controller.search(name: 'Ada');
+
+    // When
+    await controller.clearFilters();
+
+    // Then
+    verify(
+      () => repository.listScopePersons(
+        scopeId: 'scope-1',
+        name: '',
+        email: '',
+        includeDeleted: false,
+        pageNumber: 1,
+      ),
+    ).called(1);
+  });
+
+  test('GivenARequestInFlight_WhenAskedAgain_ThenOnlyOneIsSent', () async {
+    // Given
+    final pending = Completer<Result<Page<Person>>>();
+    when(
+      () => repository.listScopePersons(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer((_) => pending.future);
+    final controller = controllerUnderTest();
+
+    // When
+    final first = controller.goToPage(2);
+    final second = controller.goToPage(3);
+    pending.complete(Success<Page<Person>>(_page()));
+    await Future.wait<void>(<Future<void>>[first, second]);
+
+    // Then
+    verify(
+      () => repository.listScopePersons(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).called(1);
+  });
+}

--- a/test/features/persons/presentation/person_list_screen_test.dart
+++ b/test/features/persons/presentation/person_list_screen_test.dart
@@ -1,0 +1,423 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:heimdall_ui/app/theme.dart';
+import 'package:heimdall_ui/core/network/envelope.dart' as envelope;
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/core/storage/token_store.dart';
+import 'package:heimdall_ui/features/auth/domain/session.dart';
+import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
+import 'package:heimdall_ui/features/persons/domain/person.dart';
+import 'package:heimdall_ui/features/persons/domain/person_repository.dart';
+import 'package:heimdall_ui/features/persons/presentation/person_list_screen.dart';
+import 'package:heimdall_ui/features/profile/presentation/profile_controller.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockPersonRepository extends Mock implements PersonRepository {}
+
+String _jwt() {
+  final payload = base64Url.encode(
+    utf8.encode(
+      jsonEncode(<String, dynamic>{
+        'sub': 'person-9',
+        'email': 'admin@example.com',
+        'role': 1,
+      }),
+    ),
+  );
+
+  return 'header.$payload.signature';
+}
+
+const _ada = Person(
+  id: 'person-1',
+  name: 'Ada',
+  email: 'ada@example.com',
+  role: Role.user,
+);
+
+envelope.Page<Person> _page({
+  List<Person> items = const <Person>[_ada],
+  int pageNumber = 1,
+  int totalPages = 1,
+}) => envelope.Page<Person>(
+  items: items,
+  pageNumber: pageNumber,
+  pageSize: 20,
+  totalItems: items.length,
+  totalPages: totalPages,
+);
+
+const Size _compact = Size(400, 900);
+const Size _medium = Size(800, 900);
+const Size _expanded = Size(1400, 900);
+
+void main() {
+  late _MockPersonRepository repository;
+  late InMemoryTokenStore store;
+  late ProviderContainer container;
+  late GoRouter router;
+
+  Future<void> pump(
+    WidgetTester tester, {
+    Size size = _expanded,
+    ThemeData? theme,
+  }) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await store.write(AuthToken(value: _jwt(), expiresAt: DateTime.utc(2030)));
+
+    container = ProviderContainer(
+      overrides: <Override>[
+        personRepositoryProvider.overrideWithValue(repository),
+        tokenStoreProvider.overrideWithValue(store),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(sessionControllerProvider.notifier).restore();
+
+    router = GoRouter(
+      initialLocation: '/scopes/scope-1/persons',
+      routes: <RouteBase>[
+        GoRoute(
+          path: '/scopes',
+          builder: (context, state) => const Scaffold(body: Text('scopes')),
+        ),
+        GoRoute(
+          path: '/scopes/:scopeId',
+          builder: (context, state) => const Scaffold(body: Text('scope')),
+        ),
+        GoRoute(
+          path: '/scopes/:scopeId/persons',
+          builder: (context, state) =>
+              PersonListScreen(scopeId: state.pathParameters['scopeId']!),
+        ),
+        GoRoute(
+          path: '/scopes/:scopeId/persons/new',
+          builder: (context, state) => const Scaffold(body: Text('create')),
+        ),
+        GoRoute(
+          path: '/scopes/:scopeId/persons/:personId',
+          builder: (context, state) => Scaffold(
+            body: Text('detail ${state.pathParameters['personId']}'),
+          ),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(
+          theme: theme ?? buildLightTheme(),
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  void answerWith(Result<envelope.Page<Person>> result) {
+    when(
+      () => repository.listScopePersons(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    repository = _MockPersonRepository();
+    store = InMemoryTokenStore();
+  });
+
+  testWidgets('GivenAPageOfPersons_WhenOpened_ThenTheyAreListed', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Person>>(_page()));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Ada'), findsOneWidget);
+  });
+
+  testWidgets('GivenAPersonRow_WhenRendered_ThenItsRoleIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Person>>(_page()));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('User'), findsOneWidget);
+  });
+
+  // FR-UX-04 — a table when the window is wide, cards when it is not.
+  testWidgets('GivenAnExpandedWindow_WhenListed_ThenATableIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Person>>(_page()));
+
+    // When
+    await pump(tester, size: _expanded);
+
+    // Then
+    expect(find.byType(DataTable), findsOneWidget);
+  });
+
+  testWidgets('GivenAMediumWindow_WhenListed_ThenATableIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Person>>(_page()));
+
+    // When
+    await pump(tester, size: _medium);
+
+    // Then
+    expect(find.byType(DataTable), findsOneWidget);
+  });
+
+  testWidgets('GivenACompactWindow_WhenListed_ThenCardsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Person>>(_page()));
+
+    // When
+    await pump(tester, size: _compact);
+
+    // Then
+    expect(find.byType(DataTable), findsNothing);
+    expect(find.byType(Card), findsOneWidget);
+  });
+
+  testWidgets('GivenAPerson_WhenTapped_ThenTheirDetailOpens', (tester) async {
+    // Given
+    answerWith(Success<envelope.Page<Person>>(_page()));
+    await pump(tester, size: _compact);
+
+    // When
+    await tester.tap(find.text('Ada'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('detail person-1'), findsOneWidget);
+  });
+
+  // AF-16a — nobody here yet, which offers UI-17.
+  testWidgets('GivenNoPersonsAndNoFilter_WhenListed_ThenCreateIsOffered', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Person>>(_page(items: const <Person>[])));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('No persons yet'), findsOneWidget);
+  });
+
+  // AF-16a — no matches, which offers to clear the filter.
+  testWidgets('GivenNoMatches_WhenSearched_ThenClearingIsOffered', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Person>>(_page(items: const <Person>[])));
+    await pump(tester);
+
+    // When
+    await tester.enterText(
+      find.widgetWithText(TextField, 'Search by name'),
+      'nobody',
+    );
+    await tester.tap(find.widgetWithText(FilledButton, 'Search'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('No persons matched'), findsOneWidget);
+  });
+
+  testWidgets('GivenBothFilters_WhenSearched_ThenBothAreSent', (tester) async {
+    // Given
+    answerWith(Success<envelope.Page<Person>>(_page()));
+    await pump(tester);
+
+    // When
+    await tester.enterText(
+      find.widgetWithText(TextField, 'Search by name'),
+      'Ada',
+    );
+    await tester.enterText(
+      find.widgetWithText(TextField, 'Search by email'),
+      'ada@example.com',
+    );
+    await tester.tap(find.widgetWithText(FilledButton, 'Search'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => repository.listScopePersons(
+        scopeId: 'scope-1',
+        name: 'Ada',
+        email: 'ada@example.com',
+        includeDeleted: false,
+        pageNumber: 1,
+      ),
+    ).called(1);
+  });
+
+  // AF-16b — the returned errors, with a retry.
+  testWidgets('GivenARefusedListing_WhenOpened_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(
+      const FailureResult<envelope.Page<Person>>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['Page size is too large.'],
+        ),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Page size is too large.'), findsOneWidget);
+  });
+
+  testWidgets('GivenATransportFailure_WhenOpened_ThenARetryIsOffered', (
+    tester,
+  ) async {
+    // Given
+    answerWith(
+      const FailureResult<envelope.Page<Person>>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.widgetWithText(TextButton, 'Retry'), findsOneWidget);
+  });
+
+  // AF-16c — a scope this admin does not own.
+  testWidgets('GivenAForbiddenScope_WhenOpened_ThenTheRolePanelIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(
+      const FailureResult<envelope.Page<Person>>(
+        Failure(kind: FailureKind.forbidden, errors: <String>[]),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Not available for your role'), findsOneWidget);
+  });
+
+  testWidgets('GivenIncludeDeleted_WhenToggled_ThenTheFlagIsSent', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Person>>(_page()));
+    await pump(tester);
+
+    // When
+    await tester.tap(find.byType(Switch));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => repository.listScopePersons(
+        scopeId: 'scope-1',
+        name: '',
+        email: '',
+        includeDeleted: true,
+        pageNumber: 1,
+      ),
+    ).called(1);
+  });
+
+  testWidgets('GivenSeveralPages_WhenNextTapped_ThenTheNextPageIsRead', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Person>>(_page(totalPages: 3)));
+    await pump(tester);
+
+    // When
+    await tester.tap(
+      find.ancestor(
+        of: find.byIcon(Icons.chevron_right),
+        matching: find.byType(IconButton),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => repository.listScopePersons(
+        scopeId: 'scope-1',
+        name: '',
+        email: '',
+        includeDeleted: false,
+        pageNumber: 2,
+      ),
+    ).called(1);
+  });
+
+  testWidgets('GivenTheCreateControl_WhenTapped_ThenTheFormOpens', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Person>>(_page()));
+    await pump(tester);
+
+    // When
+    await tester.tap(find.widgetWithText(FloatingActionButton, 'New person'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('create'), findsOneWidget);
+  });
+
+  testWidgets('GivenTheDarkTheme_WhenListed_ThenThePersonsAreStillShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Person>>(_page()));
+
+    // When
+    await pump(tester, theme: buildDarkTheme());
+
+    // Then
+    expect(find.text('Ada'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #16

Implements UI-16 — `/scopes/:scopeId/persons` over `GET /api/scopes/{scopeId}/persons` (FR-PE-01, FR-PE-02), on the shared collection UI-10 established.

## Flows

| Flow | How it is handled |
| --- | --- |
| Main | The page is read on open; the user searches, toggles deleted, and pages. |
| AF-16a | "No persons yet" offers UI-17; "No persons matched" offers to clear the filters. |
| AF-16b | The returned errors, or a retry for a transport failure, with the failing query kept. |
| AF-16c | A `403` shows the not-available-for-your-role panel rather than an error. |
| AF-16d | A new search or a changed include-deleted flag returns to page 1. |

The search is two fields rather than one: the API filters by `Name` and `Email` separately, and collapsing them into a single box would mean guessing which the user meant.

## Verification

`dart format --set-exit-if-changed .`, `flutter analyze`, and `flutter test` all pass — **543 tests**, 29 of them new. No presentation file imports `package:heimdall_api_client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)