### PR TITLE
feat(ui-21): create an application

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ the board is where an item's status changes as it moves.
 | Use case | Status | Issue |
 | --- | --- | --- |
 | UI-20: Browse applications in a scope | ✅ | [#20](https://github.com/artur-rios/heimdall-ui/issues/20) |
-| UI-21: Create an application | ⬜ | [#21](https://github.com/artur-rios/heimdall-ui/issues/21) |
+| UI-21: Create an application | ✅ | [#21](https://github.com/artur-rios/heimdall-ui/issues/21) |
 | UI-22: View and update an application | ⬜ | [#22](https://github.com/artur-rios/heimdall-ui/issues/22) |
 | UI-23: Delete an application, logically and permanently | ⬜ | [#23](https://github.com/artur-rios/heimdall-ui/issues/23) |
 

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../features/applications/presentation/application_create_screen.dart';
 import '../features/applications/presentation/application_list_screen.dart';
 import '../features/auth/domain/session.dart';
 import '../features/auth/presentation/login_screen.dart';
@@ -139,6 +140,11 @@ final Provider<GoRouter> routerProvider = Provider<GoRouter>((ref) {
         path: '/scopes/:scopeId/applications',
         builder: (context, state) =>
             ApplicationListScreen(scopeId: state.pathParameters['scopeId']!),
+      ),
+      GoRoute(
+        path: '/scopes/:scopeId/applications/new',
+        builder: (context, state) =>
+            ApplicationCreateScreen(scopeId: state.pathParameters['scopeId']!),
       ),
       GoRoute(
         path: '/scopes/:scopeId/owners',

--- a/lib/features/applications/data/application_repository_impl.dart
+++ b/lib/features/applications/data/application_repository_impl.dart
@@ -62,6 +62,54 @@ class ApiApplicationRepository implements ApplicationRepository {
     }
   }
 
+  @override
+  Future<Result<Application>> create({
+    required String scopeId,
+    required String name,
+    required String ownerId,
+  }) async {
+    try {
+      final response = await _client.applicationCreate(
+        scopeId: scopeId,
+        body: CreateApplicationCommand(name: name, ownerId: ownerId),
+      );
+
+      if (response.success != true) {
+        // AF-21b and AF-21c: a duplicate name and an owner who is not of this
+        // scope both arrive here, told apart by the API's own strings.
+        return FailureResult<Application>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: response.errors ?? const <String>[],
+          ),
+        );
+      }
+
+      final data = response.data;
+
+      if (data == null) {
+        return const FailureResult<Application>(
+          Failure(
+            kind: FailureKind.unknown,
+            errors: <String>['The API returned an incomplete response.'],
+          ),
+        );
+      }
+
+      return Success<Application>(
+        Application(
+          id: data.id ?? '',
+          name: data.name ?? name,
+          ownerId: data.ownerId ?? ownerId,
+          scopeId: data.scopeId ?? scopeId,
+          createdAt: data.createdAt,
+        ),
+      );
+    } on DioException catch (error) {
+      return FailureResult<Application>(failureFromDioException(error));
+    }
+  }
+
   static String? _filter(String? value) =>
       (value?.trim().isEmpty ?? true) ? null : value!.trim();
 }

--- a/lib/features/applications/domain/application_repository.dart
+++ b/lib/features/applications/domain/application_repository.dart
@@ -15,6 +15,16 @@ abstract interface class ApplicationRepository {
     int pageNumber = 1,
     int pageSize = 20,
   });
+
+  /// Creates an application within a scope.
+  ///
+  /// Whether [ownerId] names a person of that scope is the API's question —
+  /// AF-21c is what its answer looks like when they are not.
+  Future<Result<Application>> create({
+    required String scopeId,
+    required String name,
+    required String ownerId,
+  });
 }
 
 /// Overridden at start-up with the client-backed implementation, and in tests

--- a/lib/features/applications/presentation/application_create_controller.dart
+++ b/lib/features/applications/presentation/application_create_controller.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/result/result.dart';
+import '../domain/application.dart';
+import '../domain/application_repository.dart';
+
+/// How far a create attempt has got.
+sealed class ApplicationCreateState {
+  const ApplicationCreateState();
+}
+
+/// The form is being filled in.
+final class ApplicationCreateEditing extends ApplicationCreateState {
+  const ApplicationCreateEditing();
+}
+
+/// A request is in flight. The form refuses a second submission in this state.
+final class ApplicationCreateSending extends ApplicationCreateState {
+  const ApplicationCreateSending();
+}
+
+/// The application exists. The screen opens its detail from here.
+final class ApplicationCreated extends ApplicationCreateState {
+  const ApplicationCreated(this.application);
+
+  final Application application;
+}
+
+/// AF-21b and AF-21c — the API refused. The form keeps everything typed.
+final class ApplicationCreateRejected extends ApplicationCreateState {
+  const ApplicationCreateRejected(this.failure);
+
+  final Failure failure;
+}
+
+final NotifierProviderFamily<
+  ApplicationCreateController,
+  ApplicationCreateState,
+  String
+>
+applicationCreateControllerProvider =
+    NotifierProvider.family<
+      ApplicationCreateController,
+      ApplicationCreateState,
+      String
+    >(ApplicationCreateController.new);
+
+/// Owns one create attempt from filled in to created.
+class ApplicationCreateController
+    extends FamilyNotifier<ApplicationCreateState, String> {
+  @override
+  ApplicationCreateState build(String scopeId) =>
+      const ApplicationCreateEditing();
+
+  Future<void> create({required String name, required String ownerId}) async {
+    if (state is ApplicationCreateSending) {
+      return;
+    }
+
+    state = const ApplicationCreateSending();
+
+    final result = await ref
+        .read(applicationRepositoryProvider)
+        .create(scopeId: arg, name: name, ownerId: ownerId);
+
+    state = result.fold(
+      onSuccess: ApplicationCreated.new,
+      onFailure: ApplicationCreateRejected.new,
+    );
+  }
+}

--- a/lib/features/applications/presentation/application_create_screen.dart
+++ b/lib/features/applications/presentation/application_create_screen.dart
@@ -1,0 +1,213 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../core/result/result.dart';
+import '../../../shared/layout/app_shell.dart';
+import '../../../shared/widgets/confirm_dialog.dart';
+import '../../../shared/widgets/failure_banner.dart';
+import '../../persons/domain/person.dart';
+import '../../persons/presentation/scope_members.dart';
+import 'application_create_controller.dart';
+import 'application_list_controller.dart';
+
+/// UI-21 — the create-application form.
+class ApplicationCreateScreen extends ConsumerStatefulWidget {
+  const ApplicationCreateScreen({required this.scopeId, super.key});
+
+  final String scopeId;
+
+  @override
+  ConsumerState<ApplicationCreateScreen> createState() =>
+      _ApplicationCreateScreenState();
+}
+
+class _ApplicationCreateScreenState
+    extends ConsumerState<ApplicationCreateScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _name = TextEditingController();
+  String? _ownerId;
+
+  @override
+  void dispose() {
+    _name.dispose();
+    super.dispose();
+  }
+
+  /// Whether anything has been entered, which is what AF-21d asks about.
+  bool get _isDirty => _name.text.trim().isNotEmpty || _ownerId != null;
+
+  Future<void> _submit() async {
+    // AF-21a: an empty name, or no owner, never reaches the API.
+    if (!(_formKey.currentState?.validate() ?? false)) {
+      return;
+    }
+
+    final ownerId = _ownerId;
+
+    if (ownerId == null) {
+      setState(() {});
+
+      return;
+    }
+
+    await ref
+        .read(applicationCreateControllerProvider(widget.scopeId).notifier)
+        .create(name: _name.text.trim(), ownerId: ownerId);
+  }
+
+  /// AF-21d — leaving a modified form asks first.
+  Future<void> _cancel() async {
+    final leave =
+        !_isDirty ||
+        await showConfirm(
+          context: context,
+          title: 'Discard this application?',
+          message: 'What you have entered has not been saved and will be lost.',
+          confirmLabel: 'Discard',
+          cancelLabel: 'Keep editing',
+        );
+
+    if (leave && mounted) {
+      context.go('/scopes/${widget.scopeId}/applications');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final state = ref.watch(
+      applicationCreateControllerProvider(widget.scopeId),
+    );
+    final members = ref.watch(scopeMembersProvider(widget.scopeId));
+    final sending = state is ApplicationCreateSending;
+
+    ref.listen<ApplicationCreateState>(
+      applicationCreateControllerProvider(widget.scopeId),
+      (previous, next) {
+        if (next case ApplicationCreated(:final application)) {
+          // The listing behind this form is now stale.
+          ref
+              .read(applicationListControllerProvider(widget.scopeId).notifier)
+              .load();
+          context.go(
+            '/scopes/${widget.scopeId}/applications/${application.id}',
+          );
+        }
+      },
+    );
+
+    return AppShell(
+      currentRoute: '/scopes',
+      title: const Text('New application'),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 560),
+            child: Form(
+              key: _formKey,
+              onChanged: () => setState(() {}),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  Text(
+                    'Create an application',
+                    style: theme.textTheme.headlineSmall,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'An application uses this scope for its identity, and is '
+                    'owned by one of the scope’s people.',
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                  const SizedBox(height: 24),
+                  if (state is ApplicationCreateRejected) ...<Widget>[
+                    if (state.failure.kind == FailureKind.network)
+                      RetryBanner(onRetry: sending ? null : _submit)
+                    else
+                      // AF-21b and AF-21c: the API's own strings, as returned.
+                      ErrorBanner(failure: state.failure),
+                    const SizedBox(height: 16),
+                  ],
+                  TextFormField(
+                    controller: _name,
+                    decoration: const InputDecoration(labelText: 'Name'),
+                    validator: (value) => (value?.trim().isEmpty ?? true)
+                        ? 'Enter a name for the application.'
+                        : null,
+                  ),
+                  const SizedBox(height: 16),
+                  // AF-21c: only the scope's own people are offered, so the
+                  // refusal the API would give is not invited in the first
+                  // place.
+                  switch (members) {
+                    AsyncData<List<Person>>(:final value) when value.isEmpty =>
+                      Text(
+                        'This scope has nobody who could own an application '
+                        'yet. Create a person first.',
+                        style: theme.textTheme.bodyMedium,
+                      ),
+                    AsyncData<List<Person>>(:final value) =>
+                      DropdownButtonFormField<String>(
+                        initialValue: _ownerId,
+                        // A person's name and address together are wider than
+                        // a narrow window, so the field takes the width it has
+                        // and the label gives way rather than overflowing.
+                        isExpanded: true,
+                        decoration: const InputDecoration(labelText: 'Owner'),
+                        items: <DropdownMenuItem<String>>[
+                          for (final person in value)
+                            DropdownMenuItem<String>(
+                              value: person.id,
+                              child: Text(
+                                '${person.name} (${person.email})',
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                        ],
+                        onChanged: sending
+                            ? null
+                            : (id) => setState(() => _ownerId = id),
+                      ),
+                    AsyncError<List<Person>>() => Text(
+                      'The people of this scope could not be read, so there '
+                      'is nobody to choose from.',
+                      style: theme.textTheme.bodyMedium,
+                    ),
+                    _ => const Padding(
+                      padding: EdgeInsets.symmetric(vertical: 12),
+                      child: LinearProgressIndicator(),
+                    ),
+                  },
+                  if (_ownerId == null) ...<Widget>[
+                    const SizedBox(height: 8),
+                    Text(
+                      'No owner selected yet.',
+                      style: theme.textTheme.bodySmall,
+                    ),
+                  ],
+                  const SizedBox(height: 24),
+                  FilledButton(
+                    onPressed: sending ? null : _submit,
+                    child: sending
+                        ? const SizedBox.square(
+                            dimension: 20,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Text('Create application'),
+                  ),
+                  const SizedBox(height: 8),
+                  TextButton(
+                    onPressed: sending ? null : _cancel,
+                    child: const Text('Cancel'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/persons/presentation/scope_members.dart
+++ b/lib/features/persons/presentation/scope_members.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/network/envelope.dart';
+import '../../../core/result/result.dart';
+import '../../profile/presentation/profile_controller.dart';
+import '../domain/person.dart';
+
+/// Everyone associated with a scope: its users and the admins who own it.
+///
+/// UI-21 and UI-22 pick an application's owner from this, and AF-21c is why it
+/// is the two listings rather than a free-text identifier — the API refuses an
+/// owner who is not of the scope, and offering only those who are is what
+/// keeps the interface from inviting the refusal.
+final FutureProviderFamily<List<Person>, String> scopeMembersProvider =
+    FutureProvider.family<List<Person>, String>((ref, scopeId) async {
+      final repository = ref.watch(personRepositoryProvider);
+
+      // The two listings are independent: a scope with no users still has
+      // owners, so either failing must not hide the other.
+      final results = await Future.wait<Result<Page<Person>>>(
+        <Future<Result<Page<Person>>>>[
+          repository.listScopePersons(scopeId: scopeId, pageSize: 100),
+          repository.listScopeOwners(scopeId: scopeId, pageSize: 100),
+        ],
+      );
+
+      final byId = <String, Person>{};
+
+      for (final result in results) {
+        for (final person in result.valueOrNull?.items ?? const <Person>[]) {
+          byId[person.id] = person;
+        }
+      }
+
+      final members = byId.values.toList()
+        ..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+
+      return List<Person>.unmodifiable(members);
+    });

--- a/test/features/applications/presentation/application_create_screen_test.dart
+++ b/test/features/applications/presentation/application_create_screen_test.dart
@@ -1,0 +1,524 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:heimdall_ui/app/theme.dart';
+import 'package:heimdall_ui/core/network/envelope.dart' as envelope;
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/core/storage/token_store.dart';
+import 'package:heimdall_ui/features/applications/domain/application.dart';
+import 'package:heimdall_ui/features/applications/domain/application_repository.dart';
+import 'package:heimdall_ui/features/applications/presentation/application_create_screen.dart';
+import 'package:heimdall_ui/features/auth/domain/session.dart';
+import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
+import 'package:heimdall_ui/features/persons/domain/person.dart';
+import 'package:heimdall_ui/features/persons/domain/person_repository.dart';
+import 'package:heimdall_ui/features/profile/presentation/profile_controller.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockApplicationRepository extends Mock
+    implements ApplicationRepository {}
+
+class _MockPersonRepository extends Mock implements PersonRepository {}
+
+String _jwt() {
+  final payload = base64Url.encode(
+    utf8.encode(
+      jsonEncode(<String, dynamic>{
+        'sub': 'person-9',
+        'email': 'admin@example.com',
+        'role': 1,
+      }),
+    ),
+  );
+
+  return 'header.$payload.signature';
+}
+
+const _ada = Person(
+  id: 'person-1',
+  name: 'Ada',
+  email: 'ada@example.com',
+  role: Role.user,
+);
+
+const _grace = Person(
+  id: 'person-2',
+  name: 'Grace',
+  email: 'grace@example.com',
+  role: Role.scopeAdmin,
+);
+
+const _created = Application(id: 'app-9', name: 'Billing', ownerId: 'person-1');
+
+envelope.Page<Person> _people(List<Person> items) => envelope.Page<Person>(
+  items: items,
+  pageNumber: 1,
+  pageSize: 100,
+  totalItems: items.length,
+  totalPages: 1,
+);
+
+const Size _compact = Size(400, 900);
+const Size _medium = Size(800, 900);
+const Size _expanded = Size(1400, 900);
+
+void main() {
+  late _MockApplicationRepository applications;
+  late _MockPersonRepository persons;
+  late InMemoryTokenStore store;
+  late ProviderContainer container;
+  late GoRouter router;
+
+  Future<void> pump(
+    WidgetTester tester, {
+    Size size = _expanded,
+    ThemeData? theme,
+  }) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await store.write(AuthToken(value: _jwt(), expiresAt: DateTime.utc(2030)));
+
+    container = ProviderContainer(
+      overrides: <Override>[
+        applicationRepositoryProvider.overrideWithValue(applications),
+        personRepositoryProvider.overrideWithValue(persons),
+        tokenStoreProvider.overrideWithValue(store),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(sessionControllerProvider.notifier).restore();
+
+    router = GoRouter(
+      initialLocation: '/scopes/scope-1/applications/new',
+      routes: <RouteBase>[
+        GoRoute(
+          path: '/scopes/:scopeId/applications',
+          builder: (context, state) => const Scaffold(body: Text('listing')),
+        ),
+        GoRoute(
+          path: '/scopes/:scopeId/applications/new',
+          builder: (context, state) => ApplicationCreateScreen(
+            scopeId: state.pathParameters['scopeId']!,
+          ),
+        ),
+        GoRoute(
+          path: '/scopes/:scopeId/applications/:applicationId',
+          builder: (context, state) => Scaffold(
+            body: Text('detail ${state.pathParameters['applicationId']}'),
+          ),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(
+          theme: theme ?? buildLightTheme(),
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  void answerCreateWith(Result<Application> result) {
+    when(
+      () => applications.create(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        ownerId: any(named: 'ownerId'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  void answerMembersWith({
+    Result<envelope.Page<Person>>? users,
+    Result<envelope.Page<Person>>? owners,
+  }) {
+    when(
+      () => persons.listScopePersons(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer(
+      (_) async =>
+          users ?? Success<envelope.Page<Person>>(_people(<Person>[_ada])),
+    );
+    when(
+      () => persons.listScopeOwners(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer(
+      (_) async =>
+          owners ?? Success<envelope.Page<Person>>(_people(<Person>[_grace])),
+    );
+  }
+
+  Future<void> chooseOwner(WidgetTester tester, String label) async {
+    await tester.tap(find.byType(DropdownButtonFormField<String>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(label).last);
+    await tester.pumpAndSettle();
+  }
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    applications = _MockApplicationRepository();
+    persons = _MockPersonRepository();
+    store = InMemoryTokenStore();
+    answerCreateWith(const Success<Application>(_created));
+    answerMembersWith();
+    when(
+      () => applications.list(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        ownerId: any(named: 'ownerId'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer(
+      (_) async => const FailureResult<envelope.Page<Application>>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
+  });
+
+  // AF-21c — the selector lists the scope's own people, users and owners both.
+  testWidgets('GivenAScope_WhenOpened_ThenItsPeopleAreOffered', (tester) async {
+    // Given / When
+    await pump(tester);
+    await tester.tap(find.byType(DropdownButtonFormField<String>));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.textContaining('Ada'), findsWidgets);
+    expect(find.textContaining('Grace'), findsWidgets);
+  });
+
+  testWidgets('GivenACompleteForm_WhenSubmitted_ThenTheApplicationIsCreated', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Name'),
+      'Billing',
+    );
+    await tester.pumpAndSettle();
+    await chooseOwner(tester, 'Ada (ada@example.com)');
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create application'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => applications.create(
+        scopeId: 'scope-1',
+        name: 'Billing',
+        ownerId: 'person-1',
+      ),
+    ).called(1);
+  });
+
+  testWidgets('GivenACreatedApplication_WhenCreated_ThenItsDetailOpens', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Name'),
+      'Billing',
+    );
+    await tester.pumpAndSettle();
+    await chooseOwner(tester, 'Ada (ada@example.com)');
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create application'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('detail app-9'), findsOneWidget);
+  });
+
+  // AF-21a — an empty name never reaches the API.
+  testWidgets('GivenNoName_WhenSubmitted_ThenNoRequestIsMade', (tester) async {
+    // Given
+    await pump(tester);
+    await chooseOwner(tester, 'Ada (ada@example.com)');
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create application'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verifyNever(
+      () => applications.create(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        ownerId: any(named: 'ownerId'),
+      ),
+    );
+  });
+
+  // AF-21a — nor does an application with no owner.
+  testWidgets('GivenNoOwner_WhenSubmitted_ThenNoRequestIsMade', (tester) async {
+    // Given
+    await pump(tester);
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Name'),
+      'Billing',
+    );
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create application'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verifyNever(
+      () => applications.create(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        ownerId: any(named: 'ownerId'),
+      ),
+    );
+  });
+
+  testWidgets('GivenNoOwner_WhenRendered_ThenTheFormSaysSo', (tester) async {
+    // Given / When
+    await pump(tester);
+
+    // Then
+    expect(find.text('No owner selected yet.'), findsOneWidget);
+  });
+
+  // AF-21b — a duplicate name, in the API's own words.
+  testWidgets('GivenADuplicateName_WhenSubmitted_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerCreateWith(
+      const FailureResult<Application>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['An application with that name already exists.'],
+        ),
+      ),
+    );
+    await pump(tester);
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Name'),
+      'Billing',
+    );
+    await tester.pumpAndSettle();
+    await chooseOwner(tester, 'Ada (ada@example.com)');
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create application'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(
+      find.text('An application with that name already exists.'),
+      findsOneWidget,
+    );
+  });
+
+  // AF-21c — the API refuses an owner who is not of the scope.
+  testWidgets('GivenARejectedOwner_WhenSubmitted_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerCreateWith(
+      const FailureResult<Application>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['That person is not of this scope.'],
+        ),
+      ),
+    );
+    await pump(tester);
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Name'),
+      'Billing',
+    );
+    await tester.pumpAndSettle();
+    await chooseOwner(tester, 'Ada (ada@example.com)');
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create application'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('That person is not of this scope.'), findsOneWidget);
+  });
+
+  testWidgets('GivenARejectedCreate_WhenSubmitted_ThenTheInputIsKept', (
+    tester,
+  ) async {
+    // Given
+    answerCreateWith(
+      const FailureResult<Application>(
+        Failure(kind: FailureKind.validation, errors: <String>['No.']),
+      ),
+    );
+    await pump(tester);
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Name'),
+      'Billing',
+    );
+    await tester.pumpAndSettle();
+    await chooseOwner(tester, 'Ada (ada@example.com)');
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create application'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.widgetWithText(TextFormField, 'Billing'), findsOneWidget);
+  });
+
+  testWidgets('GivenAScopeWithNobodyInIt_WhenOpened_ThenItSaysSo', (
+    tester,
+  ) async {
+    // Given
+    answerMembersWith(
+      users: Success<envelope.Page<Person>>(_people(const <Person>[])),
+      owners: Success<envelope.Page<Person>>(_people(const <Person>[])),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(
+      find.textContaining('nobody who could own an application'),
+      findsOneWidget,
+    );
+  });
+
+  // Either listing failing must not hide the other.
+  testWidgets(
+    'GivenAFailedUserListing_WhenOpened_ThenTheOwnersAreStillOffered',
+    (tester) async {
+      // Given
+      answerMembersWith(
+        users: const FailureResult<envelope.Page<Person>>(
+          Failure(kind: FailureKind.forbidden, errors: <String>[]),
+        ),
+      );
+
+      // When
+      await pump(tester);
+      await tester.tap(find.byType(DropdownButtonFormField<String>));
+      await tester.pumpAndSettle();
+
+      // Then
+      expect(find.textContaining('Grace'), findsWidgets);
+    },
+  );
+
+  // AF-21d — leaving a modified form asks first.
+  testWidgets('GivenAModifiedForm_WhenCancelled_ThenConfirmationIsAsked', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Name'),
+      'Billing',
+    );
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('Discard this application?'), findsOneWidget);
+  });
+
+  testWidgets('GivenAModifiedForm_WhenDiscardConfirmed_ThenTheListingOpens', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Name'),
+      'Billing',
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Discard'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('listing'), findsOneWidget);
+  });
+
+  testWidgets('GivenAnUntouchedForm_WhenCancelled_ThenTheListingOpensAtOnce', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+
+    // When
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('listing'), findsOneWidget);
+  });
+
+  testWidgets('GivenACompactWindow_WhenRendered_ThenTheFormIsShown', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, size: _compact);
+
+    // Then
+    expect(find.text('Create an application'), findsOneWidget);
+  });
+
+  testWidgets('GivenAMediumWindow_WhenRendered_ThenTheFormIsShown', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, size: _medium);
+
+    // Then
+    expect(find.text('Create an application'), findsOneWidget);
+  });
+
+  testWidgets('GivenTheDarkTheme_WhenRendered_ThenTheFormIsStillShown', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, theme: buildDarkTheme());
+
+    // Then
+    expect(find.text('Create an application'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #21

Implements UI-21 — `/scopes/:scopeId/applications/new` over `POST /api/scopes/{scopeId}/applications` (FR-AP-03).

## Flows

| Flow | How it is handled |
| --- | --- |
| Main | Name and an owner drawn from the scope's people; on success the new application's detail opens. |
| AF-21a | An empty name, or no owner, blocks submission. |
| AF-21b | A duplicate name comes back as the API's own strings, form untouched. |
| AF-21c | An owner the API rejects comes back the same way — and only the scope's people are offered. |
| AF-21d | Leaving a modified form asks for confirmation first. |

## The owner selector

Unlike UI-11's scope owners, a scope's *own* people can be listed, so this is a real picker rather than a typed identifier. `scopeMembers` reads `GET /api/scopes/{scopeId}/persons` and `GET /api/scopes/{scopeId}/owners` together and offers the union, sorted by name.

The two listings are independent: a scope with no users still has owners, so either failing leaves the other's people selectable rather than emptying the selector. A widget test covers that case. UI-22 reuses the same provider for the same choice.

## Verification

`dart format --set-exit-if-changed .`, `flutter analyze`, and `flutter test` all pass — **667 tests**, 17 of them new. No presentation file imports `package:heimdall_api_client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)