### PR TITLE
feat(ui-20): browse applications in a scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ the board is where an item's status changes as it moves.
 
 | Use case | Status | Issue |
 | --- | --- | --- |
-| UI-20: Browse applications in a scope | ⬜ | [#20](https://github.com/artur-rios/heimdall-ui/issues/20) |
+| UI-20: Browse applications in a scope | ✅ | [#20](https://github.com/artur-rios/heimdall-ui/issues/20) |
 | UI-21: Create an application | ⬜ | [#21](https://github.com/artur-rios/heimdall-ui/issues/21) |
 | UI-22: View and update an application | ⬜ | [#22](https://github.com/artur-rios/heimdall-ui/issues/22) |
 | UI-23: Delete an application, logically and permanently | ⬜ | [#23](https://github.com/artur-rios/heimdall-ui/issues/23) |

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../features/applications/presentation/application_list_screen.dart';
 import '../features/auth/domain/session.dart';
 import '../features/auth/presentation/login_screen.dart';
 import '../features/auth/presentation/password_recovery_screen.dart';
@@ -133,6 +134,11 @@ final Provider<GoRouter> routerProvider = Provider<GoRouter>((ref) {
         path: '/scopes/:scopeId',
         builder: (context, state) =>
             ScopeDetailScreen(scopeId: state.pathParameters['scopeId']!),
+      ),
+      GoRoute(
+        path: '/scopes/:scopeId/applications',
+        builder: (context, state) =>
+            ApplicationListScreen(scopeId: state.pathParameters['scopeId']!),
       ),
       GoRoute(
         path: '/scopes/:scopeId/owners',

--- a/lib/features/applications/data/application_repository_impl.dart
+++ b/lib/features/applications/data/application_repository_impl.dart
@@ -1,0 +1,78 @@
+import 'package:dio/dio.dart';
+import 'package:heimdall_api_client/export.dart';
+
+import '../../../core/network/envelope.dart';
+import '../../../core/result/result.dart';
+import '../domain/application.dart';
+import '../domain/application_repository.dart';
+
+/// [ApplicationRepository] over the generated client.
+class ApiApplicationRepository implements ApplicationRepository {
+  const ApiApplicationRepository(this._client);
+
+  final ApplicationClient _client;
+
+  @override
+  Future<Result<Page<Application>>> list({
+    required String scopeId,
+    String? name,
+    String? ownerId,
+    bool includeDeleted = false,
+    int pageNumber = 1,
+    int pageSize = 20,
+  }) async {
+    try {
+      final response = await _client.applicationList(
+        scopeId: scopeId,
+        // An empty filter is no filter: sending it would ask the API to match
+        // the empty string rather than to stop filtering.
+        name: _filter(name),
+        ownerId: _filter(ownerId),
+        includeDeleted: includeDeleted,
+        pageNumber: pageNumber,
+        pageSize: pageSize,
+      );
+
+      if (response.success != true) {
+        return FailureResult<Page<Application>>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: response.errors ?? const <String>[],
+          ),
+        );
+      }
+
+      final items = (response.data ?? const <ApplicationOutput>[])
+          .map(applicationFromOutput)
+          .toList(growable: false);
+
+      return Success<Page<Application>>(
+        Page<Application>(
+          items: items,
+          pageNumber: response.pageNumber ?? pageNumber,
+          pageSize: response.pageSize ?? pageSize,
+          totalItems: response.totalItems ?? items.length,
+          totalPages: response.totalPages ?? 1,
+        ),
+      );
+    } on DioException catch (error) {
+      // AF-20b and AF-20c depend on this: a transport failure and a `403` are
+      // different panels, and only the kind tells them apart.
+      return FailureResult<Page<Application>>(failureFromDioException(error));
+    }
+  }
+
+  static String? _filter(String? value) =>
+      (value?.trim().isEmpty ?? true) ? null : value!.trim();
+}
+
+/// Maps the generated output onto the domain entity.
+Application applicationFromOutput(ApplicationOutput output) => Application(
+  id: output.id ?? '',
+  name: output.name ?? '',
+  ownerId: output.ownerId ?? '',
+  scopeId: output.scopeId,
+  isDeleted: output.isDeleted ?? false,
+  createdAt: output.createdAt,
+  updatedAt: output.updatedAt,
+);

--- a/lib/features/applications/domain/application.dart
+++ b/lib/features/applications/domain/application.dart
@@ -1,0 +1,24 @@
+/// An application as the API describes one.
+class Application {
+  const Application({
+    required this.id,
+    required this.name,
+    required this.ownerId,
+    this.scopeId,
+    this.isDeleted = false,
+    this.createdAt,
+    this.updatedAt,
+  });
+
+  final String id;
+  final String name;
+
+  /// The person who owns it. FR-AP-08: the interface resolves this to a person
+  /// where it can, and shows the identifier where it cannot.
+  final String ownerId;
+
+  final String? scopeId;
+  final bool isDeleted;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+}

--- a/lib/features/applications/domain/application_repository.dart
+++ b/lib/features/applications/domain/application_repository.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/network/envelope.dart';
+import '../../../core/result/result.dart';
+import 'application.dart';
+
+/// The application operations the interface depends on.
+abstract interface class ApplicationRepository {
+  /// Reads one page of a scope's applications.
+  Future<Result<Page<Application>>> list({
+    required String scopeId,
+    String? name,
+    String? ownerId,
+    bool includeDeleted = false,
+    int pageNumber = 1,
+    int pageSize = 20,
+  });
+}
+
+/// Overridden at start-up with the client-backed implementation, and in tests
+/// with a fake.
+final Provider<ApplicationRepository> applicationRepositoryProvider =
+    Provider<ApplicationRepository>(
+      (ref) => throw UnimplementedError(
+        'applicationRepositoryProvider must be overridden',
+      ),
+    );

--- a/lib/features/applications/presentation/application_list_controller.dart
+++ b/lib/features/applications/presentation/application_list_controller.dart
@@ -1,0 +1,163 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/network/envelope.dart';
+import '../../../core/result/result.dart';
+import '../../profile/presentation/profile_controller.dart';
+import '../domain/application.dart';
+import '../domain/application_repository.dart';
+import 'owner_names.dart';
+
+/// What the listing is currently asking the API for.
+class ApplicationQuery {
+  const ApplicationQuery({
+    this.name = '',
+    this.includeDeleted = false,
+    this.pageNumber = 1,
+  });
+
+  final String name;
+  final bool includeDeleted;
+  final int pageNumber;
+
+  /// Whether the user has narrowed the listing at all, which is what tells an
+  /// empty result from an unfiltered empty collection (AF-20a).
+  bool get isFiltered => name.trim().isNotEmpty || includeDeleted;
+
+  ApplicationQuery copyWith({
+    String? name,
+    bool? includeDeleted,
+    int? pageNumber,
+  }) => ApplicationQuery(
+    name: name ?? this.name,
+    includeDeleted: includeDeleted ?? this.includeDeleted,
+    pageNumber: pageNumber ?? this.pageNumber,
+  );
+}
+
+/// How far the listing has got. The query travels with every state, so the
+/// filters survive a failure and a retry.
+sealed class ApplicationListState {
+  const ApplicationListState(this.query);
+
+  final ApplicationQuery query;
+}
+
+/// The first page is on its way and the list shows a placeholder.
+final class ApplicationListLoading extends ApplicationListState {
+  const ApplicationListLoading(super.query);
+}
+
+/// A page arrived, with its owners resolved as far as they could be.
+final class ApplicationListLoaded extends ApplicationListState {
+  const ApplicationListLoaded(
+    super.query,
+    this.page, {
+    required this.ownerLabel,
+    this.busy = false,
+  });
+
+  final Page<Application> page;
+  final bool busy;
+
+  /// FR-AP-08 and AF-20d — the owner's name, or their identifier when the API
+  /// would not resolve it.
+  final String Function(String ownerId) ownerLabel;
+}
+
+/// AF-20b and AF-20c — the request failed, and the query that failed is kept.
+final class ApplicationListFailed extends ApplicationListState {
+  const ApplicationListFailed(super.query, this.failure);
+
+  final Failure failure;
+
+  /// AF-20c — a scope this admin does not own.
+  bool get isForbidden => failure.kind == FailureKind.forbidden;
+}
+
+final NotifierProviderFamily<
+  ApplicationListController,
+  ApplicationListState,
+  String
+>
+applicationListControllerProvider =
+    NotifierProvider.family<
+      ApplicationListController,
+      ApplicationListState,
+      String
+    >(ApplicationListController.new);
+
+/// Owns one scope's application listing.
+class ApplicationListController
+    extends FamilyNotifier<ApplicationListState, String> {
+  bool _inFlight = false;
+  late final OwnerNames _owners = OwnerNames(
+    ref.read(personRepositoryProvider),
+  );
+
+  @override
+  ApplicationListState build(String scopeId) =>
+      const ApplicationListLoading(ApplicationQuery());
+
+  Future<void> load() => _fetch(state.query);
+
+  /// A new search starts at the first page.
+  Future<void> search(String name) =>
+      _fetch(state.query.copyWith(name: name, pageNumber: 1));
+
+  Future<void> setIncludeDeleted(bool includeDeleted) => _fetch(
+    state.query.copyWith(includeDeleted: includeDeleted, pageNumber: 1),
+  );
+
+  Future<void> goToPage(int pageNumber) =>
+      _fetch(state.query.copyWith(pageNumber: pageNumber));
+
+  /// AF-20a — returns to the unfiltered listing from the empty-result panel.
+  Future<void> clearFilters() => _fetch(const ApplicationQuery());
+
+  Future<void> _fetch(ApplicationQuery query) async {
+    if (_inFlight) {
+      return;
+    }
+
+    final current = state;
+    _inFlight = true;
+
+    state = current is ApplicationListLoaded
+        ? ApplicationListLoaded(
+            query,
+            current.page,
+            ownerLabel: current.ownerLabel,
+            busy: true,
+          )
+        : ApplicationListLoading(query);
+
+    try {
+      final result = await ref
+          .read(applicationRepositoryProvider)
+          .list(
+            scopeId: arg,
+            name: query.name,
+            includeDeleted: query.includeDeleted,
+            pageNumber: query.pageNumber,
+          );
+
+      switch (result) {
+        case Success<Page<Application>>(:final value):
+          // The owners are resolved before the page is shown, so a row never
+          // flickers from an identifier to a name under the reader's eye.
+          await _owners.resolve(
+            value.items.map((application) => application.ownerId),
+          );
+          state = ApplicationListLoaded(
+            query,
+            value,
+            ownerLabel: _owners.labelFor,
+          );
+        case FailureResult<Page<Application>>(:final failure):
+          state = ApplicationListFailed(query, failure);
+      }
+    } finally {
+      _inFlight = false;
+    }
+  }
+}

--- a/lib/features/applications/presentation/application_list_screen.dart
+++ b/lib/features/applications/presentation/application_list_screen.dart
@@ -1,0 +1,205 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../shared/layout/app_shell.dart';
+import '../../../shared/widgets/adaptive_collection.dart';
+import '../../../shared/widgets/collection_states.dart';
+import '../domain/application.dart';
+import 'application_list_controller.dart';
+
+/// UI-20 — the applications of one scope.
+class ApplicationListScreen extends ConsumerStatefulWidget {
+  const ApplicationListScreen({required this.scopeId, super.key});
+
+  final String scopeId;
+
+  @override
+  ConsumerState<ApplicationListScreen> createState() =>
+      _ApplicationListScreenState();
+}
+
+class _ApplicationListScreenState extends ConsumerState<ApplicationListScreen> {
+  final _search = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => ref
+          .read(applicationListControllerProvider(widget.scopeId).notifier)
+          .load(),
+    );
+  }
+
+  @override
+  void dispose() {
+    _search.dispose();
+    super.dispose();
+  }
+
+  ApplicationListController get _controller =>
+      ref.read(applicationListControllerProvider(widget.scopeId).notifier);
+
+  void _clearFilters() {
+    _search.clear();
+    _controller.clearFilters();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(applicationListControllerProvider(widget.scopeId));
+    final createRoute = '/scopes/${widget.scopeId}/applications/new';
+
+    return AppShell(
+      currentRoute: '/scopes',
+      title: const Text('Applications'),
+      actions: <Widget>[
+        IconButton(
+          tooltip: 'Back to the scope',
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.go('/scopes/${widget.scopeId}'),
+        ),
+      ],
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () => context.go(createRoute),
+        icon: const Icon(Icons.add),
+        label: const Text('New application'),
+      ),
+      body: Column(
+        children: <Widget>[
+          _Filters(
+            search: _search,
+            includeDeleted: state.query.includeDeleted,
+            onSearch: () => _controller.search(_search.text),
+            onIncludeDeletedChanged: _controller.setIncludeDeleted,
+          ),
+          Expanded(
+            child: switch (state) {
+              ApplicationListLoading() => const CollectionLoading(),
+              // AF-20c — the scope is not one this admin owns.
+              ApplicationListFailed(isForbidden: true) => CollectionEmpty(
+                title: 'Not available for your role',
+                message:
+                    'This scope is not one you administer. Nothing is '
+                    'wrong with your session.',
+                icon: Icons.lock_person_outlined,
+                actionLabel: 'Back to scopes',
+                onAction: () => context.go('/scopes'),
+              ),
+              // AF-20b — the returned errors, with a retry.
+              ApplicationListFailed(:final failure) => CollectionFailed(
+                failure: failure,
+                onRetry: _controller.load,
+              ),
+              ApplicationListLoaded(:final page, :final query)
+                  when page.items.isEmpty =>
+                _empty(query, createRoute),
+              final ApplicationListLoaded loaded =>
+                AdaptiveCollection<Application>(
+                  items: loaded.page.items,
+                  busy: loaded.busy,
+                  reservesFloatingAction: true,
+                  pageNumber: loaded.page.pageNumber,
+                  totalPages: loaded.page.totalPages,
+                  totalItems: loaded.page.totalItems,
+                  onPageChanged: _controller.goToPage,
+                  onTap: (application) => context.go(
+                    '/scopes/${widget.scopeId}/applications/'
+                    '${application.id}',
+                  ),
+                  title: (application) => application.name,
+                  columns: <CollectionColumn<Application>>[
+                    CollectionColumn<Application>(
+                      label: 'Owner',
+                      // FR-AP-08 and AF-20d: the owner's name where the API
+                      // resolved one, their identifier where it did not.
+                      cell: (application) =>
+                          Text(loaded.ownerLabel(application.ownerId)),
+                    ),
+                    CollectionColumn<Application>(
+                      label: 'State',
+                      cell: (application) =>
+                          Text(application.isDeleted ? 'Deleted' : 'Active'),
+                    ),
+                  ],
+                ),
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// AF-20a — an empty scope and an empty search are different situations.
+  Widget _empty(ApplicationQuery query, String createRoute) => query.isFiltered
+      ? CollectionEmpty(
+          title: 'No applications matched',
+          message:
+              'Nothing here matches what you searched for. Clearing the '
+              'filters shows them all again.',
+          icon: Icons.search_off_outlined,
+          actionLabel: 'Clear filters',
+          onAction: _clearFilters,
+        )
+      : CollectionEmpty(
+          title: 'No applications yet',
+          message:
+              'An application is something that uses this scope for its '
+              'identity. Create the first one to get started.',
+          icon: Icons.apps_outlined,
+          actionLabel: 'New application',
+          onAction: () => context.go(createRoute),
+        );
+}
+
+/// The search field and the include-deleted switch.
+class _Filters extends StatelessWidget {
+  const _Filters({
+    required this.search,
+    required this.includeDeleted,
+    required this.onSearch,
+    required this.onIncludeDeletedChanged,
+  });
+
+  final TextEditingController search;
+  final bool includeDeleted;
+  final VoidCallback onSearch;
+  final ValueChanged<bool> onIncludeDeletedChanged;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.fromLTRB(12, 12, 12, 0),
+    child: Wrap(
+      spacing: 16,
+      runSpacing: 8,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: <Widget>[
+        SizedBox(
+          width: 320,
+          child: TextField(
+            controller: search,
+            decoration: InputDecoration(
+              labelText: 'Search by name',
+              prefixIcon: const Icon(Icons.search),
+              suffixIcon: IconButton(
+                tooltip: 'Search',
+                icon: const Icon(Icons.arrow_forward),
+                onPressed: onSearch,
+              ),
+            ),
+            onSubmitted: (_) => onSearch(),
+          ),
+        ),
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Switch(value: includeDeleted, onChanged: onIncludeDeletedChanged),
+            const SizedBox(width: 8),
+            const Text('Include deleted'),
+          ],
+        ),
+      ],
+    ),
+  );
+}

--- a/lib/features/applications/presentation/owner_names.dart
+++ b/lib/features/applications/presentation/owner_names.dart
@@ -1,0 +1,45 @@
+import '../../persons/domain/person_repository.dart';
+
+/// Resolves owner identifiers to person names, and remembers what it learned.
+///
+/// FR-AP-08: an application carries an owner identifier, and the interface
+/// shows a name where it can. AF-20d is the other half — an owner that cannot
+/// be resolved is shown by its identifier rather than blanking the row, which
+/// is why a failed read is remembered as "unresolvable" and not retried on
+/// every page.
+class OwnerNames {
+  OwnerNames(this._repository);
+
+  final PersonRepository _repository;
+
+  /// Identifier to name, or to `null` when the API would not tell us.
+  final Map<String, String?> _known = <String, String?>{};
+
+  /// The name to show for [ownerId] — the identifier itself until something
+  /// better is known, which is also the permanent answer for AF-20d.
+  String labelFor(String ownerId) => _known[ownerId] ?? ownerId;
+
+  /// Reads whichever of [ownerIds] have not been looked up yet.
+  ///
+  /// Deduplicated and run together: a page of twenty applications owned by two
+  /// people costs two requests, not twenty.
+  Future<void> resolve(Iterable<String> ownerIds) async {
+    final unknown = ownerIds
+        .where((id) => id.isNotEmpty && !_known.containsKey(id))
+        .toSet();
+
+    if (unknown.isEmpty) {
+      return;
+    }
+
+    await Future.wait<void>(
+      unknown.map((id) async {
+        // Deleted persons still own applications, and a row that says the
+        // identifier because the owner was deleted is worse than one that
+        // names them.
+        final person = await _repository.getById(id, includeDeleted: true);
+        _known[id] = person.valueOrNull?.name;
+      }),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,8 @@ import 'core/network/dio_client.dart';
 import 'core/scope/scope_source.dart';
 import 'core/scope/session_scope_source.dart';
 import 'core/storage/token_store.dart';
+import 'features/applications/data/application_repository_impl.dart';
+import 'features/applications/domain/application_repository.dart';
 import 'features/auth/data/auth_repository_impl.dart';
 import 'features/auth/data/google_sign_in_gateway_impl.dart';
 import 'features/auth/presentation/session_controller.dart';
@@ -43,6 +45,11 @@ void main() {
         ),
         personRepositoryProvider.overrideWith(
           (ref) => ApiPersonRepository(PersonClient(ref.watch(dioProvider))),
+        ),
+        applicationRepositoryProvider.overrideWith(
+          (ref) => ApiApplicationRepository(
+            ApplicationClient(ref.watch(dioProvider)),
+          ),
         ),
         googleUserRepositoryProvider.overrideWith(
           (ref) =>

--- a/test/features/applications/data/application_repository_impl_test.dart
+++ b/test/features/applications/data/application_repository_impl_test.dart
@@ -1,0 +1,203 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdall_api_client/export.dart';
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/features/applications/data/application_repository_impl.dart';
+
+void main() {
+  late Dio dio;
+  late _StubAdapter adapter;
+
+  ApiApplicationRepository repositoryAnswering(_Answer answer) {
+    adapter = _StubAdapter(answer);
+    dio.httpClientAdapter = adapter;
+
+    return ApiApplicationRepository(ApplicationClient(dio));
+  }
+
+  const onePage = _Answer(
+    status: 200,
+    body: <String, dynamic>{
+      'success': true,
+      'errors': <String>[],
+      'data': <Map<String, dynamic>>[
+        <String, dynamic>{
+          'id': 'app-1',
+          'name': 'Billing',
+          'scopeId': 'scope-1',
+          'ownerId': 'person-1',
+          'isDeleted': false,
+        },
+      ],
+      'pageNumber': 1,
+      'pageSize': 20,
+      'totalItems': 1,
+      'totalPages': 1,
+    },
+  );
+
+  setUp(() {
+    dio = Dio(BaseOptions(baseUrl: 'https://example.invalid'));
+  });
+
+  test('GivenAPage_WhenListed_ThenTheApplicationsAreReturned', () async {
+    // Given
+    final repository = repositoryAnswering(onePage);
+
+    // When
+    final result = await repository.list(scopeId: 'scope-1');
+
+    // Then
+    expect(result.valueOrNull?.items.single.name, 'Billing');
+    expect(result.valueOrNull?.items.single.ownerId, 'person-1');
+  });
+
+  test('GivenAName_WhenListed_ThenItTravelsAsAQueryParameter', () async {
+    // Given
+    final repository = repositoryAnswering(onePage);
+
+    // When
+    await repository.list(
+      scopeId: 'scope-1',
+      name: 'Billing',
+      includeDeleted: true,
+      pageNumber: 2,
+    );
+
+    // Then
+    expect(adapter.queries.single, containsPair('Name', 'Billing'));
+    expect(adapter.queries.single, containsPair('IncludeDeleted', true));
+    expect(adapter.queries.single, containsPair('PageNumber', 2));
+  });
+
+  test('GivenABlankName_WhenListed_ThenNoNameIsSent', () async {
+    // Given
+    final repository = repositoryAnswering(onePage);
+
+    // When
+    await repository.list(scopeId: 'scope-1', name: '   ');
+
+    // Then
+    expect(adapter.queries.single.containsKey('Name'), isFalse);
+  });
+
+  test(
+    'GivenAnApplicationWithNoOwner_WhenListed_ThenTheOwnerIsEmpty',
+    () async {
+      // Given
+      final repository = repositoryAnswering(
+        const _Answer(
+          status: 200,
+          body: <String, dynamic>{
+            'success': true,
+            'errors': <String>[],
+            'data': <Map<String, dynamic>>[
+              <String, dynamic>{'id': 'app-1', 'name': 'Billing'},
+            ],
+            'totalItems': 1,
+          },
+        ),
+      );
+
+      // When
+      final result = await repository.list(scopeId: 'scope-1');
+
+      // Then
+      expect(result.valueOrNull?.items.single.ownerId, '');
+    },
+  );
+
+  // AF-20b — the API refused, and its own strings are what the screen shows.
+  test('GivenARefusedListing_WhenListed_ThenApiErrorsAreReturned', () async {
+    // Given
+    final repository = repositoryAnswering(
+      const _Answer(
+        status: 200,
+        body: <String, dynamic>{
+          'success': false,
+          'errors': <String>['Page size is too large.'],
+        },
+      ),
+    );
+
+    // When
+    final result = await repository.list(scopeId: 'scope-1');
+
+    // Then
+    expect(result.failureOrNull?.errors, <String>['Page size is too large.']);
+  });
+
+  // AF-20c — a scope this admin does not own.
+  test('GivenAForbiddenScope_WhenListed_ThenForbiddenIsReturned', () async {
+    // Given
+    final repository = repositoryAnswering(
+      const _Answer(
+        status: 403,
+        body: <String, dynamic>{'success': false, 'errors': <String>[]},
+      ),
+    );
+
+    // When
+    final result = await repository.list(scopeId: 'scope-1');
+
+    // Then
+    expect(result.failureOrNull?.kind, FailureKind.forbidden);
+  });
+
+  test('GivenNoConnection_WhenListed_ThenNetworkFailureIsReturned', () async {
+    // Given
+    final repository = repositoryAnswering(const _Answer(status: 0));
+
+    // When
+    final result = await repository.list(scopeId: 'scope-1');
+
+    // Then
+    expect(result.failureOrNull?.kind, FailureKind.network);
+  });
+}
+
+class _Answer {
+  const _Answer({required this.status, this.body});
+
+  final int status;
+  final Map<String, dynamic>? body;
+}
+
+/// Answers from memory, so no test reaches the network.
+class _StubAdapter implements HttpClientAdapter {
+  _StubAdapter(this._answer);
+
+  final _Answer _answer;
+
+  final List<Map<String, dynamic>> queries = <Map<String, dynamic>>[];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    queries.add(options.queryParameters);
+
+    if (_answer.status == 0) {
+      throw DioException.connectionError(
+        requestOptions: options,
+        reason: 'No route to host',
+      );
+    }
+
+    return ResponseBody.fromString(
+      jsonEncode(_answer.body),
+      _answer.status,
+      headers: <String, List<String>>{
+        Headers.contentTypeHeader: <String>[Headers.jsonContentType],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}

--- a/test/features/applications/presentation/application_list_controller_test.dart
+++ b/test/features/applications/presentation/application_list_controller_test.dart
@@ -1,0 +1,352 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdall_ui/core/network/envelope.dart';
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/features/applications/domain/application.dart';
+import 'package:heimdall_ui/features/applications/domain/application_repository.dart';
+import 'package:heimdall_ui/features/applications/presentation/application_list_controller.dart';
+import 'package:heimdall_ui/features/auth/domain/session.dart';
+import 'package:heimdall_ui/features/persons/domain/person.dart';
+import 'package:heimdall_ui/features/persons/domain/person_repository.dart';
+import 'package:heimdall_ui/features/profile/presentation/profile_controller.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockApplicationRepository extends Mock
+    implements ApplicationRepository {}
+
+class _MockPersonRepository extends Mock implements PersonRepository {}
+
+const _billing = Application(id: 'app-1', name: 'Billing', ownerId: 'person-1');
+
+const _ada = Person(
+  id: 'person-1',
+  name: 'Ada',
+  email: 'ada@example.com',
+  role: Role.user,
+);
+
+Page<Application> _page({
+  List<Application> items = const <Application>[_billing],
+  int pageNumber = 1,
+  int totalPages = 1,
+}) => Page<Application>(
+  items: items,
+  pageNumber: pageNumber,
+  pageSize: 20,
+  totalItems: items.length,
+  totalPages: totalPages,
+);
+
+void main() {
+  late _MockApplicationRepository applications;
+  late _MockPersonRepository persons;
+  late ProviderContainer container;
+
+  ApplicationListController controllerUnderTest() {
+    container = ProviderContainer(
+      overrides: <Override>[
+        applicationRepositoryProvider.overrideWithValue(applications),
+        personRepositoryProvider.overrideWithValue(persons),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    return container.read(
+      applicationListControllerProvider('scope-1').notifier,
+    );
+  }
+
+  ApplicationListState currentState() =>
+      container.read(applicationListControllerProvider('scope-1'));
+
+  void answerWith(Result<Page<Application>> result) {
+    when(
+      () => applications.list(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        ownerId: any(named: 'ownerId'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  void answerOwnerWith(Result<Person> result) {
+    when(
+      () =>
+          persons.getById(any(), includeDeleted: any(named: 'includeDeleted')),
+    ).thenAnswer((_) async => result);
+  }
+
+  setUp(() {
+    applications = _MockApplicationRepository();
+    persons = _MockPersonRepository();
+    answerOwnerWith(const Success<Person>(_ada));
+  });
+
+  test('GivenAPage_WhenLoaded_ThenTheApplicationsAreShown', () async {
+    // Given
+    answerWith(Success<Page<Application>>(_page()));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    expect(
+      (currentState() as ApplicationListLoaded).page.items.single.name,
+      'Billing',
+    );
+  });
+
+  // FR-AP-08 — the owner is resolved to a person.
+  test('GivenAResolvableOwner_WhenLoaded_ThenTheirNameIsShown', () async {
+    // Given
+    answerWith(Success<Page<Application>>(_page()));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    final state = currentState() as ApplicationListLoaded;
+    expect(state.ownerLabel('person-1'), 'Ada');
+  });
+
+  // AF-20d — an owner that cannot be resolved is shown by its identifier.
+  test(
+    'GivenAnUnresolvableOwner_WhenLoaded_ThenTheIdentifierIsShown',
+    () async {
+      // Given
+      answerWith(Success<Page<Application>>(_page()));
+      answerOwnerWith(
+        const FailureResult<Person>(
+          Failure(kind: FailureKind.notFound, errors: <String>[]),
+        ),
+      );
+      final controller = controllerUnderTest();
+
+      // When
+      await controller.load();
+
+      // Then
+      final state = currentState() as ApplicationListLoaded;
+      expect(state.ownerLabel('person-1'), 'person-1');
+    },
+  );
+
+  // A deleted person still owns applications, and naming them beats an id.
+  test('GivenAnOwner_WhenResolved_ThenDeletedPersonsAreIncluded', () async {
+    // Given
+    answerWith(Success<Page<Application>>(_page()));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    verify(() => persons.getById('person-1', includeDeleted: true)).called(1);
+  });
+
+  test('GivenOneOwnerAcrossManyRows_WhenLoaded_ThenTheyAreReadOnce', () async {
+    // Given
+    answerWith(
+      Success<Page<Application>>(
+        _page(
+          items: const <Application>[
+            _billing,
+            Application(id: 'app-2', name: 'Portal', ownerId: 'person-1'),
+            Application(id: 'app-3', name: 'Reports', ownerId: 'person-1'),
+          ],
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    verify(
+      () =>
+          persons.getById(any(), includeDeleted: any(named: 'includeDeleted')),
+    ).called(1);
+  });
+
+  test(
+    'GivenAnAlreadyResolvedOwner_WhenPaged_ThenTheyAreNotReadAgain',
+    () async {
+      // Given
+      answerWith(Success<Page<Application>>(_page(totalPages: 3)));
+      final controller = controllerUnderTest();
+      await controller.load();
+
+      // When
+      await controller.goToPage(2);
+
+      // Then
+      verify(
+        () => persons.getById(
+          any(),
+          includeDeleted: any(named: 'includeDeleted'),
+        ),
+      ).called(1);
+    },
+  );
+
+  test('GivenASearch_WhenSubmitted_ThenTheNameIsSent', () async {
+    // Given
+    answerWith(Success<Page<Application>>(_page()));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.search('Billing');
+
+    // Then
+    verify(
+      () => applications.list(
+        scopeId: 'scope-1',
+        name: 'Billing',
+        includeDeleted: false,
+        pageNumber: 1,
+      ),
+    ).called(1);
+  });
+
+  test('GivenAPageOtherThanTheFirst_WhenSearched_ThenPagingResets', () async {
+    // Given
+    answerWith(Success<Page<Application>>(_page(totalPages: 5)));
+    final controller = controllerUnderTest();
+    await controller.load();
+    await controller.goToPage(3);
+
+    // When
+    await controller.search('Billing');
+
+    // Then
+    expect(currentState().query.pageNumber, 1);
+  });
+
+  test('GivenIncludeDeleted_WhenToggled_ThenTheFlagIsSent', () async {
+    // Given
+    answerWith(Success<Page<Application>>(_page()));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.setIncludeDeleted(true);
+
+    // Then
+    verify(
+      () => applications.list(
+        scopeId: 'scope-1',
+        name: '',
+        includeDeleted: true,
+        pageNumber: 1,
+      ),
+    ).called(1);
+  });
+
+  // AF-20b — the query that failed is kept, so the retry asks it again.
+  test('GivenAFailedRequest_WhenSearched_ThenTheFiltersSurvive', () async {
+    // Given
+    answerWith(
+      const FailureResult<Page<Application>>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.search('Billing');
+
+    // Then
+    expect(currentState().query.name, 'Billing');
+  });
+
+  // AF-20c — a scope this admin does not own.
+  test('GivenAForbiddenScope_WhenLoaded_ThenStateIsForbidden', () async {
+    // Given
+    answerWith(
+      const FailureResult<Page<Application>>(
+        Failure(kind: FailureKind.forbidden, errors: <String>[]),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    expect((currentState() as ApplicationListFailed).isForbidden, isTrue);
+  });
+
+  // AF-20a — a filtered listing knows it is filtered.
+  test('GivenASearch_WhenApplied_ThenTheQueryIsFiltered', () async {
+    // Given
+    answerWith(Success<Page<Application>>(_page(items: const <Application>[])));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.search('nothing');
+
+    // Then
+    expect(currentState().query.isFiltered, isTrue);
+  });
+
+  test('GivenFilters_WhenCleared_ThenTheFullListingIsRead', () async {
+    // Given
+    answerWith(Success<Page<Application>>(_page()));
+    final controller = controllerUnderTest();
+    await controller.search('Billing');
+
+    // When
+    await controller.clearFilters();
+
+    // Then
+    verify(
+      () => applications.list(
+        scopeId: 'scope-1',
+        name: '',
+        includeDeleted: false,
+        pageNumber: 1,
+      ),
+    ).called(1);
+  });
+
+  test('GivenARequestInFlight_WhenAskedAgain_ThenOnlyOneIsSent', () async {
+    // Given
+    final pending = Completer<Result<Page<Application>>>();
+    when(
+      () => applications.list(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        ownerId: any(named: 'ownerId'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer((_) => pending.future);
+    final controller = controllerUnderTest();
+
+    // When
+    final first = controller.goToPage(2);
+    final second = controller.goToPage(3);
+    pending.complete(Success<Page<Application>>(_page()));
+    await Future.wait<void>(<Future<void>>[first, second]);
+
+    // Then
+    verify(
+      () => applications.list(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        ownerId: any(named: 'ownerId'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).called(1);
+  });
+}

--- a/test/features/applications/presentation/application_list_screen_test.dart
+++ b/test/features/applications/presentation/application_list_screen_test.dart
@@ -1,0 +1,408 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:heimdall_ui/app/theme.dart';
+import 'package:heimdall_ui/core/network/envelope.dart' as envelope;
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/core/storage/token_store.dart';
+import 'package:heimdall_ui/features/applications/domain/application.dart';
+import 'package:heimdall_ui/features/applications/domain/application_repository.dart';
+import 'package:heimdall_ui/features/applications/presentation/application_list_screen.dart';
+import 'package:heimdall_ui/features/auth/domain/session.dart';
+import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
+import 'package:heimdall_ui/features/persons/domain/person.dart';
+import 'package:heimdall_ui/features/persons/domain/person_repository.dart';
+import 'package:heimdall_ui/features/profile/presentation/profile_controller.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockApplicationRepository extends Mock
+    implements ApplicationRepository {}
+
+class _MockPersonRepository extends Mock implements PersonRepository {}
+
+String _jwt() {
+  final payload = base64Url.encode(
+    utf8.encode(
+      jsonEncode(<String, dynamic>{
+        'sub': 'person-9',
+        'email': 'admin@example.com',
+        'role': 1,
+      }),
+    ),
+  );
+
+  return 'header.$payload.signature';
+}
+
+const _billing = Application(id: 'app-1', name: 'Billing', ownerId: 'person-1');
+
+const _ada = Person(
+  id: 'person-1',
+  name: 'Ada',
+  email: 'ada@example.com',
+  role: Role.user,
+);
+
+envelope.Page<Application> _page({
+  List<Application> items = const <Application>[_billing],
+  int pageNumber = 1,
+  int totalPages = 1,
+}) => envelope.Page<Application>(
+  items: items,
+  pageNumber: pageNumber,
+  pageSize: 20,
+  totalItems: items.length,
+  totalPages: totalPages,
+);
+
+const Size _compact = Size(400, 900);
+const Size _medium = Size(800, 900);
+const Size _expanded = Size(1400, 900);
+
+void main() {
+  late _MockApplicationRepository applications;
+  late _MockPersonRepository persons;
+  late InMemoryTokenStore store;
+  late ProviderContainer container;
+  late GoRouter router;
+
+  Future<void> pump(
+    WidgetTester tester, {
+    Size size = _expanded,
+    ThemeData? theme,
+  }) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await store.write(AuthToken(value: _jwt(), expiresAt: DateTime.utc(2030)));
+
+    container = ProviderContainer(
+      overrides: <Override>[
+        applicationRepositoryProvider.overrideWithValue(applications),
+        personRepositoryProvider.overrideWithValue(persons),
+        tokenStoreProvider.overrideWithValue(store),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(sessionControllerProvider.notifier).restore();
+
+    router = GoRouter(
+      initialLocation: '/scopes/scope-1/applications',
+      routes: <RouteBase>[
+        GoRoute(
+          path: '/scopes',
+          builder: (context, state) => const Scaffold(body: Text('scopes')),
+        ),
+        GoRoute(
+          path: '/scopes/:scopeId',
+          builder: (context, state) => const Scaffold(body: Text('scope')),
+        ),
+        GoRoute(
+          path: '/scopes/:scopeId/applications',
+          builder: (context, state) =>
+              ApplicationListScreen(scopeId: state.pathParameters['scopeId']!),
+        ),
+        GoRoute(
+          path: '/scopes/:scopeId/applications/new',
+          builder: (context, state) => const Scaffold(body: Text('create')),
+        ),
+        GoRoute(
+          path: '/scopes/:scopeId/applications/:applicationId',
+          builder: (context, state) => Scaffold(
+            body: Text('detail ${state.pathParameters['applicationId']}'),
+          ),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(
+          theme: theme ?? buildLightTheme(),
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  void answerWith(Result<envelope.Page<Application>> result) {
+    when(
+      () => applications.list(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        ownerId: any(named: 'ownerId'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  void answerOwnerWith(Result<Person> result) {
+    when(
+      () =>
+          persons.getById(any(), includeDeleted: any(named: 'includeDeleted')),
+    ).thenAnswer((_) async => result);
+  }
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    applications = _MockApplicationRepository();
+    persons = _MockPersonRepository();
+    store = InMemoryTokenStore();
+    answerOwnerWith(const Success<Person>(_ada));
+  });
+
+  testWidgets('GivenAPage_WhenOpened_ThenTheApplicationsAreListed', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Application>>(_page()));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Billing'), findsOneWidget);
+  });
+
+  // FR-AP-08 — the owner is shown by name.
+  testWidgets('GivenAResolvableOwner_WhenListed_ThenTheirNameIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Application>>(_page()));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Ada'), findsOneWidget);
+  });
+
+  // AF-20d — an owner that cannot be resolved is shown by its identifier.
+  testWidgets('GivenAnUnresolvableOwner_WhenListed_ThenTheIdentifierIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Application>>(_page()));
+    answerOwnerWith(
+      const FailureResult<Person>(
+        Failure(kind: FailureKind.notFound, errors: <String>[]),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('person-1'), findsOneWidget);
+  });
+
+  // FR-UX-04 — a table when the window is wide, cards when it is not.
+  testWidgets('GivenAnExpandedWindow_WhenListed_ThenATableIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Application>>(_page()));
+
+    // When
+    await pump(tester, size: _expanded);
+
+    // Then
+    expect(find.byType(DataTable), findsOneWidget);
+  });
+
+  testWidgets('GivenAMediumWindow_WhenListed_ThenATableIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Application>>(_page()));
+
+    // When
+    await pump(tester, size: _medium);
+
+    // Then
+    expect(find.byType(DataTable), findsOneWidget);
+  });
+
+  testWidgets('GivenACompactWindow_WhenListed_ThenCardsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Application>>(_page()));
+
+    // When
+    await pump(tester, size: _compact);
+
+    // Then
+    expect(find.byType(DataTable), findsNothing);
+    expect(find.byType(Card), findsOneWidget);
+  });
+
+  testWidgets('GivenAnApplication_WhenTapped_ThenItsDetailOpens', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Application>>(_page()));
+    await pump(tester, size: _compact);
+
+    // When
+    await tester.tap(find.text('Billing'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('detail app-1'), findsOneWidget);
+  });
+
+  // AF-20a — none yet, which offers UI-21.
+  testWidgets('GivenNoneAndNoFilter_WhenListed_ThenCreateIsOffered', (
+    tester,
+  ) async {
+    // Given
+    answerWith(
+      Success<envelope.Page<Application>>(_page(items: const <Application>[])),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('No applications yet'), findsOneWidget);
+  });
+
+  // AF-20a — no matches, which offers to clear the filter.
+  testWidgets('GivenNoMatches_WhenSearched_ThenClearingIsOffered', (
+    tester,
+  ) async {
+    // Given
+    answerWith(
+      Success<envelope.Page<Application>>(_page(items: const <Application>[])),
+    );
+    await pump(tester);
+
+    // When
+    await tester.enterText(find.byType(TextField), 'nothing');
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('No applications matched'), findsOneWidget);
+  });
+
+  // AF-20b — the returned errors, with a retry.
+  testWidgets('GivenARefusedListing_WhenOpened_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(
+      const FailureResult<envelope.Page<Application>>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['Page size is too large.'],
+        ),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Page size is too large.'), findsOneWidget);
+  });
+
+  testWidgets('GivenATransportFailure_WhenOpened_ThenARetryIsOffered', (
+    tester,
+  ) async {
+    // Given
+    answerWith(
+      const FailureResult<envelope.Page<Application>>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.widgetWithText(TextButton, 'Retry'), findsOneWidget);
+  });
+
+  // AF-20c — a scope this admin does not own.
+  testWidgets('GivenAForbiddenScope_WhenOpened_ThenTheRolePanelIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(
+      const FailureResult<envelope.Page<Application>>(
+        Failure(kind: FailureKind.forbidden, errors: <String>[]),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Not available for your role'), findsOneWidget);
+  });
+
+  testWidgets('GivenIncludeDeleted_WhenToggled_ThenTheFlagIsSent', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Application>>(_page()));
+    await pump(tester);
+
+    // When
+    await tester.tap(find.byType(Switch));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => applications.list(
+        scopeId: 'scope-1',
+        name: '',
+        includeDeleted: true,
+        pageNumber: 1,
+      ),
+    ).called(1);
+  });
+
+  testWidgets('GivenTheCreateControl_WhenTapped_ThenTheFormOpens', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Application>>(_page()));
+    await pump(tester);
+
+    // When
+    await tester.tap(
+      find.widgetWithText(FloatingActionButton, 'New application'),
+    );
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('create'), findsOneWidget);
+  });
+
+  testWidgets('GivenTheDarkTheme_WhenListed_ThenTheApplicationsAreStillShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<Application>>(_page()));
+
+    // When
+    await pump(tester, theme: buildDarkTheme());
+
+    // Then
+    expect(find.text('Billing'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #20

Implements UI-20 — `/scopes/:scopeId/applications` over `GET /api/scopes/{scopeId}/applications` (FR-AP-01, FR-AP-02).

## Flows

| Flow | How it is handled |
| --- | --- |
| Main | The page is read on open with each application's name, owner and deletion state. |
| AF-20a | "No applications yet" offers UI-21; "No applications matched" offers to clear the filters. |
| AF-20b | The returned errors, or a retry for a transport failure, with the failing query kept. |
| AF-20c | A `403` shows the not-available-for-your-role panel. |
| AF-20d | An owner that cannot be resolved is shown by its identifier, not blanked. |

## Owner resolution (FR-AP-08)

An application carries an owner *identifier*, not a name. `OwnerNames` resolves each distinct identifier once and remembers the answer — including the answer "the API would not tell us", so an unresolvable owner is not asked about again on every page. A page of twenty applications owned by two people costs two reads; paging back and forth costs none.

The read passes `includeDeleted`: a deleted person still owns applications, and naming them beats showing a bare identifier.

## Verification

`dart format --set-exit-if-changed .`, `flutter analyze`, and `flutter test` all pass — **650 tests**, 36 of them new. No presentation file imports `package:heimdall_api_client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)