### PR TITLE
feat(ui-19): delete a person, logically and permanently

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ the board is where an item's status changes as it moves.
 | UI-16: Browse and search persons in a scope | ✅ | [#16](https://github.com/artur-rios/heimdall-ui/issues/16) |
 | UI-17: Create a person | ✅ | [#17](https://github.com/artur-rios/heimdall-ui/issues/17) |
 | UI-18: View and update a person | ✅ | [#18](https://github.com/artur-rios/heimdall-ui/issues/18) |
-| UI-19: Delete a person, logically and permanently | ⬜ | [#19](https://github.com/artur-rios/heimdall-ui/issues/19) |
+| UI-19: Delete a person, logically and permanently | ✅ | [#19](https://github.com/artur-rios/heimdall-ui/issues/19) |
 
 ### Application Management
 

--- a/lib/features/persons/data/person_repository_impl.dart
+++ b/lib/features/persons/data/person_repository_impl.dart
@@ -185,6 +185,30 @@ class ApiPersonRepository implements PersonRepository {
   }
 
   @override
+  Future<Result<void>> delete(String id) async {
+    try {
+      final response = await _client.personDelete(id: id);
+
+      // AF-19b: the API refuses a person it will not delete — the last owner
+      // of a scope, for instance — and its own strings say why.
+      return _acknowledgement(response.success, response.errors);
+    } on DioException catch (error) {
+      return FailureResult<void>(failureFromDioException(error));
+    }
+  }
+
+  @override
+  Future<Result<void>> hardDelete(String id) async {
+    try {
+      final response = await _client.personHardDelete(id: id);
+
+      return _acknowledgement(response.success, response.errors);
+    } on DioException catch (error) {
+      return FailureResult<void>(failureFromDioException(error));
+    }
+  }
+
+  @override
   Future<Result<Page<Person>>> listScopeOwners({
     required String scopeId,
     String? name,

--- a/lib/features/persons/domain/person_repository.dart
+++ b/lib/features/persons/domain/person_repository.dart
@@ -42,6 +42,13 @@ abstract interface class PersonRepository {
     required Role role,
   });
 
+  /// Logically deletes a person. The record is kept and the API can restore it.
+  Future<Result<void>> delete(String id);
+
+  /// Permanently deletes a person and everything that belonged to them. Only a
+  /// System Admin may, which is why UI-19 shows the control to nobody else.
+  Future<Result<void>> hardDelete(String id);
+
   /// Lists the Scope Admins who own a scope.
   Future<Result<Page<Person>>> listScopeOwners({
     required String scopeId,

--- a/lib/features/persons/presentation/person_detail_controller.dart
+++ b/lib/features/persons/presentation/person_detail_controller.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/result/result.dart';
 import '../../profile/presentation/profile_controller.dart';
 import '../domain/person.dart';
+import '../domain/person_repository.dart';
 
 /// How far the person detail has got.
 sealed class PersonDetailState {
@@ -24,6 +25,11 @@ final class PersonDetailUnavailable extends PersonDetailState {
   bool get isForbidden => failure.kind == FailureKind.forbidden;
 }
 
+/// The person is gone, and the screen returns to the listing.
+final class PersonDeleted extends PersonDetailState {
+  const PersonDeleted();
+}
+
 /// The record is on screen.
 final class PersonDetailLoaded extends PersonDetailState {
   const PersonDetailLoaded(
@@ -31,12 +37,20 @@ final class PersonDetailLoaded extends PersonDetailState {
     this.saving = false,
     this.saveFailure,
     this.saved = false,
+    this.deleting = false,
+    this.deleteFailure,
   });
 
   final Person person;
   final bool saving;
   final Failure? saveFailure;
   final bool saved;
+
+  /// A deletion is on its way. Both controls are disabled while it is.
+  final bool deleting;
+
+  /// AF-19b — the API refused to delete, and the person stays open.
+  final Failure? deleteFailure;
 
   /// AF-18d — a logically deleted person is shown, but nothing about them may
   /// be changed from here.
@@ -48,11 +62,18 @@ final class PersonDetailLoaded extends PersonDetailState {
     Failure? saveFailure,
     bool clearSaveFailure = false,
     bool? saved,
+    bool? deleting,
+    Failure? deleteFailure,
+    bool clearDeleteFailure = false,
   }) => PersonDetailLoaded(
     person ?? this.person,
     saving: saving ?? this.saving,
     saveFailure: clearSaveFailure ? null : (saveFailure ?? this.saveFailure),
     saved: saved ?? this.saved,
+    deleting: deleting ?? this.deleting,
+    deleteFailure: clearDeleteFailure
+        ? null
+        : (deleteFailure ?? this.deleteFailure),
   );
 }
 
@@ -127,6 +148,40 @@ class PersonDetailController extends FamilyNotifier<PersonDetailState, String> {
   void acknowledgeSave() {
     if (state case final PersonDetailLoaded loaded) {
       state = loaded.copyWith(saved: false);
+    }
+  }
+
+  /// Logically deletes the person. The record is kept and the API can restore
+  /// it, which is what the confirmation says before this is called.
+  Future<void> delete() => _delete((repository) => repository.delete(arg));
+
+  /// Permanently deletes the person and everything that belonged to them.
+  Future<void> deletePermanently() =>
+      _delete((repository) => repository.hardDelete(arg));
+
+  Future<void> _delete(
+    Future<Result<void>> Function(PersonRepository repository) send,
+  ) async {
+    final current = state;
+
+    if (current is! PersonDetailLoaded || current.deleting) {
+      return;
+    }
+
+    state = current.copyWith(deleting: true, clearDeleteFailure: true);
+
+    final result = await send(ref.read(personRepositoryProvider));
+
+    switch (result) {
+      case Success<void>():
+        state = const PersonDeleted();
+      case FailureResult<void>(:final failure):
+        // Somebody already deleted them, which is the outcome that was asked
+        // for. Reporting it as a failure would ask the user to delete a record
+        // that no longer exists.
+        state = failure.kind == FailureKind.notFound
+            ? const PersonDeleted()
+            : current.copyWith(deleting: false, deleteFailure: failure);
     }
   }
 }

--- a/lib/features/persons/presentation/person_detail_screen.dart
+++ b/lib/features/persons/presentation/person_detail_screen.dart
@@ -5,12 +5,14 @@ import 'package:go_router/go_router.dart';
 import '../../../core/result/result.dart';
 import '../../../shared/layout/app_shell.dart';
 import '../../../shared/widgets/collection_states.dart';
+import '../../../shared/widgets/confirm_dialog.dart';
 import '../../../shared/widgets/failure_banner.dart';
 import '../../auth/domain/session.dart';
 import '../../auth/presentation/session_controller.dart';
 import '../../home/presentation/home_screen.dart';
 import '../domain/person.dart';
 import 'person_detail_controller.dart';
+import 'person_list_controller.dart';
 
 /// UI-18 — one person, as an administrator sees them.
 class PersonDetailScreen extends ConsumerStatefulWidget {
@@ -78,6 +80,52 @@ class _PersonDetailScreenState extends ConsumerState<PersonDetailScreen> {
     return session is Authenticated && session.principal.id == widget.personId;
   }
 
+  /// AF-19e — only a System Admin erases a person permanently.
+  bool get _maySeeHardDelete {
+    final session = ref.watch(sessionControllerProvider);
+
+    return session is Authenticated && session.principal.isSystemAdmin;
+  }
+
+  /// AF-19a — a dialog the user closes sends nothing.
+  Future<void> _confirmDelete(Person person) async {
+    final confirmed = await showConfirm(
+      context: context,
+      title: 'Delete ${person.name}?',
+      message:
+          '${person.name} will be marked deleted. The record is kept and '
+          'the API can restore it.',
+      confirmLabel: 'Delete',
+    );
+
+    if (confirmed && mounted) {
+      await ref
+          .read(personDetailControllerProvider(widget.personId).notifier)
+          .delete();
+    }
+  }
+
+  /// AF-19c — the confirm control stays disabled until the address matches.
+  Future<void> _confirmDeletePermanently(Person person) async {
+    final confirmed = await showTypeToConfirm(
+      context: context,
+      title: 'Delete ${person.name} permanently?',
+      message:
+          'Their record, the applications they own, their tokens, and '
+          'their scope membership are all erased. This cannot be undone. Type '
+          'their email address to confirm:',
+      confirmationValue: person.email,
+      fieldLabel: 'Email address',
+      confirmLabel: 'Delete permanently',
+    );
+
+    if (confirmed && mounted) {
+      await ref
+          .read(personDetailControllerProvider(widget.personId).notifier)
+          .deletePermanently();
+    }
+  }
+
   Future<void> _save() async {
     if (!(_formKey.currentState?.validate() ?? false)) {
       return;
@@ -95,6 +143,19 @@ class _PersonDetailScreenState extends ConsumerState<PersonDetailScreen> {
       personDetailControllerProvider(widget.personId).notifier,
     );
     final backToListing = '/scopes/${widget.scopeId}/persons';
+
+    // A deleted person returns to the listing, which is now stale.
+    ref.listen<PersonDetailState>(
+      personDetailControllerProvider(widget.personId),
+      (previous, next) {
+        if (next is PersonDeleted) {
+          ref
+              .read(personListControllerProvider(widget.scopeId).notifier)
+              .load();
+          context.go(backToListing);
+        }
+      },
+    );
 
     return AppShell(
       currentRoute: '/scopes',
@@ -137,6 +198,9 @@ class _PersonDetailScreenState extends ConsumerState<PersonDetailScreen> {
           failure: failure,
           onRetry: controller.load,
         ),
+        // The listing is where a deleted person leaves the user; this is the
+        // frame in between.
+        PersonDeleted() => const Center(child: CircularProgressIndicator()),
         final PersonDetailLoaded loaded => _detail(loaded),
       },
     );
@@ -244,6 +308,20 @@ class _PersonDetailScreenState extends ConsumerState<PersonDetailScreen> {
                   ],
                 ),
               ),
+              // AF-19d — the controls are disabled on your own record, and
+              // AF-18d leaves a deleted person nothing left to delete.
+              if (!state.isReadOnly) ...<Widget>[
+                const SizedBox(height: 24),
+                _DangerZone(
+                  person: person,
+                  deleting: state.deleting,
+                  failure: state.deleteFailure,
+                  isSelf: _isSelf,
+                  mayDeletePermanently: _maySeeHardDelete,
+                  onDelete: _confirmDelete,
+                  onDeletePermanently: _confirmDeletePermanently,
+                ),
+              ],
               const SizedBox(height: 24),
               Card(
                 child: Padding(
@@ -343,4 +421,89 @@ class _Fact extends StatelessWidget {
       ],
     ),
   );
+}
+
+/// The two deletions, kept apart from the rest of the screen because neither
+/// is an ordinary edit.
+class _DangerZone extends StatelessWidget {
+  const _DangerZone({
+    required this.person,
+    required this.deleting,
+    required this.failure,
+    required this.isSelf,
+    required this.mayDeletePermanently,
+    required this.onDelete,
+    required this.onDeletePermanently,
+  });
+
+  final Person person;
+  final bool deleting;
+  final Failure? failure;
+
+  /// AF-19d — you cannot delete yourself from here. The API refuses it too;
+  /// this is what stops the interface offering it.
+  final bool isSelf;
+
+  /// AF-19e — a Scope Admin never sees the permanent deletion.
+  final bool mayDeletePermanently;
+
+  final Future<void> Function(Person person) onDelete;
+  final Future<void> Function(Person person) onDeletePermanently;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final blocked = deleting || isSelf;
+
+    return Card(
+      color: theme.colorScheme.errorContainer,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              'Delete this person',
+              style: theme.textTheme.titleMedium?.copyWith(
+                color: theme.colorScheme.onErrorContainer,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              isSelf
+                  ? 'You cannot delete your own account from here.'
+                  : 'Deleting keeps the record and can be undone by the API. '
+                        'Deleting permanently erases it.',
+              style: TextStyle(color: theme.colorScheme.onErrorContainer),
+            ),
+            // AF-19b — the API refused, and the person is still open.
+            if (failure case final refusal?) ...<Widget>[
+              const SizedBox(height: 16),
+              ErrorBanner(failure: refusal),
+            ],
+            const SizedBox(height: 16),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: <Widget>[
+                OutlinedButton.icon(
+                  onPressed: blocked ? null : () => onDelete(person),
+                  icon: const Icon(Icons.delete_outline),
+                  label: const Text('Delete person'),
+                ),
+                if (mayDeletePermanently)
+                  FilledButton.icon(
+                    onPressed: blocked
+                        ? null
+                        : () => onDeletePermanently(person),
+                    icon: const Icon(Icons.delete_forever_outlined),
+                    label: const Text('Delete permanently'),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }

--- a/test/features/persons/presentation/person_detail_controller_test.dart
+++ b/test/features/persons/presentation/person_detail_controller_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:heimdall_ui/core/result/result.dart';
@@ -51,6 +53,14 @@ void main() {
         includeDeleted: any(named: 'includeDeleted'),
       ),
     ).thenAnswer((_) async => result);
+  }
+
+  void answerDeleteWith(Result<void> result) {
+    when(() => repository.delete(any())).thenAnswer((_) async => result);
+  }
+
+  void answerHardDeleteWith(Result<void> result) {
+    when(() => repository.hardDelete(any())).thenAnswer((_) async => result);
   }
 
   void answerUpdateWith(Result<Person> result) {
@@ -284,5 +294,95 @@ void main() {
 
     // Then
     expect((currentState() as PersonDetailLoaded).saved, isFalse);
+  });
+
+  test('GivenAnOpenPerson_WhenDeleted_ThenThePersonIsDeleted', () async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+    answerDeleteWith(const Success<void>(null));
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.delete();
+
+    // Then
+    verify(() => repository.delete('person-1')).called(1);
+    expect(currentState(), isA<PersonDeleted>());
+  });
+
+  test('GivenAnOpenPerson_WhenErased_ThenTheHardEndpointIsUsed', () async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+    answerHardDeleteWith(const Success<void>(null));
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.deletePermanently();
+
+    // Then
+    verify(() => repository.hardDelete('person-1')).called(1);
+  });
+
+  // AF-19b — the API refused, and the person stays open.
+  test('GivenARefusedDeletion_WhenDeleted_ThenThePersonStaysOpen', () async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+    answerDeleteWith(
+      const FailureResult<void>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['They are the last owner of a scope.'],
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.delete();
+
+    // Then
+    final state = currentState() as PersonDetailLoaded;
+    expect(state.deleteFailure?.errors, <String>[
+      'They are the last owner of a scope.',
+    ]);
+  });
+
+  test('GivenAnAlreadyDeletedPerson_WhenDeleted_ThenItCountsAsDone', () async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+    answerDeleteWith(
+      const FailureResult<void>(
+        Failure(kind: FailureKind.notFound, errors: <String>[]),
+      ),
+    );
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.delete();
+
+    // Then
+    expect(currentState(), isA<PersonDeleted>());
+  });
+
+  test('GivenADeletionInFlight_WhenAskedAgain_ThenOnlyOneIsSent', () async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+    final pending = Completer<Result<void>>();
+    when(() => repository.delete(any())).thenAnswer((_) => pending.future);
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    final first = controller.delete();
+    final second = controller.delete();
+    pending.complete(const Success<void>(null));
+    await Future.wait<void>(<Future<void>>[first, second]);
+
+    // Then
+    verify(() => repository.delete('person-1')).called(1);
   });
 }

--- a/test/features/persons/presentation/person_detail_screen_test.dart
+++ b/test/features/persons/presentation/person_detail_screen_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:heimdall_ui/app/theme.dart';
+import 'package:heimdall_ui/core/network/envelope.dart' as envelope;
 import 'package:heimdall_ui/core/result/result.dart';
 import 'package:heimdall_ui/core/storage/token_store.dart';
 import 'package:heimdall_ui/features/auth/domain/session.dart';
@@ -19,13 +20,13 @@ import 'package:shared_preferences/shared_preferences.dart';
 class _MockPersonRepository extends Mock implements PersonRepository {}
 
 /// A token naming the signed-in person, which AF-18e compares against.
-String _jwt({String sub = 'person-9'}) {
+String _jwt({String sub = 'person-9', int role = 1}) {
   final payload = base64Url.encode(
     utf8.encode(
       jsonEncode(<String, dynamic>{
         'sub': sub,
         'email': 'admin@example.com',
-        'role': 1,
+        'role': role,
       }),
     ),
   );
@@ -64,6 +65,7 @@ void main() {
     Size size = _expanded,
     ThemeData? theme,
     String signedInAs = 'person-9',
+    int role = 1,
   }) async {
     tester.view.physicalSize = size;
     tester.view.devicePixelRatio = 1;
@@ -71,7 +73,7 @@ void main() {
 
     await store.write(
       AuthToken(
-        value: _jwt(sub: signedInAs),
+        value: _jwt(sub: signedInAs, role: role),
         expiresAt: DateTime.utc(2030),
       ),
     );
@@ -122,6 +124,42 @@ void main() {
         includeDeleted: any(named: 'includeDeleted'),
       ),
     ).thenAnswer((_) async => result);
+  }
+
+  /// The deletion controls sit at the bottom of a scrolling detail, so they
+  /// are not on screen until the view is brought to them.
+  Future<void> tapAfterScrolling(WidgetTester tester, Finder finder) async {
+    await tester.ensureVisible(finder);
+    await tester.pumpAndSettle();
+    await tester.tap(finder);
+    await tester.pumpAndSettle();
+  }
+
+  void answerDeleteWith(Result<void> result) {
+    when(() => repository.delete(any())).thenAnswer((_) async => result);
+  }
+
+  void answerHardDeleteWith(Result<void> result) {
+    when(() => repository.hardDelete(any())).thenAnswer((_) async => result);
+  }
+
+  /// The listing behind the detail is reloaded after a deletion; what it
+  /// answers does not matter here, only that it answers.
+  void answerListWith() {
+    when(
+      () => repository.listScopePersons(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer(
+      (_) async => const FailureResult<envelope.Page<Person>>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
   }
 
   void answerUpdateWith(Result<Person> result) {
@@ -406,5 +444,281 @@ void main() {
 
     // Then
     expect(find.widgetWithText(TextFormField, 'Ada'), findsOneWidget);
+  });
+
+  testWidgets('GivenASystemAdmin_WhenOpened_ThenBothDeletionsAreOffered', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(
+      find.widgetWithText(OutlinedButton, 'Delete person'),
+      findsOneWidget,
+    );
+    expect(
+      find.widgetWithText(FilledButton, 'Delete permanently'),
+      findsOneWidget,
+    );
+  });
+
+  // AF-19e — a Scope Admin never sees the permanent deletion.
+  testWidgets('GivenAScopeAdmin_WhenOpened_ThenOnlyTheLogicalOneIsOffered', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+
+    // When
+    await pump(tester, role: 2);
+
+    // Then
+    expect(
+      find.widgetWithText(OutlinedButton, 'Delete person'),
+      findsOneWidget,
+    );
+    expect(
+      find.widgetWithText(FilledButton, 'Delete permanently'),
+      findsNothing,
+    );
+  });
+
+  // AF-19d — the controls are disabled on your own record.
+  testWidgets('GivenYourOwnRecord_WhenOpened_ThenDeletionIsDisabled', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+
+    // When
+    await pump(tester, signedInAs: 'person-1');
+
+    // Then
+    expect(
+      tester
+          .widget<OutlinedButton>(
+            find.widgetWithText(OutlinedButton, 'Delete person'),
+          )
+          .onPressed,
+      isNull,
+    );
+  });
+
+  testWidgets('GivenYourOwnRecord_WhenOpened_ThenTheReasonIsStated', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+
+    // When
+    await pump(tester, signedInAs: 'person-1');
+
+    // Then
+    expect(
+      find.text('You cannot delete your own account from here.'),
+      findsOneWidget,
+    );
+  });
+
+  // AF-18d — a deleted person has nothing left to delete.
+  testWidgets('GivenADeletedPerson_WhenOpened_ThenDeletionIsNotOffered', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Person>(_deleted));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.widgetWithText(OutlinedButton, 'Delete person'), findsNothing);
+  });
+
+  testWidgets('GivenTheDeleteControl_WhenTapped_ThenConfirmationIsAsked', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+    await pump(tester);
+
+    // When
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(OutlinedButton, 'Delete person'),
+    );
+
+    // Then
+    expect(find.text('Delete Ada?'), findsOneWidget);
+  });
+
+  testWidgets('GivenAConfirmedDeletion_WhenConfirmed_ThenThePersonIsDeleted', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+    answerDeleteWith(const Success<void>(null));
+    answerListWith();
+    await pump(tester);
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(OutlinedButton, 'Delete person'),
+    );
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(() => repository.delete('person-1')).called(1);
+  });
+
+  testWidgets('GivenADeletedPerson_WhenDeleted_ThenTheListingOpens', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+    answerDeleteWith(const Success<void>(null));
+    answerListWith();
+    await pump(tester);
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(OutlinedButton, 'Delete person'),
+    );
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('listing'), findsOneWidget);
+  });
+
+  // AF-19a — the dialog closes and nothing is sent.
+  testWidgets('GivenTheDeleteDialog_WhenCancelled_ThenNothingIsSent', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+    answerDeleteWith(const Success<void>(null));
+    await pump(tester);
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(OutlinedButton, 'Delete person'),
+    );
+
+    // When
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verifyNever(() => repository.delete(any()));
+  });
+
+  // AF-19b — the API refused, and the person stays open.
+  testWidgets('GivenARefusedDeletion_WhenConfirmed_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+    answerDeleteWith(
+      const FailureResult<void>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['They are the last owner of a scope.'],
+        ),
+      ),
+    );
+    await pump(tester);
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(OutlinedButton, 'Delete person'),
+    );
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('They are the last owner of a scope.'), findsOneWidget);
+  });
+
+  // AF-19c — the confirm control stays disabled until the address matches.
+  testWidgets('GivenTheHardDeleteDialog_WhenOpened_ThenConfirmIsDisabled', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+    await pump(tester);
+
+    // When
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(FilledButton, 'Delete permanently'),
+    );
+
+    // Then
+    expect(
+      tester
+          .widget<FilledButton>(
+            find.widgetWithText(FilledButton, 'Delete permanently').last,
+          )
+          .onPressed,
+      isNull,
+    );
+  });
+
+  testWidgets('GivenAMistypedEmail_WhenTyped_ThenConfirmStaysDisabled', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+    await pump(tester);
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(FilledButton, 'Delete permanently'),
+    );
+
+    // When
+    await tester.enterText(find.byType(TextField).last, 'ADA@example.com');
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(
+      tester
+          .widget<FilledButton>(
+            find.widgetWithText(FilledButton, 'Delete permanently').last,
+          )
+          .onPressed,
+      isNull,
+    );
+  });
+
+  testWidgets('GivenTheTypedEmail_WhenItMatches_ThenThePersonIsErased', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+    answerHardDeleteWith(const Success<void>(null));
+    answerListWith();
+    await pump(tester);
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(FilledButton, 'Delete permanently'),
+    );
+    await tester.enterText(find.byType(TextField).last, 'ada@example.com');
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(
+      find.widgetWithText(FilledButton, 'Delete permanently').last,
+    );
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(() => repository.hardDelete('person-1')).called(1);
   });
 }


### PR DESCRIPTION
Closes #19

Implements UI-19 — both deletions from the person detail, over `DELETE /api/persons/{id}` (FR-PE-07) and `DELETE /api/persons/{id}/hard` (FR-PE-08).

## Flows

| Flow | How it is handled |
| --- | --- |
| Main — logical | A dialog names the person and says the record is kept; on success the listing reopens, refreshed. |
| Main — permanent | A dialog states what is erased and requires the person's email to be typed. |
| AF-19a | Closing either dialog sends nothing. |
| AF-19b | A refusal shows the API's strings and leaves the person open. |
| AF-19c | The confirm control stays disabled until the address matches exactly — case included. |
| AF-19d | Both controls are disabled on your own record, with the reason stated. |
| AF-19e | Only a System Admin is shown the permanent deletion. |

A `404` is treated as done, as UI-13 treats it: somebody already deleted them, which is the outcome that was asked for.

## Verification

`dart format --set-exit-if-changed .`, `flutter analyze`, and `flutter test` all pass — **614 tests**, 18 of them new. No presentation file imports `package:heimdall_api_client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)