### PR TITLE
feat(ui-18): view and update a person

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ the board is where an item's status changes as it moves.
 | --- | --- | --- |
 | UI-16: Browse and search persons in a scope | ✅ | [#16](https://github.com/artur-rios/heimdall-ui/issues/16) |
 | UI-17: Create a person | ✅ | [#17](https://github.com/artur-rios/heimdall-ui/issues/17) |
-| UI-18: View and update a person | ⬜ | [#18](https://github.com/artur-rios/heimdall-ui/issues/18) |
+| UI-18: View and update a person | ✅ | [#18](https://github.com/artur-rios/heimdall-ui/issues/18) |
 | UI-19: Delete a person, logically and permanently | ⬜ | [#19](https://github.com/artur-rios/heimdall-ui/issues/19) |
 
 ### Application Management

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -11,6 +11,7 @@ import '../features/auth/presentation/two_factor_screen.dart';
 import '../features/auth/presentation/verify_email_screen.dart';
 import '../features/home/presentation/home_screen.dart';
 import '../features/persons/presentation/person_create_screen.dart';
+import '../features/persons/presentation/person_detail_screen.dart';
 import '../features/persons/presentation/person_list_screen.dart';
 import '../features/profile/presentation/profile_screen.dart';
 import '../features/scopes/presentation/scope_create_screen.dart';
@@ -147,6 +148,13 @@ final Provider<GoRouter> routerProvider = Provider<GoRouter>((ref) {
         path: '/scopes/:scopeId/persons/new',
         builder: (context, state) =>
             PersonCreateScreen(scopeId: state.pathParameters['scopeId']!),
+      ),
+      GoRoute(
+        path: '/scopes/:scopeId/persons/:personId',
+        builder: (context, state) => PersonDetailScreen(
+          scopeId: state.pathParameters['scopeId']!,
+          personId: state.pathParameters['personId']!,
+        ),
       ),
       GoRoute(
         path: '/not-available',

--- a/lib/features/persons/presentation/person_detail_controller.dart
+++ b/lib/features/persons/presentation/person_detail_controller.dart
@@ -1,0 +1,132 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/result/result.dart';
+import '../../profile/presentation/profile_controller.dart';
+import '../domain/person.dart';
+
+/// How far the person detail has got.
+sealed class PersonDetailState {
+  const PersonDetailState();
+}
+
+/// The record is being read.
+final class PersonDetailLoading extends PersonDetailState {
+  const PersonDetailLoading();
+}
+
+/// AF-18a and AF-18b — the record could not be read.
+final class PersonDetailUnavailable extends PersonDetailState {
+  const PersonDetailUnavailable(this.failure);
+
+  final Failure failure;
+
+  bool get isNotFound => failure.kind == FailureKind.notFound;
+  bool get isForbidden => failure.kind == FailureKind.forbidden;
+}
+
+/// The record is on screen.
+final class PersonDetailLoaded extends PersonDetailState {
+  const PersonDetailLoaded(
+    this.person, {
+    this.saving = false,
+    this.saveFailure,
+    this.saved = false,
+  });
+
+  final Person person;
+  final bool saving;
+  final Failure? saveFailure;
+  final bool saved;
+
+  /// AF-18d — a logically deleted person is shown, but nothing about them may
+  /// be changed from here.
+  bool get isReadOnly => person.isDeleted;
+
+  PersonDetailLoaded copyWith({
+    Person? person,
+    bool? saving,
+    Failure? saveFailure,
+    bool clearSaveFailure = false,
+    bool? saved,
+  }) => PersonDetailLoaded(
+    person ?? this.person,
+    saving: saving ?? this.saving,
+    saveFailure: clearSaveFailure ? null : (saveFailure ?? this.saveFailure),
+    saved: saved ?? this.saved,
+  );
+}
+
+/// Family-keyed on the person's identifier, so two detail screens opened from
+/// two tabs do not share one state.
+final NotifierProviderFamily<PersonDetailController, PersonDetailState, String>
+personDetailControllerProvider =
+    NotifierProvider.family<PersonDetailController, PersonDetailState, String>(
+      PersonDetailController.new,
+    );
+
+/// Owns one person's detail: reading it, and saving edits to it.
+class PersonDetailController extends FamilyNotifier<PersonDetailState, String> {
+  @override
+  PersonDetailState build(String personId) => const PersonDetailLoading();
+
+  /// Reads the person.
+  ///
+  /// Deleted persons are included: AF-18d shows one read-only, and it cannot
+  /// do that if the API is asked to pretend they are gone.
+  Future<void> load() async {
+    state = const PersonDetailLoading();
+
+    final result = await ref
+        .read(personRepositoryProvider)
+        .getById(arg, includeDeleted: true);
+
+    state = result.fold(
+      onSuccess: PersonDetailLoaded.new,
+      onFailure: PersonDetailUnavailable.new,
+    );
+  }
+
+  /// Saves [name] and [email].
+  ///
+  /// The role is never sent. FR-PE-06 makes this screen's edit the name and
+  /// the address, and leaving the role out is also what stops anyone changing
+  /// their own (AF-18e).
+  Future<void> save({required String name, required String email}) async {
+    final current = state;
+
+    if (current is! PersonDetailLoaded ||
+        current.saving ||
+        current.isReadOnly) {
+      return;
+    }
+
+    if (name == current.person.name && email == current.person.email) {
+      return;
+    }
+
+    state = current.copyWith(
+      saving: true,
+      clearSaveFailure: true,
+      saved: false,
+    );
+
+    final result = await ref
+        .read(personRepositoryProvider)
+        .update(id: arg, name: name, email: email);
+
+    state = result.fold(
+      onSuccess: (person) => PersonDetailLoaded(person, saved: true),
+      // AF-18c: the refusal is kept as it came back, and the record on screen
+      // is still the one the API last confirmed.
+      onFailure: (failure) =>
+          current.copyWith(saving: false, saveFailure: failure),
+    );
+  }
+
+  /// Drops the "saved" acknowledgement so a later edit starts clean.
+  void acknowledgeSave() {
+    if (state case final PersonDetailLoaded loaded) {
+      state = loaded.copyWith(saved: false);
+    }
+  }
+}

--- a/lib/features/persons/presentation/person_detail_screen.dart
+++ b/lib/features/persons/presentation/person_detail_screen.dart
@@ -1,0 +1,346 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../core/result/result.dart';
+import '../../../shared/layout/app_shell.dart';
+import '../../../shared/widgets/collection_states.dart';
+import '../../../shared/widgets/failure_banner.dart';
+import '../../auth/domain/session.dart';
+import '../../auth/presentation/session_controller.dart';
+import '../../home/presentation/home_screen.dart';
+import '../domain/person.dart';
+import 'person_detail_controller.dart';
+
+/// UI-18 — one person, as an administrator sees them.
+class PersonDetailScreen extends ConsumerStatefulWidget {
+  const PersonDetailScreen({
+    required this.scopeId,
+    required this.personId,
+    super.key,
+  });
+
+  final String scopeId;
+  final String personId;
+
+  @override
+  ConsumerState<PersonDetailScreen> createState() => _PersonDetailScreenState();
+}
+
+class _PersonDetailScreenState extends ConsumerState<PersonDetailScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _name = TextEditingController();
+  final _email = TextEditingController();
+
+  /// The record the fields were last seeded from, which is what decides
+  /// whether anything actually differs.
+  Person? _seeded;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => ref
+          .read(personDetailControllerProvider(widget.personId).notifier)
+          .load(),
+    );
+  }
+
+  @override
+  void dispose() {
+    _name.dispose();
+    _email.dispose();
+    super.dispose();
+  }
+
+  /// Copies a freshly read or freshly saved record into the fields.
+  ///
+  /// AF-18c is why this only runs when the record itself changed: a refused
+  /// save must leave what the user typed exactly where it was.
+  void _seed(Person person) {
+    if (identical(_seeded, person)) {
+      return;
+    }
+
+    _seeded = person;
+    _name.text = person.name;
+    _email.text = person.email;
+  }
+
+  bool _differsFrom(Person person) =>
+      _name.text.trim() != person.name || _email.text.trim() != person.email;
+
+  /// AF-18e — whether this is the caller's own record, which is worth saying
+  /// out loud on an administrative screen.
+  bool get _isSelf {
+    final session = ref.watch(sessionControllerProvider);
+
+    return session is Authenticated && session.principal.id == widget.personId;
+  }
+
+  Future<void> _save() async {
+    if (!(_formKey.currentState?.validate() ?? false)) {
+      return;
+    }
+
+    await ref
+        .read(personDetailControllerProvider(widget.personId).notifier)
+        .save(name: _name.text.trim(), email: _email.text.trim());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(personDetailControllerProvider(widget.personId));
+    final controller = ref.read(
+      personDetailControllerProvider(widget.personId).notifier,
+    );
+    final backToListing = '/scopes/${widget.scopeId}/persons';
+
+    return AppShell(
+      currentRoute: '/scopes',
+      title: Text(switch (state) {
+        PersonDetailLoaded(:final person) => person.name,
+        _ => 'Person',
+      }),
+      actions: <Widget>[
+        IconButton(
+          tooltip: 'Back to the listing',
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.go(backToListing),
+        ),
+      ],
+      body: switch (state) {
+        PersonDetailLoading() => const Center(
+          child: CircularProgressIndicator(),
+        ),
+        // AF-18a — no such person.
+        PersonDetailUnavailable(isNotFound: true) => CollectionEmpty(
+          title: 'Person not found',
+          message:
+              'There is nobody with that identifier. They may have been '
+              'permanently deleted.',
+          icon: Icons.search_off_outlined,
+          actionLabel: 'Back to the listing',
+          onAction: () => context.go(backToListing),
+        ),
+        // AF-18b — the API says this person is not within reach of this role.
+        PersonDetailUnavailable(isForbidden: true) => CollectionEmpty(
+          title: 'Not available for your role',
+          message:
+              'This person is not one you administer. Nothing is wrong '
+              'with your session.',
+          icon: Icons.lock_person_outlined,
+          actionLabel: 'Back to the listing',
+          onAction: () => context.go(backToListing),
+        ),
+        PersonDetailUnavailable(:final failure) => CollectionFailed(
+          failure: failure,
+          onRetry: controller.load,
+        ),
+        final PersonDetailLoaded loaded => _detail(loaded),
+      },
+    );
+  }
+
+  Widget _detail(PersonDetailLoaded state) {
+    final theme = Theme.of(context);
+    _seed(state.person);
+    final person = state.person;
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(24),
+      child: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 640),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              // AF-18d — a deleted person says so before anything else, since
+              // everything below is read-only because of it.
+              if (state.isReadOnly) ...<Widget>[
+                const _Notice(
+                  icon: Icons.person_off_outlined,
+                  message:
+                      'This person is deleted. They are shown for '
+                      'reference and cannot be changed from here.',
+                  destructive: true,
+                ),
+                const SizedBox(height: 16),
+              ],
+              // AF-18e — this is you. The editing is the same as UI-08's, and
+              // the role is not editable here for anyone.
+              if (_isSelf && !state.isReadOnly) ...<Widget>[
+                const _Notice(
+                  icon: Icons.person_outline,
+                  message:
+                      'This is your own record. Your role is not '
+                      'something you can change here.',
+                ),
+                const SizedBox(height: 16),
+              ],
+              Form(
+                key: _formKey,
+                onChanged: () => setState(() {}),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: <Widget>[
+                    if (state.saveFailure
+                        case final Failure failure) ...<Widget>[
+                      if (failure.kind == FailureKind.network)
+                        RetryBanner(onRetry: state.saving ? null : _save)
+                      else
+                        // AF-18c: the API's own strings, as returned.
+                        ErrorBanner(failure: failure),
+                      const SizedBox(height: 16),
+                    ],
+                    if (state.saved) ...<Widget>[
+                      const _Notice(
+                        icon: Icons.check_circle_outline,
+                        message: 'Saved.',
+                      ),
+                      const SizedBox(height: 16),
+                    ],
+                    TextFormField(
+                      controller: _name,
+                      readOnly: state.isReadOnly,
+                      decoration: const InputDecoration(labelText: 'Name'),
+                      validator: (value) => (value?.trim().isEmpty ?? true)
+                          ? 'Enter a name.'
+                          : null,
+                    ),
+                    const SizedBox(height: 16),
+                    TextFormField(
+                      controller: _email,
+                      readOnly: state.isReadOnly,
+                      keyboardType: TextInputType.emailAddress,
+                      decoration: const InputDecoration(labelText: 'Email'),
+                      validator: (value) {
+                        final email = value?.trim() ?? '';
+
+                        if (email.isEmpty) {
+                          return 'Enter an email address.';
+                        }
+
+                        return email.contains('@')
+                            ? null
+                            : 'Enter a valid email address.';
+                      },
+                    ),
+                    const SizedBox(height: 16),
+                    if (!state.isReadOnly)
+                      FilledButton(
+                        onPressed: (state.saving || !_differsFrom(person))
+                            ? null
+                            : _save,
+                        child: state.saving
+                            ? const SizedBox.square(
+                                dimension: 20,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
+                              )
+                            : const Text('Save changes'),
+                      ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 24),
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: DefaultTextStyle.merge(
+                    style: theme.textTheme.bodyMedium,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        _Fact(label: 'Role', value: roleLabel(person.role)),
+                        _Fact(
+                          label: 'Email verified',
+                          value: person.emailVerified ? 'Yes' : 'No',
+                        ),
+                        _Fact(
+                          label: 'Scope',
+                          value: person.scopeId ?? 'Not a member of a scope',
+                        ),
+                        _Fact(
+                          label: 'Owned scopes',
+                          value: person.ownedScopeIds.isEmpty
+                              ? 'None'
+                              : person.ownedScopeIds.join(', '),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// A one-line panel: what a deleted record, your own record, and a saved edit
+/// each say about themselves.
+class _Notice extends StatelessWidget {
+  const _Notice({
+    required this.icon,
+    required this.message,
+    this.destructive = false,
+  });
+
+  final IconData icon;
+  final String message;
+  final bool destructive;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final background = destructive
+        ? scheme.errorContainer
+        : scheme.secondaryContainer;
+    final foreground = destructive
+        ? scheme.onErrorContainer
+        : scheme.onSecondaryContainer;
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: <Widget>[
+          Icon(icon, color: foreground),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(message, style: TextStyle(color: foreground)),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Fact extends StatelessWidget {
+  const _Fact({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.symmetric(vertical: 4),
+    child: Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        SizedBox(
+          width: 140,
+          child: Text(label, style: Theme.of(context).textTheme.labelLarge),
+        ),
+        Expanded(child: Text(value)),
+      ],
+    ),
+  );
+}

--- a/test/features/persons/presentation/person_detail_controller_test.dart
+++ b/test/features/persons/presentation/person_detail_controller_test.dart
@@ -1,0 +1,288 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/features/auth/domain/session.dart';
+import 'package:heimdall_ui/features/persons/domain/person.dart';
+import 'package:heimdall_ui/features/persons/domain/person_repository.dart';
+import 'package:heimdall_ui/features/persons/presentation/person_detail_controller.dart';
+import 'package:heimdall_ui/features/profile/presentation/profile_controller.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockPersonRepository extends Mock implements PersonRepository {}
+
+const _ada = Person(
+  id: 'person-1',
+  name: 'Ada',
+  email: 'ada@example.com',
+  role: Role.user,
+  scopeId: 'scope-1',
+);
+
+const _deleted = Person(
+  id: 'person-1',
+  name: 'Ada',
+  email: 'ada@example.com',
+  role: Role.user,
+  isDeleted: true,
+);
+
+void main() {
+  late _MockPersonRepository repository;
+  late ProviderContainer container;
+
+  PersonDetailController controllerUnderTest() {
+    container = ProviderContainer(
+      overrides: <Override>[
+        personRepositoryProvider.overrideWithValue(repository),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    return container.read(personDetailControllerProvider('person-1').notifier);
+  }
+
+  PersonDetailState currentState() =>
+      container.read(personDetailControllerProvider('person-1'));
+
+  void answerGetWith(Result<Person> result) {
+    when(
+      () => repository.getById(
+        any(),
+        includeDeleted: any(named: 'includeDeleted'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  void answerUpdateWith(Result<Person> result) {
+    when(
+      () => repository.update(
+        id: any(named: 'id'),
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        roleId: any(named: 'roleId'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  setUp(() {
+    repository = _MockPersonRepository();
+  });
+
+  test('GivenAPerson_WhenLoaded_ThenTheRecordIsShown', () async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    expect((currentState() as PersonDetailLoaded).person.name, 'Ada');
+  });
+
+  // AF-18d — a deleted person must be readable, so the read includes them.
+  test('GivenAPerson_WhenLoaded_ThenDeletedRecordsAreIncluded', () async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    verify(
+      () => repository.getById('person-1', includeDeleted: true),
+    ).called(1);
+  });
+
+  // AF-18a — no such person.
+  test('GivenAMissingPerson_WhenLoaded_ThenStateIsNotFound', () async {
+    // Given
+    answerGetWith(
+      const FailureResult<Person>(
+        Failure(kind: FailureKind.notFound, errors: <String>[]),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    expect((currentState() as PersonDetailUnavailable).isNotFound, isTrue);
+  });
+
+  // AF-18b — the person is out of this role's reach.
+  test('GivenAForbiddenPerson_WhenLoaded_ThenStateIsForbidden', () async {
+    // Given
+    answerGetWith(
+      const FailureResult<Person>(
+        Failure(kind: FailureKind.forbidden, errors: <String>[]),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    expect((currentState() as PersonDetailUnavailable).isForbidden, isTrue);
+  });
+
+  test('GivenAnEdit_WhenSaved_ThenTheNewValuesAreSent', () async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+    answerUpdateWith(
+      const Success<Person>(
+        Person(
+          id: 'person-1',
+          name: 'Ada L',
+          email: 'ada@example.com',
+          role: Role.user,
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.save(name: 'Ada L', email: 'ada@example.com');
+
+    // Then
+    verify(
+      () => repository.update(
+        id: 'person-1',
+        name: 'Ada L',
+        email: 'ada@example.com',
+      ),
+    ).called(1);
+  });
+
+  // AF-18e — the role is never part of what this screen sends.
+  test('GivenAnEdit_WhenSaved_ThenNoRoleIsSent', () async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+    answerUpdateWith(const Success<Person>(_ada));
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.save(name: 'Ada L', email: 'ada@example.com');
+
+    // Then
+    final captured = verify(
+      () => repository.update(
+        id: any(named: 'id'),
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        roleId: captureAny(named: 'roleId'),
+      ),
+    ).captured;
+    expect(captured.single, isNull);
+  });
+
+  // AF-18c — a refusal keeps the record and carries the API's own errors.
+  test('GivenARejectedUpdate_WhenSaved_ThenApiErrorsAreKept', () async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+    answerUpdateWith(
+      const FailureResult<Person>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['That email address is already registered.'],
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.save(name: 'Ada', email: 'taken@example.com');
+
+    // Then
+    final state = currentState() as PersonDetailLoaded;
+    expect(state.saveFailure?.errors, <String>[
+      'That email address is already registered.',
+    ]);
+    expect(state.person.email, 'ada@example.com');
+  });
+
+  // AF-18d — a deleted person is read-only.
+  test('GivenADeletedPerson_WhenLoaded_ThenTheyAreReadOnly', () async {
+    // Given
+    answerGetWith(const Success<Person>(_deleted));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    expect((currentState() as PersonDetailLoaded).isReadOnly, isTrue);
+  });
+
+  test('GivenADeletedPerson_WhenSaved_ThenNoRequestIsMade', () async {
+    // Given
+    answerGetWith(const Success<Person>(_deleted));
+    answerUpdateWith(const Success<Person>(_deleted));
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.save(name: 'Anything', email: 'anything@example.com');
+
+    // Then
+    verifyNever(
+      () => repository.update(
+        id: any(named: 'id'),
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        roleId: any(named: 'roleId'),
+      ),
+    );
+  });
+
+  test('GivenNoChange_WhenSaved_ThenNoRequestIsMade', () async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+    answerUpdateWith(const Success<Person>(_ada));
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.save(name: 'Ada', email: 'ada@example.com');
+
+    // Then
+    verifyNever(
+      () => repository.update(
+        id: any(named: 'id'),
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        roleId: any(named: 'roleId'),
+      ),
+    );
+  });
+
+  test('GivenASavedPerson_WhenAcknowledged_ThenTheNoticeClears', () async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+    answerUpdateWith(
+      const Success<Person>(
+        Person(
+          id: 'person-1',
+          name: 'Ada L',
+          email: 'ada@example.com',
+          role: Role.user,
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+    await controller.load();
+    await controller.save(name: 'Ada L', email: 'ada@example.com');
+
+    // When
+    controller.acknowledgeSave();
+
+    // Then
+    expect((currentState() as PersonDetailLoaded).saved, isFalse);
+  });
+}

--- a/test/features/persons/presentation/person_detail_screen_test.dart
+++ b/test/features/persons/presentation/person_detail_screen_test.dart
@@ -1,0 +1,410 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:heimdall_ui/app/theme.dart';
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/core/storage/token_store.dart';
+import 'package:heimdall_ui/features/auth/domain/session.dart';
+import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
+import 'package:heimdall_ui/features/persons/domain/person.dart';
+import 'package:heimdall_ui/features/persons/domain/person_repository.dart';
+import 'package:heimdall_ui/features/persons/presentation/person_detail_screen.dart';
+import 'package:heimdall_ui/features/profile/presentation/profile_controller.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockPersonRepository extends Mock implements PersonRepository {}
+
+/// A token naming the signed-in person, which AF-18e compares against.
+String _jwt({String sub = 'person-9'}) {
+  final payload = base64Url.encode(
+    utf8.encode(
+      jsonEncode(<String, dynamic>{
+        'sub': sub,
+        'email': 'admin@example.com',
+        'role': 1,
+      }),
+    ),
+  );
+
+  return 'header.$payload.signature';
+}
+
+const _ada = Person(
+  id: 'person-1',
+  name: 'Ada',
+  email: 'ada@example.com',
+  role: Role.user,
+  scopeId: 'scope-1',
+);
+
+const _deleted = Person(
+  id: 'person-1',
+  name: 'Ada',
+  email: 'ada@example.com',
+  role: Role.user,
+  isDeleted: true,
+);
+
+const Size _compact = Size(400, 900);
+const Size _medium = Size(800, 900);
+const Size _expanded = Size(1400, 900);
+
+void main() {
+  late _MockPersonRepository repository;
+  late InMemoryTokenStore store;
+  late ProviderContainer container;
+  late GoRouter router;
+
+  Future<void> pump(
+    WidgetTester tester, {
+    Size size = _expanded,
+    ThemeData? theme,
+    String signedInAs = 'person-9',
+  }) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await store.write(
+      AuthToken(
+        value: _jwt(sub: signedInAs),
+        expiresAt: DateTime.utc(2030),
+      ),
+    );
+
+    container = ProviderContainer(
+      overrides: <Override>[
+        personRepositoryProvider.overrideWithValue(repository),
+        tokenStoreProvider.overrideWithValue(store),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(sessionControllerProvider.notifier).restore();
+
+    router = GoRouter(
+      initialLocation: '/scopes/scope-1/persons/person-1',
+      routes: <RouteBase>[
+        GoRoute(
+          path: '/scopes/:scopeId/persons',
+          builder: (context, state) => const Scaffold(body: Text('listing')),
+        ),
+        GoRoute(
+          path: '/scopes/:scopeId/persons/:personId',
+          builder: (context, state) => PersonDetailScreen(
+            scopeId: state.pathParameters['scopeId']!,
+            personId: state.pathParameters['personId']!,
+          ),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(
+          theme: theme ?? buildLightTheme(),
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  void answerGetWith(Result<Person> result) {
+    when(
+      () => repository.getById(
+        any(),
+        includeDeleted: any(named: 'includeDeleted'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  void answerUpdateWith(Result<Person> result) {
+    when(
+      () => repository.update(
+        id: any(named: 'id'),
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        roleId: any(named: 'roleId'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    repository = _MockPersonRepository();
+    store = InMemoryTokenStore();
+  });
+
+  testWidgets('GivenAPerson_WhenOpened_ThenTheRecordIsShown', (tester) async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.widgetWithText(TextFormField, 'Ada'), findsOneWidget);
+  });
+
+  testWidgets('GivenAPerson_WhenOpened_ThenTheirFactsAreShown', (tester) async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('User'), findsOneWidget);
+    expect(find.text('scope-1'), findsOneWidget);
+  });
+
+  testWidgets('GivenAnEdit_WhenSaved_ThenTheNewValuesAreSent', (tester) async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+    answerUpdateWith(
+      const Success<Person>(
+        Person(
+          id: 'person-1',
+          name: 'Ada L',
+          email: 'ada@example.com',
+          role: Role.user,
+        ),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await tester.enterText(find.widgetWithText(TextFormField, 'Ada'), 'Ada L');
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, 'Save changes'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => repository.update(
+        id: 'person-1',
+        name: 'Ada L',
+        email: 'ada@example.com',
+      ),
+    ).called(1);
+  });
+
+  // AF-18a — no such person.
+  testWidgets('GivenAMissingPerson_WhenOpened_ThenNotFoundIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(
+      const FailureResult<Person>(
+        Failure(kind: FailureKind.notFound, errors: <String>[]),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Person not found'), findsOneWidget);
+  });
+
+  testWidgets('GivenAMissingPerson_WhenBackTapped_ThenTheListingOpens', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(
+      const FailureResult<Person>(
+        Failure(kind: FailureKind.notFound, errors: <String>[]),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Back to the listing'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('listing'), findsOneWidget);
+  });
+
+  // AF-18b — the person is out of this role's reach.
+  testWidgets('GivenAForbiddenPerson_WhenOpened_ThenTheRolePanelIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(
+      const FailureResult<Person>(
+        Failure(kind: FailureKind.forbidden, errors: <String>[]),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Not available for your role'), findsOneWidget);
+  });
+
+  // AF-18c — the API's own errors, with the typed input kept.
+  testWidgets('GivenARejectedUpdate_WhenSaved_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+    answerUpdateWith(
+      const FailureResult<Person>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['That email address is already registered.'],
+        ),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'ada@example.com'),
+      'taken@example.com',
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, 'Save changes'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(
+      find.text('That email address is already registered.'),
+      findsOneWidget,
+    );
+    expect(
+      find.widgetWithText(TextFormField, 'taken@example.com'),
+      findsOneWidget,
+    );
+  });
+
+  // AF-18d — a deleted person is shown, marked, and read-only.
+  testWidgets('GivenADeletedPerson_WhenOpened_ThenTheyAreMarkedDeleted', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Person>(_deleted));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.textContaining('This person is deleted'), findsOneWidget);
+  });
+
+  testWidgets('GivenADeletedPerson_WhenOpened_ThenSavingIsNotOffered', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Person>(_deleted));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.widgetWithText(FilledButton, 'Save changes'), findsNothing);
+  });
+
+  // AF-18e — your own record says so, and the role is not editable anywhere.
+  testWidgets('GivenYourOwnRecord_WhenOpened_ThenItSaysSo', (tester) async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+
+    // When
+    await pump(tester, signedInAs: 'person-1');
+
+    // Then
+    expect(find.textContaining('This is your own record'), findsOneWidget);
+  });
+
+  testWidgets('GivenSomebodyElsesRecord_WhenOpened_ThenNoSelfNoticeIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+
+    // When
+    await pump(tester, signedInAs: 'person-9');
+
+    // Then
+    expect(find.textContaining('This is your own record'), findsNothing);
+  });
+
+  testWidgets('GivenAnyRecord_WhenOpened_ThenTheRoleIsNotEditable', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+
+    // When
+    await pump(tester, signedInAs: 'person-1');
+
+    // Then
+    expect(find.byType(DropdownButtonFormField<Role>), findsNothing);
+  });
+
+  testWidgets('GivenNoEdit_WhenRendered_ThenSaveIsDisabled', (tester) async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(
+      tester
+          .widget<FilledButton>(
+            find.widgetWithText(FilledButton, 'Save changes'),
+          )
+          .onPressed,
+      isNull,
+    );
+  });
+
+  testWidgets('GivenACompactWindow_WhenRendered_ThenTheDetailIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+
+    // When
+    await pump(tester, size: _compact);
+
+    // Then
+    expect(find.widgetWithText(TextFormField, 'Ada'), findsOneWidget);
+  });
+
+  testWidgets('GivenAMediumWindow_WhenRendered_ThenTheDetailIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+
+    // When
+    await pump(tester, size: _medium);
+
+    // Then
+    expect(find.widgetWithText(TextFormField, 'Ada'), findsOneWidget);
+  });
+
+  testWidgets('GivenTheDarkTheme_WhenRendered_ThenTheDetailIsStillShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+
+    // When
+    await pump(tester, theme: buildDarkTheme());
+
+    // Then
+    expect(find.widgetWithText(TextFormField, 'Ada'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #18

Implements UI-18 — `/scopes/:scopeId/persons/:personId` over `GET /api/persons/{id}` (FR-PE-05) and `PUT /api/persons/{id}` (FR-PE-06).

## Flows

| Flow | How it is handled |
| --- | --- |
| Main | The record is read on open with its role, scope, owned scopes and verification state. |
| AF-18a | A `404` shows a not-found panel with a way back to the listing. |
| AF-18b | A `403` shows the not-available-for-your-role panel. |
| AF-18c | A refused update shows the API's strings; the record and typed input are untouched. |
| AF-18d | A deleted person is shown, marked, and read-only — the read passes `includeDeleted`. |
| AF-18e | Your own record says so, and the role is not editable here for anyone. |

**On AF-18e:** the role is simply not part of what this screen sends. FR-PE-06 makes the edit the name and the address, and leaving `roleId` null is also what makes "never lets you change your own role" true by construction rather than by a guard that could be forgotten. A unit test captures the argument and asserts it is null.

## Verification

`dart format --set-exit-if-changed .`, `flutter analyze`, and `flutter test` all pass — **596 tests**, 27 of them new. No presentation file imports `package:heimdall_api_client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)