### PR TITLE
feat(ui-17): create a person

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ the board is where an item's status changes as it moves.
 | Use case | Status | Issue |
 | --- | --- | --- |
 | UI-16: Browse and search persons in a scope | ✅ | [#16](https://github.com/artur-rios/heimdall-ui/issues/16) |
-| UI-17: Create a person | ⬜ | [#17](https://github.com/artur-rios/heimdall-ui/issues/17) |
+| UI-17: Create a person | ✅ | [#17](https://github.com/artur-rios/heimdall-ui/issues/17) |
 | UI-18: View and update a person | ⬜ | [#18](https://github.com/artur-rios/heimdall-ui/issues/18) |
 | UI-19: Delete a person, logically and permanently | ⬜ | [#19](https://github.com/artur-rios/heimdall-ui/issues/19) |
 

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -10,6 +10,7 @@ import '../features/auth/presentation/session_controller.dart';
 import '../features/auth/presentation/two_factor_screen.dart';
 import '../features/auth/presentation/verify_email_screen.dart';
 import '../features/home/presentation/home_screen.dart';
+import '../features/persons/presentation/person_create_screen.dart';
 import '../features/persons/presentation/person_list_screen.dart';
 import '../features/profile/presentation/profile_screen.dart';
 import '../features/scopes/presentation/scope_create_screen.dart';
@@ -141,6 +142,11 @@ final Provider<GoRouter> routerProvider = Provider<GoRouter>((ref) {
         path: '/scopes/:scopeId/persons',
         builder: (context, state) =>
             PersonListScreen(scopeId: state.pathParameters['scopeId']!),
+      ),
+      GoRoute(
+        path: '/scopes/:scopeId/persons/new',
+        builder: (context, state) =>
+            PersonCreateScreen(scopeId: state.pathParameters['scopeId']!),
       ),
       GoRoute(
         path: '/not-available',

--- a/lib/features/persons/data/person_repository_impl.dart
+++ b/lib/features/persons/data/person_repository_impl.dart
@@ -102,6 +102,89 @@ class ApiPersonRepository implements PersonRepository {
   }
 
   @override
+  Future<Result<Person>> createUser({
+    required String scopeId,
+    required String name,
+    required String email,
+    required String password,
+  }) => _created(
+    () => _client.personCreateUser(
+      scopeId: scopeId,
+      body: CreateUserCommand(name: name, email: email, password: password),
+    ),
+    name: name,
+    email: email,
+    fallbackRole: Role.user,
+  );
+
+  @override
+  Future<Result<Person>> createAdmin({
+    required String name,
+    required String email,
+    required String password,
+    required Role role,
+  }) => _created(
+    () => _client.personCreateAdmin(
+      body: CreateAdminCommand(
+        name: name,
+        email: email,
+        password: password,
+        role: role.value,
+      ),
+    ),
+    name: name,
+    email: email,
+    fallbackRole: role,
+  );
+
+  /// Runs a person-creating command and maps its envelope.
+  ///
+  /// AF-17b and AF-17c both arrive as an unsuccessful envelope carrying the
+  /// API's own strings — a registered address and a password its policy
+  /// refuses are told apart by what it says, not by anything decided here.
+  Future<Result<Person>> _created(
+    Future<CreatePersonCommandOutputDataOutput> Function() send, {
+    required String name,
+    required String email,
+    required Role fallbackRole,
+  }) async {
+    try {
+      final response = await send();
+
+      if (response.success != true) {
+        return FailureResult<Person>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: response.errors ?? const <String>[],
+          ),
+        );
+      }
+
+      final data = response.data;
+
+      if (data == null) {
+        return const FailureResult<Person>(incompleteResponse);
+      }
+
+      return Success<Person>(
+        Person(
+          id: data.id ?? '',
+          name: data.name ?? name,
+          email: data.email ?? email,
+          role: roleFromValue(data.role ?? fallbackRole.value),
+          // A person the API just created has not verified anything yet; the
+          // verification email is on its way.
+          emailVerified: data.emailVerified ?? false,
+          scopeId: data.scopeId,
+          createdAt: data.createdAt,
+        ),
+      );
+    } on DioException catch (error) {
+      return FailureResult<Person>(failureFromDioException(error));
+    }
+  }
+
+  @override
   Future<Result<Page<Person>>> listScopeOwners({
     required String scopeId,
     String? name,

--- a/lib/features/persons/domain/person_repository.dart
+++ b/lib/features/persons/domain/person_repository.dart
@@ -1,5 +1,6 @@
 import '../../../core/network/envelope.dart';
 import '../../../core/result/result.dart';
+import '../../auth/domain/session.dart';
 import 'person.dart';
 
 /// The person operations the interface depends on.
@@ -22,6 +23,23 @@ abstract interface class PersonRepository {
     required String name,
     required String email,
     int? roleId,
+  });
+
+  /// Creates a User within a scope.
+  Future<Result<Person>> createUser({
+    required String scopeId,
+    required String name,
+    required String email,
+    required String password,
+  });
+
+  /// Creates a person who belongs to no scope — a Scope Admin or a System
+  /// Admin. Only a System Admin may.
+  Future<Result<Person>> createAdmin({
+    required String name,
+    required String email,
+    required String password,
+    required Role role,
   });
 
   /// Lists the Scope Admins who own a scope.

--- a/lib/features/persons/presentation/person_create_controller.dart
+++ b/lib/features/persons/presentation/person_create_controller.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/result/result.dart';
+import '../../auth/domain/session.dart';
+import '../../profile/presentation/profile_controller.dart';
+import '../domain/person.dart';
+
+/// How far a create attempt has got.
+sealed class PersonCreateState {
+  const PersonCreateState();
+}
+
+/// The form is being filled in.
+final class PersonCreateEditing extends PersonCreateState {
+  const PersonCreateEditing();
+}
+
+/// A request is in flight. The form refuses a second submission in this state,
+/// so a double tap cannot create two people.
+final class PersonCreateSending extends PersonCreateState {
+  const PersonCreateSending();
+}
+
+/// The person exists, and their verification email is on its way.
+final class PersonCreated extends PersonCreateState {
+  const PersonCreated(this.person);
+
+  final Person person;
+}
+
+/// AF-17b, AF-17c, AF-17d — the API refused. The form keeps everything typed.
+final class PersonCreateRejected extends PersonCreateState {
+  const PersonCreateRejected(this.failure);
+
+  final Failure failure;
+}
+
+final NotifierProviderFamily<PersonCreateController, PersonCreateState, String>
+personCreateControllerProvider =
+    NotifierProvider.family<PersonCreateController, PersonCreateState, String>(
+      PersonCreateController.new,
+    );
+
+/// Owns one create attempt from filled in to created.
+class PersonCreateController extends FamilyNotifier<PersonCreateState, String> {
+  @override
+  PersonCreateState build(String scopeId) => const PersonCreateEditing();
+
+  /// Creates the person.
+  ///
+  /// The chosen [role] decides which endpoint answers: a User belongs to the
+  /// scope, while a Scope Admin or System Admin belongs to none and is created
+  /// through the unscoped endpoint the API reserves for a System Admin.
+  Future<void> create({
+    required String name,
+    required String email,
+    required String password,
+    required Role role,
+  }) async {
+    if (state is PersonCreateSending) {
+      return;
+    }
+
+    state = const PersonCreateSending();
+
+    final repository = ref.read(personRepositoryProvider);
+    final result = role == Role.user
+        ? await repository.createUser(
+            scopeId: arg,
+            name: name,
+            email: email,
+            password: password,
+          )
+        : await repository.createAdmin(
+            name: name,
+            email: email,
+            password: password,
+            role: role,
+          );
+
+    state = result.fold(
+      onSuccess: PersonCreated.new,
+      onFailure: PersonCreateRejected.new,
+    );
+  }
+}
+
+/// The roles a [principal] may create.
+///
+/// AF-17d: a Scope Admin may not create a System Admin — nor, since the
+/// unscoped endpoint is a System Admin's alone, a Scope Admin. They create
+/// users of their scope, which is what they are offered.
+List<Role> creatableRolesFor(Principal principal) => principal.isSystemAdmin
+    ? const <Role>[Role.user, Role.scopeAdmin, Role.systemAdmin]
+    : const <Role>[Role.user];

--- a/lib/features/persons/presentation/person_create_screen.dart
+++ b/lib/features/persons/presentation/person_create_screen.dart
@@ -1,0 +1,216 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../core/result/result.dart';
+import '../../../shared/layout/app_shell.dart';
+import '../../../shared/widgets/confirm_dialog.dart';
+import '../../../shared/widgets/failure_banner.dart';
+import '../../auth/domain/session.dart';
+import '../../auth/presentation/session_controller.dart';
+import '../../home/presentation/home_screen.dart';
+import 'person_create_controller.dart';
+import 'person_list_controller.dart';
+
+/// UI-17 — the create-person form.
+class PersonCreateScreen extends ConsumerStatefulWidget {
+  const PersonCreateScreen({required this.scopeId, super.key});
+
+  final String scopeId;
+
+  @override
+  ConsumerState<PersonCreateScreen> createState() => _PersonCreateScreenState();
+}
+
+class _PersonCreateScreenState extends ConsumerState<PersonCreateScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _name = TextEditingController();
+  final _email = TextEditingController();
+  final _password = TextEditingController();
+  Role _role = Role.user;
+
+  @override
+  void dispose() {
+    _name.dispose();
+    _email.dispose();
+    _password.dispose();
+    super.dispose();
+  }
+
+  /// Whether anything has been entered, which is what AF-17e asks about before
+  /// letting the form go.
+  bool get _isDirty =>
+      _name.text.trim().isNotEmpty ||
+      _email.text.trim().isNotEmpty ||
+      _password.text.isNotEmpty ||
+      _role != Role.user;
+
+  Future<void> _submit() async {
+    // AF-17a: an empty name, a malformed address, or an empty password never
+    // reaches the API.
+    if (!(_formKey.currentState?.validate() ?? false)) {
+      return;
+    }
+
+    await ref
+        .read(personCreateControllerProvider(widget.scopeId).notifier)
+        .create(
+          name: _name.text.trim(),
+          email: _email.text.trim(),
+          password: _password.text,
+          role: _role,
+        );
+  }
+
+  /// AF-17e — leaving a modified form asks first.
+  Future<void> _cancel() async {
+    final leave =
+        !_isDirty ||
+        await showConfirm(
+          context: context,
+          title: 'Discard this person?',
+          message: 'What you have entered has not been saved and will be lost.',
+          confirmLabel: 'Discard',
+          cancelLabel: 'Keep editing',
+        );
+
+    if (leave && mounted) {
+      context.go('/scopes/${widget.scopeId}/persons');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final state = ref.watch(personCreateControllerProvider(widget.scopeId));
+    final session = ref.watch(sessionControllerProvider);
+    final sending = state is PersonCreateSending;
+
+    // AF-17d: the roles this caller may create. A Scope Admin is offered only
+    // the one they can actually make.
+    final roles = session is Authenticated
+        ? creatableRolesFor(session.principal)
+        : const <Role>[Role.user];
+
+    ref.listen<PersonCreateState>(
+      personCreateControllerProvider(widget.scopeId),
+      (previous, next) {
+        if (next case PersonCreated(:final person)) {
+          // The listing behind this form is now stale.
+          ref
+              .read(personListControllerProvider(widget.scopeId).notifier)
+              .load();
+          context.go('/scopes/${widget.scopeId}/persons/${person.id}');
+        }
+      },
+    );
+
+    return AppShell(
+      currentRoute: '/scopes',
+      title: const Text('New person'),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 560),
+            child: Form(
+              key: _formKey,
+              onChanged: () => setState(() {}),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  Text('Create a person', style: theme.textTheme.headlineSmall),
+                  const SizedBox(height: 8),
+                  Text(
+                    'The API sends them a verification email as soon as the '
+                    'record exists.',
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                  const SizedBox(height: 24),
+                  if (state is PersonCreateRejected) ...<Widget>[
+                    if (state.failure.kind == FailureKind.network)
+                      RetryBanner(onRetry: sending ? null : _submit)
+                    else
+                      // AF-17b, AF-17c, AF-17d: the API's own strings, as
+                      // returned.
+                      ErrorBanner(failure: state.failure),
+                    const SizedBox(height: 16),
+                  ],
+                  TextFormField(
+                    controller: _name,
+                    decoration: const InputDecoration(labelText: 'Name'),
+                    validator: (value) => (value?.trim().isEmpty ?? true)
+                        ? 'Enter a name.'
+                        : null,
+                  ),
+                  const SizedBox(height: 16),
+                  TextFormField(
+                    controller: _email,
+                    keyboardType: TextInputType.emailAddress,
+                    decoration: const InputDecoration(labelText: 'Email'),
+                    validator: (value) {
+                      final email = value?.trim() ?? '';
+
+                      if (email.isEmpty) {
+                        return 'Enter an email address.';
+                      }
+
+                      return email.contains('@')
+                          ? null
+                          : 'Enter a valid email address.';
+                    },
+                  ),
+                  const SizedBox(height: 16),
+                  TextFormField(
+                    controller: _password,
+                    obscureText: true,
+                    decoration: const InputDecoration(labelText: 'Password'),
+                    validator: (value) =>
+                        (value?.isEmpty ?? true) ? 'Enter a password.' : null,
+                  ),
+                  const SizedBox(height: 16),
+                  DropdownButtonFormField<Role>(
+                    initialValue: _role,
+                    decoration: const InputDecoration(labelText: 'Role'),
+                    items: <DropdownMenuItem<Role>>[
+                      for (final role in roles)
+                        DropdownMenuItem<Role>(
+                          value: role,
+                          child: Text(roleLabel(role)),
+                        ),
+                    ],
+                    onChanged: sending
+                        ? null
+                        : (role) => setState(() => _role = role ?? Role.user),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    _role == Role.user
+                        ? 'A user belongs to this scope.'
+                        : 'An administrator belongs to no scope.',
+                    style: theme.textTheme.bodySmall,
+                  ),
+                  const SizedBox(height: 24),
+                  FilledButton(
+                    onPressed: sending ? null : _submit,
+                    child: sending
+                        ? const SizedBox.square(
+                            dimension: 20,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Text('Create person'),
+                  ),
+                  const SizedBox(height: 8),
+                  TextButton(
+                    onPressed: sending ? null : _cancel,
+                    child: const Text('Cancel'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/persons/presentation/person_create_controller_test.dart
+++ b/test/features/persons/presentation/person_create_controller_test.dart
@@ -1,0 +1,288 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/features/auth/domain/session.dart';
+import 'package:heimdall_ui/features/persons/domain/person.dart';
+import 'package:heimdall_ui/features/persons/domain/person_repository.dart';
+import 'package:heimdall_ui/features/persons/presentation/person_create_controller.dart';
+import 'package:heimdall_ui/features/profile/presentation/profile_controller.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockPersonRepository extends Mock implements PersonRepository {}
+
+const _created = Person(
+  id: 'person-9',
+  name: 'Ada',
+  email: 'ada@example.com',
+  role: Role.user,
+  emailVerified: false,
+);
+
+void main() {
+  late _MockPersonRepository repository;
+  late ProviderContainer container;
+
+  PersonCreateController controllerUnderTest() {
+    container = ProviderContainer(
+      overrides: <Override>[
+        personRepositoryProvider.overrideWithValue(repository),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    return container.read(personCreateControllerProvider('scope-1').notifier);
+  }
+
+  PersonCreateState currentState() =>
+      container.read(personCreateControllerProvider('scope-1'));
+
+  void answerUserWith(Result<Person> result) {
+    when(
+      () => repository.createUser(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        password: any(named: 'password'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  void answerAdminWith(Result<Person> result) {
+    when(
+      () => repository.createAdmin(
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        password: any(named: 'password'),
+        role: any(named: 'role'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  setUpAll(() {
+    // `any(named: 'role')` needs a value it can pass around without touching.
+    registerFallbackValue(Role.user);
+  });
+
+  setUp(() {
+    repository = _MockPersonRepository();
+  });
+
+  test('GivenTheUserRole_WhenCreated_ThenTheScopeEndpointIsUsed', () async {
+    // Given
+    answerUserWith(const Success<Person>(_created));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.create(
+      name: 'Ada',
+      email: 'ada@example.com',
+      password: 'secret',
+      role: Role.user,
+    );
+
+    // Then
+    verify(
+      () => repository.createUser(
+        scopeId: 'scope-1',
+        name: 'Ada',
+        email: 'ada@example.com',
+        password: 'secret',
+      ),
+    ).called(1);
+  });
+
+  test('GivenAnAdminRole_WhenCreated_ThenTheUnscopedEndpointIsUsed', () async {
+    // Given
+    answerAdminWith(const Success<Person>(_created));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.create(
+      name: 'Grace',
+      email: 'grace@example.com',
+      password: 'secret',
+      role: Role.scopeAdmin,
+    );
+
+    // Then
+    verify(
+      () => repository.createAdmin(
+        name: 'Grace',
+        email: 'grace@example.com',
+        password: 'secret',
+        role: Role.scopeAdmin,
+      ),
+    ).called(1);
+  });
+
+  test('GivenACreatedPerson_WhenCreated_ThenTheRecordIsReturned', () async {
+    // Given
+    answerUserWith(const Success<Person>(_created));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.create(
+      name: 'Ada',
+      email: 'ada@example.com',
+      password: 'secret',
+      role: Role.user,
+    );
+
+    // Then
+    expect((currentState() as PersonCreated).person.id, 'person-9');
+  });
+
+  // AF-17b — the address is already registered.
+  test('GivenARegisteredEmail_WhenCreated_ThenApiErrorsAreKept', () async {
+    // Given
+    answerUserWith(
+      const FailureResult<Person>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['That email address is already registered.'],
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.create(
+      name: 'Ada',
+      email: 'taken@example.com',
+      password: 'secret',
+      role: Role.user,
+    );
+
+    // Then
+    expect((currentState() as PersonCreateRejected).failure.errors, <String>[
+      'That email address is already registered.',
+    ]);
+  });
+
+  // AF-17c — the password does not satisfy the API's policy.
+  test('GivenARejectedPassword_WhenCreated_ThenApiErrorsAreKept', () async {
+    // Given
+    answerUserWith(
+      const FailureResult<Person>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['The password is too short.'],
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.create(
+      name: 'Ada',
+      email: 'ada@example.com',
+      password: 'x',
+      role: Role.user,
+    );
+
+    // Then
+    expect((currentState() as PersonCreateRejected).failure.errors, <String>[
+      'The password is too short.',
+    ]);
+  });
+
+  // AF-17d — the API refuses a role the caller may not create.
+  test('GivenARefusedRole_WhenCreated_ThenApiErrorsAreKept', () async {
+    // Given
+    answerAdminWith(
+      const FailureResult<Person>(
+        Failure(
+          kind: FailureKind.forbidden,
+          errors: <String>['Only a System Admin may create an administrator.'],
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.create(
+      name: 'Grace',
+      email: 'grace@example.com',
+      password: 'secret',
+      role: Role.systemAdmin,
+    );
+
+    // Then
+    expect((currentState() as PersonCreateRejected).failure.errors, <String>[
+      'Only a System Admin may create an administrator.',
+    ]);
+  });
+
+  test('GivenARequestInFlight_WhenSubmittedAgain_ThenOnlyOneIsSent', () async {
+    // Given
+    final pending = Completer<Result<Person>>();
+    when(
+      () => repository.createUser(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        password: any(named: 'password'),
+      ),
+    ).thenAnswer((_) => pending.future);
+    final controller = controllerUnderTest();
+
+    // When
+    final first = controller.create(
+      name: 'Ada',
+      email: 'ada@example.com',
+      password: 'secret',
+      role: Role.user,
+    );
+    final second = controller.create(
+      name: 'Ada',
+      email: 'ada@example.com',
+      password: 'secret',
+      role: Role.user,
+    );
+    pending.complete(const Success<Person>(_created));
+    await Future.wait<void>(<Future<void>>[first, second]);
+
+    // Then
+    verify(
+      () => repository.createUser(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        password: any(named: 'password'),
+      ),
+    ).called(1);
+  });
+
+  // AF-17d — a Scope Admin is not offered a role they cannot create.
+  test('GivenAScopeAdmin_WhenRolesOffered_ThenOnlyUserIsAmongThem', () {
+    // Given
+    const principal = Principal(
+      id: 'person-1',
+      email: 'admin@example.com',
+      role: Role.scopeAdmin,
+    );
+
+    // When
+    final roles = creatableRolesFor(principal);
+
+    // Then
+    expect(roles, <Role>[Role.user]);
+  });
+
+  test('GivenASystemAdmin_WhenRolesOffered_ThenAllThreeAreAmongThem', () {
+    // Given
+    const principal = Principal(
+      id: 'person-1',
+      email: 'admin@example.com',
+      role: Role.systemAdmin,
+    );
+
+    // When
+    final roles = creatableRolesFor(principal);
+
+    // Then
+    expect(roles, <Role>[Role.user, Role.scopeAdmin, Role.systemAdmin]);
+  });
+}

--- a/test/features/persons/presentation/person_create_screen_test.dart
+++ b/test/features/persons/presentation/person_create_screen_test.dart
@@ -1,0 +1,471 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:heimdall_ui/app/theme.dart';
+import 'package:heimdall_ui/core/network/envelope.dart' as envelope;
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/core/storage/token_store.dart';
+import 'package:heimdall_ui/features/auth/domain/session.dart';
+import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
+import 'package:heimdall_ui/features/persons/domain/person.dart';
+import 'package:heimdall_ui/features/persons/domain/person_repository.dart';
+import 'package:heimdall_ui/features/persons/presentation/person_create_screen.dart';
+import 'package:heimdall_ui/features/profile/presentation/profile_controller.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockPersonRepository extends Mock implements PersonRepository {}
+
+/// A token naming a person of [role]: 1 System Admin, 2 Scope Admin.
+String _jwt({int role = 1}) {
+  final payload = base64Url.encode(
+    utf8.encode(
+      jsonEncode(<String, dynamic>{
+        'sub': 'person-9',
+        'email': 'admin@example.com',
+        'role': role,
+      }),
+    ),
+  );
+
+  return 'header.$payload.signature';
+}
+
+const _created = Person(
+  id: 'person-9',
+  name: 'Ada',
+  email: 'ada@example.com',
+  role: Role.user,
+  emailVerified: false,
+);
+
+const Size _compact = Size(400, 900);
+const Size _medium = Size(800, 900);
+const Size _expanded = Size(1400, 900);
+
+void main() {
+  late _MockPersonRepository repository;
+  late InMemoryTokenStore store;
+  late ProviderContainer container;
+  late GoRouter router;
+
+  Future<void> pump(
+    WidgetTester tester, {
+    Size size = _expanded,
+    ThemeData? theme,
+    int role = 1,
+  }) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await store.write(
+      AuthToken(
+        value: _jwt(role: role),
+        expiresAt: DateTime.utc(2030),
+      ),
+    );
+
+    container = ProviderContainer(
+      overrides: <Override>[
+        personRepositoryProvider.overrideWithValue(repository),
+        tokenStoreProvider.overrideWithValue(store),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(sessionControllerProvider.notifier).restore();
+
+    router = GoRouter(
+      initialLocation: '/scopes/scope-1/persons/new',
+      routes: <RouteBase>[
+        GoRoute(
+          path: '/scopes/:scopeId/persons',
+          builder: (context, state) => const Scaffold(body: Text('listing')),
+        ),
+        GoRoute(
+          path: '/scopes/:scopeId/persons/new',
+          builder: (context, state) =>
+              PersonCreateScreen(scopeId: state.pathParameters['scopeId']!),
+        ),
+        GoRoute(
+          path: '/scopes/:scopeId/persons/:personId',
+          builder: (context, state) => Scaffold(
+            body: Text('detail ${state.pathParameters['personId']}'),
+          ),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(
+          theme: theme ?? buildLightTheme(),
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  void answerUserWith(Result<Person> result) {
+    when(
+      () => repository.createUser(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        password: any(named: 'password'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  Future<void> fillIn(
+    WidgetTester tester, {
+    String name = 'Ada',
+    String email = 'ada@example.com',
+    String password = 'secret',
+  }) async {
+    await tester.enterText(find.widgetWithText(TextFormField, 'Name'), name);
+    await tester.enterText(find.widgetWithText(TextFormField, 'Email'), email);
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Password'),
+      password,
+    );
+    await tester.pumpAndSettle();
+  }
+
+  setUpAll(() => registerFallbackValue(Role.user));
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    repository = _MockPersonRepository();
+    store = InMemoryTokenStore();
+    answerUserWith(const Success<Person>(_created));
+    when(
+      () => repository.createAdmin(
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        password: any(named: 'password'),
+        role: any(named: 'role'),
+      ),
+    ).thenAnswer((_) async => const Success<Person>(_created));
+    when(
+      () => repository.listScopePersons(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer(
+      (_) async => const Success<envelope.Page<Person>>(
+        envelope.Page<Person>(
+          items: <Person>[],
+          pageNumber: 1,
+          pageSize: 20,
+          totalItems: 0,
+          totalPages: 1,
+        ),
+      ),
+    );
+  });
+
+  testWidgets('GivenACompleteForm_WhenSubmitted_ThenThePersonIsCreated', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+    await fillIn(tester);
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create person'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => repository.createUser(
+        scopeId: 'scope-1',
+        name: 'Ada',
+        email: 'ada@example.com',
+        password: 'secret',
+      ),
+    ).called(1);
+  });
+
+  testWidgets('GivenACreatedPerson_WhenCreated_ThenTheirDetailOpens', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+    await fillIn(tester);
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create person'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('detail person-9'), findsOneWidget);
+  });
+
+  // AF-17a — what the client can tell is wrong never reaches the API.
+  testWidgets('GivenAnEmptyName_WhenSubmitted_ThenNoRequestIsMade', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+    await fillIn(tester, name: '');
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create person'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verifyNever(
+      () => repository.createUser(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        password: any(named: 'password'),
+      ),
+    );
+  });
+
+  testWidgets('GivenAMalformedEmail_WhenSubmitted_ThenTheFieldSaysSo', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+    await fillIn(tester, email: 'not-an-address');
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create person'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('Enter a valid email address.'), findsOneWidget);
+  });
+
+  testWidgets('GivenAnEmptyPassword_WhenSubmitted_ThenTheFieldSaysSo', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+    await fillIn(tester, password: '');
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create person'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('Enter a password.'), findsOneWidget);
+  });
+
+  // AF-17b — the address is already registered.
+  testWidgets('GivenARegisteredEmail_WhenSubmitted_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerUserWith(
+      const FailureResult<Person>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['That email address is already registered.'],
+        ),
+      ),
+    );
+    await pump(tester);
+    await fillIn(tester);
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create person'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(
+      find.text('That email address is already registered.'),
+      findsOneWidget,
+    );
+  });
+
+  // AF-17c — the password does not satisfy the API's policy.
+  testWidgets('GivenARejectedPassword_WhenSubmitted_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerUserWith(
+      const FailureResult<Person>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['The password is too short.'],
+        ),
+      ),
+    );
+    await pump(tester);
+    await fillIn(tester);
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create person'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('The password is too short.'), findsOneWidget);
+  });
+
+  testWidgets('GivenARejectedCreate_WhenSubmitted_ThenTheInputIsKept', (
+    tester,
+  ) async {
+    // Given
+    answerUserWith(
+      const FailureResult<Person>(
+        Failure(kind: FailureKind.validation, errors: <String>['No.']),
+      ),
+    );
+    await pump(tester);
+    await fillIn(tester);
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create person'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.widgetWithText(TextFormField, 'Ada'), findsOneWidget);
+  });
+
+  // AF-17d — a Scope Admin is not offered a role they cannot create.
+  testWidgets('GivenAScopeAdmin_WhenRendered_ThenOnlyUserIsOffered', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester, role: 2);
+
+    // When
+    await tester.tap(find.byType(DropdownButtonFormField<Role>));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('System Admin'), findsNothing);
+    expect(find.text('Scope Admin'), findsNothing);
+  });
+
+  testWidgets('GivenASystemAdmin_WhenRendered_ThenEveryRoleIsOffered', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+
+    // When
+    await tester.tap(find.byType(DropdownButtonFormField<Role>));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('System Admin'), findsOneWidget);
+  });
+
+  testWidgets('GivenAnAdminRole_WhenChosen_ThenTheUnscopedEndpointIsUsed', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+    await fillIn(tester, name: 'Grace', email: 'grace@example.com');
+    await tester.tap(find.byType(DropdownButtonFormField<Role>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Scope Admin').last);
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create person'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => repository.createAdmin(
+        name: 'Grace',
+        email: 'grace@example.com',
+        password: 'secret',
+        role: Role.scopeAdmin,
+      ),
+    ).called(1);
+  });
+
+  // AF-17e — leaving a modified form asks first.
+  testWidgets('GivenAModifiedForm_WhenCancelled_ThenConfirmationIsAsked', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+    await fillIn(tester);
+
+    // When
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('Discard this person?'), findsOneWidget);
+  });
+
+  testWidgets('GivenAModifiedForm_WhenDiscardConfirmed_ThenTheListingOpens', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+    await fillIn(tester);
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Discard'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('listing'), findsOneWidget);
+  });
+
+  testWidgets('GivenAnUntouchedForm_WhenCancelled_ThenTheListingOpensAtOnce', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+
+    // When
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('listing'), findsOneWidget);
+  });
+
+  testWidgets('GivenACompactWindow_WhenRendered_ThenTheFormIsShown', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, size: _compact);
+
+    // Then
+    expect(find.text('Create a person'), findsOneWidget);
+  });
+
+  testWidgets('GivenAMediumWindow_WhenRendered_ThenTheFormIsShown', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, size: _medium);
+
+    // Then
+    expect(find.text('Create a person'), findsOneWidget);
+  });
+
+  testWidgets('GivenTheDarkTheme_WhenRendered_ThenTheFormIsStillShown', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, theme: buildDarkTheme());
+
+    // Then
+    expect(find.text('Create a person'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #17

Implements UI-17 — `/scopes/:scopeId/persons/new` over `POST /api/scopes/{scopeId}/persons` (FR-PE-03) and `POST /api/persons` (FR-PE-04).

## Which endpoint

The chosen role decides. A **User** belongs to the scope and goes through the scoped endpoint; a **Scope Admin** or **System Admin** belongs to no scope and goes through the unscoped one the API reserves for a System Admin. The form states which under the selector, so the difference is not a surprise after the fact.

## Flows

| Flow | How it is handled |
| --- | --- |
| Main | Name, email, password and role; on success the new person's detail opens. |
| AF-17a | An empty name, a malformed address, or an empty password blocks submission. |
| AF-17b | A registered address comes back as the API's own strings. |
| AF-17c | So does a password its policy refuses. |
| AF-17d | A Scope Admin is offered only `User`; a refusal from the API is shown as returned. |
| AF-17e | Leaving a modified form asks for confirmation first. |

## Verification

`dart format --set-exit-if-changed .`, `flutter analyze`, and `flutter test` all pass — **569 tests**, 26 of them new. No presentation file imports `package:heimdall_api_client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)