### PR TITLE
feat(ui-22): view and update an application

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ the board is where an item's status changes as it moves.
 | --- | --- | --- |
 | UI-20: Browse applications in a scope | ✅ | [#20](https://github.com/artur-rios/heimdall-ui/issues/20) |
 | UI-21: Create an application | ✅ | [#21](https://github.com/artur-rios/heimdall-ui/issues/21) |
-| UI-22: View and update an application | ⬜ | [#22](https://github.com/artur-rios/heimdall-ui/issues/22) |
+| UI-22: View and update an application | ✅ | [#22](https://github.com/artur-rios/heimdall-ui/issues/22) |
 | UI-23: Delete an application, logically and permanently | ⬜ | [#23](https://github.com/artur-rios/heimdall-ui/issues/23) |
 
 ### Scope Permission Management

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../features/applications/presentation/application_create_screen.dart';
+import '../features/applications/presentation/application_detail_screen.dart';
 import '../features/applications/presentation/application_list_screen.dart';
 import '../features/auth/domain/session.dart';
 import '../features/auth/presentation/login_screen.dart';
@@ -145,6 +146,13 @@ final Provider<GoRouter> routerProvider = Provider<GoRouter>((ref) {
         path: '/scopes/:scopeId/applications/new',
         builder: (context, state) =>
             ApplicationCreateScreen(scopeId: state.pathParameters['scopeId']!),
+      ),
+      GoRoute(
+        path: '/scopes/:scopeId/applications/:applicationId',
+        builder: (context, state) => ApplicationDetailScreen(
+          scopeId: state.pathParameters['scopeId']!,
+          applicationId: state.pathParameters['applicationId']!,
+        ),
       ),
       GoRoute(
         path: '/scopes/:scopeId/owners',

--- a/lib/features/applications/data/application_repository_impl.dart
+++ b/lib/features/applications/data/application_repository_impl.dart
@@ -88,12 +88,7 @@ class ApiApplicationRepository implements ApplicationRepository {
       final data = response.data;
 
       if (data == null) {
-        return const FailureResult<Application>(
-          Failure(
-            kind: FailureKind.unknown,
-            errors: <String>['The API returned an incomplete response.'],
-          ),
-        );
+        return const FailureResult<Application>(_incompleteResponse);
       }
 
       return Success<Application>(
@@ -110,9 +105,99 @@ class ApiApplicationRepository implements ApplicationRepository {
     }
   }
 
+  @override
+  Future<Result<Application>> getById({
+    required String scopeId,
+    required String id,
+    bool includeDeleted = true,
+  }) async {
+    try {
+      final response = await _client.applicationGetById(
+        scopeId: scopeId,
+        id: id,
+        includeDeleted: includeDeleted,
+      );
+
+      if (response.success != true) {
+        return FailureResult<Application>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: response.errors ?? const <String>[],
+          ),
+        );
+      }
+
+      final data = response.data;
+
+      if (data == null) {
+        return const FailureResult<Application>(_incompleteResponse);
+      }
+
+      return Success<Application>(applicationFromOutput(data));
+    } on DioException catch (error) {
+      // AF-22a and AF-22b depend on this: a `404` and a `403` are different
+      // panels, and only the kind tells them apart.
+      return FailureResult<Application>(failureFromDioException(error));
+    }
+  }
+
+  @override
+  Future<Result<Application>> update({
+    required String scopeId,
+    required String id,
+    required String name,
+    required String ownerId,
+  }) async {
+    try {
+      final response = await _client.applicationUpdate(
+        scopeId: scopeId,
+        id: id,
+        body: UpdateApplicationCommand(name: name, ownerId: ownerId),
+      );
+
+      if (response.success != true) {
+        // AF-22c: a duplicate name, or an owner of another scope.
+        return FailureResult<Application>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: response.errors ?? const <String>[],
+          ),
+        );
+      }
+
+      final data = response.data;
+
+      if (data == null) {
+        return const FailureResult<Application>(_incompleteResponse);
+      }
+
+      // The update endpoint answers with its own output type, which carries no
+      // `isDeleted`: an application the API just updated is not a deleted one.
+      return Success<Application>(
+        Application(
+          id: data.id ?? id,
+          name: data.name ?? name,
+          ownerId: data.ownerId ?? ownerId,
+          scopeId: data.scopeId ?? scopeId,
+          createdAt: data.createdAt,
+          updatedAt: data.updatedAt,
+        ),
+      );
+    } on DioException catch (error) {
+      return FailureResult<Application>(failureFromDioException(error));
+    }
+  }
+
   static String? _filter(String? value) =>
       (value?.trim().isEmpty ?? true) ? null : value!.trim();
 }
+
+/// A successful envelope that nonetheless lacks what the flow needs. It should
+/// not happen; saying so plainly beats a null dereference if it ever does.
+const Failure _incompleteResponse = Failure(
+  kind: FailureKind.unknown,
+  errors: <String>['The API returned an incomplete response.'],
+);
 
 /// Maps the generated output onto the domain entity.
 Application applicationFromOutput(ApplicationOutput output) => Application(

--- a/lib/features/applications/domain/application_repository.dart
+++ b/lib/features/applications/domain/application_repository.dart
@@ -25,6 +25,25 @@ abstract interface class ApplicationRepository {
     required String name,
     required String ownerId,
   });
+
+  /// Reads one application.
+  ///
+  /// [includeDeleted] is on by default for the detail screen: AF-22d shows a
+  /// logically deleted application read-only, and it cannot do that if the API
+  /// is asked to pretend it is gone.
+  Future<Result<Application>> getById({
+    required String scopeId,
+    required String id,
+    bool includeDeleted = true,
+  });
+
+  /// Updates an application's name and owner.
+  Future<Result<Application>> update({
+    required String scopeId,
+    required String id,
+    required String name,
+    required String ownerId,
+  });
 }
 
 /// Overridden at start-up with the client-backed implementation, and in tests

--- a/lib/features/applications/presentation/application_detail_controller.dart
+++ b/lib/features/applications/presentation/application_detail_controller.dart
@@ -1,0 +1,161 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/result/result.dart';
+import '../domain/application.dart';
+import '../domain/application_repository.dart';
+
+/// Which application a detail screen is showing.
+///
+/// An application is identified by its scope as well as itself, so the family
+/// is keyed by both rather than by the identifier alone.
+class ApplicationRef {
+  const ApplicationRef({required this.scopeId, required this.applicationId});
+
+  final String scopeId;
+  final String applicationId;
+
+  @override
+  bool operator ==(Object other) =>
+      other is ApplicationRef &&
+      other.scopeId == scopeId &&
+      other.applicationId == applicationId;
+
+  @override
+  int get hashCode => Object.hash(scopeId, applicationId);
+}
+
+/// How far the application detail has got.
+sealed class ApplicationDetailState {
+  const ApplicationDetailState();
+}
+
+/// The record is being read.
+final class ApplicationDetailLoading extends ApplicationDetailState {
+  const ApplicationDetailLoading();
+}
+
+/// AF-22a and AF-22b — the record could not be read.
+final class ApplicationDetailUnavailable extends ApplicationDetailState {
+  const ApplicationDetailUnavailable(this.failure);
+
+  final Failure failure;
+
+  bool get isNotFound => failure.kind == FailureKind.notFound;
+  bool get isForbidden => failure.kind == FailureKind.forbidden;
+}
+
+/// The record is on screen.
+final class ApplicationDetailLoaded extends ApplicationDetailState {
+  const ApplicationDetailLoaded(
+    this.application, {
+    this.saving = false,
+    this.saveFailure,
+    this.saved = false,
+  });
+
+  final Application application;
+  final bool saving;
+  final Failure? saveFailure;
+  final bool saved;
+
+  /// AF-22d — a logically deleted application is shown, but nothing about it
+  /// may be changed from here.
+  bool get isReadOnly => application.isDeleted;
+
+  ApplicationDetailLoaded copyWith({
+    Application? application,
+    bool? saving,
+    Failure? saveFailure,
+    bool clearSaveFailure = false,
+    bool? saved,
+  }) => ApplicationDetailLoaded(
+    application ?? this.application,
+    saving: saving ?? this.saving,
+    saveFailure: clearSaveFailure ? null : (saveFailure ?? this.saveFailure),
+    saved: saved ?? this.saved,
+  );
+}
+
+final NotifierProviderFamily<
+  ApplicationDetailController,
+  ApplicationDetailState,
+  ApplicationRef
+>
+applicationDetailControllerProvider =
+    NotifierProvider.family<
+      ApplicationDetailController,
+      ApplicationDetailState,
+      ApplicationRef
+    >(ApplicationDetailController.new);
+
+/// Owns one application's detail: reading it, and saving edits to it.
+class ApplicationDetailController
+    extends FamilyNotifier<ApplicationDetailState, ApplicationRef> {
+  @override
+  ApplicationDetailState build(ApplicationRef ref) =>
+      const ApplicationDetailLoading();
+
+  Future<void> load() async {
+    state = const ApplicationDetailLoading();
+
+    final result = await ref
+        .read(applicationRepositoryProvider)
+        .getById(scopeId: arg.scopeId, id: arg.applicationId);
+
+    state = result.fold(
+      onSuccess: ApplicationDetailLoaded.new,
+      onFailure: ApplicationDetailUnavailable.new,
+    );
+  }
+
+  /// Saves [name] and [ownerId].
+  ///
+  /// AF-22e is enforced by the screen, which keeps the control disabled until
+  /// something differs; the same comparison is repeated here so a submission
+  /// from the keyboard obeys it too.
+  Future<void> save({required String name, required String ownerId}) async {
+    final current = state;
+
+    if (current is! ApplicationDetailLoaded ||
+        current.saving ||
+        current.isReadOnly) {
+      return;
+    }
+
+    if (name == current.application.name &&
+        ownerId == current.application.ownerId) {
+      return;
+    }
+
+    state = current.copyWith(
+      saving: true,
+      clearSaveFailure: true,
+      saved: false,
+    );
+
+    final result = await ref
+        .read(applicationRepositoryProvider)
+        .update(
+          scopeId: arg.scopeId,
+          id: arg.applicationId,
+          name: name,
+          ownerId: ownerId,
+        );
+
+    state = result.fold(
+      onSuccess: (application) =>
+          ApplicationDetailLoaded(application, saved: true),
+      // AF-22c: the refusal is kept as it came back, and the record on screen
+      // is still the one the API last confirmed.
+      onFailure: (failure) =>
+          current.copyWith(saving: false, saveFailure: failure),
+    );
+  }
+
+  /// Drops the "saved" acknowledgement so a later edit starts clean.
+  void acknowledgeSave() {
+    if (state case final ApplicationDetailLoaded loaded) {
+      state = loaded.copyWith(saved: false);
+    }
+  }
+}

--- a/lib/features/applications/presentation/application_detail_screen.dart
+++ b/lib/features/applications/presentation/application_detail_screen.dart
@@ -1,0 +1,379 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../core/result/result.dart';
+import '../../../shared/layout/app_shell.dart';
+import '../../../shared/widgets/collection_states.dart';
+import '../../../shared/widgets/failure_banner.dart';
+import '../../persons/domain/person.dart';
+import '../../persons/presentation/scope_members.dart';
+import '../domain/application.dart';
+import 'application_detail_controller.dart';
+
+/// UI-22 — one application: what it is called and who owns it.
+class ApplicationDetailScreen extends ConsumerStatefulWidget {
+  const ApplicationDetailScreen({
+    required this.scopeId,
+    required this.applicationId,
+    super.key,
+  });
+
+  final String scopeId;
+  final String applicationId;
+
+  @override
+  ConsumerState<ApplicationDetailScreen> createState() =>
+      _ApplicationDetailScreenState();
+}
+
+class _ApplicationDetailScreenState
+    extends ConsumerState<ApplicationDetailScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _name = TextEditingController();
+  String? _ownerId;
+
+  /// The record the fields were last seeded from, which is what AF-22e
+  /// compares against.
+  Application? _seeded;
+
+  ApplicationRef get _ref => ApplicationRef(
+    scopeId: widget.scopeId,
+    applicationId: widget.applicationId,
+  );
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) =>
+          ref.read(applicationDetailControllerProvider(_ref).notifier).load(),
+    );
+  }
+
+  @override
+  void dispose() {
+    _name.dispose();
+    super.dispose();
+  }
+
+  /// Copies a freshly read or freshly saved record into the fields.
+  ///
+  /// AF-22c is why this only runs when the record itself changed: a refused
+  /// save must leave what the user chose exactly where it was.
+  void _seed(Application application) {
+    if (identical(_seeded, application)) {
+      return;
+    }
+
+    _seeded = application;
+    _name.text = application.name;
+    _ownerId = application.ownerId.isEmpty ? null : application.ownerId;
+  }
+
+  bool _differsFrom(Application application) =>
+      _name.text.trim() != application.name ||
+      (_ownerId ?? '') != application.ownerId;
+
+  Future<void> _save() async {
+    if (!(_formKey.currentState?.validate() ?? false)) {
+      return;
+    }
+
+    final ownerId = _ownerId;
+
+    if (ownerId == null) {
+      return;
+    }
+
+    await ref
+        .read(applicationDetailControllerProvider(_ref).notifier)
+        .save(name: _name.text.trim(), ownerId: ownerId);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(applicationDetailControllerProvider(_ref));
+    final controller = ref.read(
+      applicationDetailControllerProvider(_ref).notifier,
+    );
+    final backToListing = '/scopes/${widget.scopeId}/applications';
+
+    return AppShell(
+      currentRoute: '/scopes',
+      title: Text(switch (state) {
+        ApplicationDetailLoaded(:final application) => application.name,
+        _ => 'Application',
+      }),
+      actions: <Widget>[
+        IconButton(
+          tooltip: 'Back to the listing',
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.go(backToListing),
+        ),
+      ],
+      body: switch (state) {
+        ApplicationDetailLoading() => const Center(
+          child: CircularProgressIndicator(),
+        ),
+        // AF-22a — no such application.
+        ApplicationDetailUnavailable(isNotFound: true) => CollectionEmpty(
+          title: 'Application not found',
+          message:
+              'There is no application with that identifier. It may have '
+              'been permanently deleted.',
+          icon: Icons.search_off_outlined,
+          actionLabel: 'Back to the listing',
+          onAction: () => context.go(backToListing),
+        ),
+        // AF-22b — out of this role's reach.
+        ApplicationDetailUnavailable(isForbidden: true) => CollectionEmpty(
+          title: 'Not available for your role',
+          message:
+              'This application is not one you administer. Nothing is '
+              'wrong with your session.',
+          icon: Icons.lock_person_outlined,
+          actionLabel: 'Back to the listing',
+          onAction: () => context.go(backToListing),
+        ),
+        ApplicationDetailUnavailable(:final failure) => CollectionFailed(
+          failure: failure,
+          onRetry: controller.load,
+        ),
+        final ApplicationDetailLoaded loaded => _detail(loaded),
+      },
+    );
+  }
+
+  Widget _detail(ApplicationDetailLoaded state) {
+    final theme = Theme.of(context);
+    _seed(state.application);
+    final application = state.application;
+    final members = ref.watch(scopeMembersProvider(widget.scopeId));
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(24),
+      child: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 640),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              // AF-22d — a deleted application says so before anything else.
+              if (state.isReadOnly) ...<Widget>[
+                const _Notice(
+                  icon: Icons.delete_outline,
+                  message:
+                      'This application is deleted. It is shown for '
+                      'reference and cannot be changed from here.',
+                  destructive: true,
+                ),
+                const SizedBox(height: 16),
+              ],
+              Form(
+                key: _formKey,
+                onChanged: () => setState(() {}),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: <Widget>[
+                    if (state.saveFailure
+                        case final Failure failure) ...<Widget>[
+                      if (failure.kind == FailureKind.network)
+                        RetryBanner(onRetry: state.saving ? null : _save)
+                      else
+                        // AF-22c: the API's own strings, as returned.
+                        ErrorBanner(failure: failure),
+                      const SizedBox(height: 16),
+                    ],
+                    if (state.saved) ...<Widget>[
+                      const _Notice(
+                        icon: Icons.check_circle_outline,
+                        message: 'Saved.',
+                      ),
+                      const SizedBox(height: 16),
+                    ],
+                    TextFormField(
+                      controller: _name,
+                      readOnly: state.isReadOnly,
+                      decoration: const InputDecoration(labelText: 'Name'),
+                      validator: (value) => (value?.trim().isEmpty ?? true)
+                          ? 'Enter a name for the application.'
+                          : null,
+                    ),
+                    const SizedBox(height: 16),
+                    _owner(state, members),
+                    const SizedBox(height: 16),
+                    if (!state.isReadOnly)
+                      FilledButton(
+                        // AF-22e: nothing to save is not an action.
+                        onPressed: (state.saving || !_differsFrom(application))
+                            ? null
+                            : _save,
+                        child: state.saving
+                            ? const SizedBox.square(
+                                dimension: 20,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
+                              )
+                            : const Text('Save changes'),
+                      ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 24),
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: DefaultTextStyle.merge(
+                    style: theme.textTheme.bodyMedium,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        _Fact(label: 'Identifier', value: application.id),
+                        _Fact(
+                          label: 'Scope',
+                          value: application.scopeId ?? widget.scopeId,
+                        ),
+                        _Fact(
+                          label: 'State',
+                          value: application.isDeleted ? 'Deleted' : 'Active',
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// The owner, as a selector over the scope's own people.
+  ///
+  /// A deleted application shows the owner it has rather than a control, since
+  /// there is nothing to change; an owner the listing does not contain is shown
+  /// by identifier for the same reason UI-20's rows are (FR-AP-08).
+  Widget _owner(
+    ApplicationDetailLoaded state,
+    AsyncValue<List<Person>> members,
+  ) {
+    final theme = Theme.of(context);
+    final application = state.application;
+
+    if (state.isReadOnly) {
+      return _Fact(label: 'Owner', value: _ownerLabel(members, application));
+    }
+
+    return switch (members) {
+      AsyncData<List<Person>>(:final value) when value.isEmpty => Text(
+        'This scope has nobody who could own an application.',
+        style: theme.textTheme.bodyMedium,
+      ),
+      AsyncData<List<Person>>(:final value) => DropdownButtonFormField<String>(
+        initialValue: value.any((person) => person.id == _ownerId)
+            ? _ownerId
+            : null,
+        isExpanded: true,
+        decoration: const InputDecoration(labelText: 'Owner'),
+        items: <DropdownMenuItem<String>>[
+          for (final person in value)
+            DropdownMenuItem<String>(
+              value: person.id,
+              child: Text(
+                '${person.name} (${person.email})',
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+        ],
+        onChanged: state.saving ? null : (id) => setState(() => _ownerId = id),
+      ),
+      AsyncError<List<Person>>() => _Fact(
+        label: 'Owner',
+        value: _ownerLabel(members, application),
+      ),
+      _ => const Padding(
+        padding: EdgeInsets.symmetric(vertical: 12),
+        child: LinearProgressIndicator(),
+      ),
+    };
+  }
+
+  String _ownerLabel(
+    AsyncValue<List<Person>> members,
+    Application application,
+  ) {
+    for (final person in members.valueOrNull ?? const <Person>[]) {
+      if (person.id == application.ownerId) {
+        return person.name;
+      }
+    }
+
+    return application.ownerId.isEmpty ? 'Nobody' : application.ownerId;
+  }
+}
+
+/// A one-line panel: what a deleted record and a saved edit each say.
+class _Notice extends StatelessWidget {
+  const _Notice({
+    required this.icon,
+    required this.message,
+    this.destructive = false,
+  });
+
+  final IconData icon;
+  final String message;
+  final bool destructive;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final background = destructive
+        ? scheme.errorContainer
+        : scheme.secondaryContainer;
+    final foreground = destructive
+        ? scheme.onErrorContainer
+        : scheme.onSecondaryContainer;
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: <Widget>[
+          Icon(icon, color: foreground),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(message, style: TextStyle(color: foreground)),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Fact extends StatelessWidget {
+  const _Fact({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.symmetric(vertical: 4),
+    child: Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        SizedBox(
+          width: 140,
+          child: Text(label, style: Theme.of(context).textTheme.labelLarge),
+        ),
+        Expanded(child: Text(value)),
+      ],
+    ),
+  );
+}

--- a/test/features/applications/presentation/application_detail_controller_test.dart
+++ b/test/features/applications/presentation/application_detail_controller_test.dart
@@ -1,0 +1,279 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/features/applications/domain/application.dart';
+import 'package:heimdall_ui/features/applications/domain/application_repository.dart';
+import 'package:heimdall_ui/features/applications/presentation/application_detail_controller.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockApplicationRepository extends Mock
+    implements ApplicationRepository {}
+
+const _billing = Application(
+  id: 'app-1',
+  name: 'Billing',
+  ownerId: 'person-1',
+  scopeId: 'scope-1',
+);
+
+const _deleted = Application(
+  id: 'app-1',
+  name: 'Billing',
+  ownerId: 'person-1',
+  scopeId: 'scope-1',
+  isDeleted: true,
+);
+
+const _ref = ApplicationRef(scopeId: 'scope-1', applicationId: 'app-1');
+
+void main() {
+  late _MockApplicationRepository repository;
+  late ProviderContainer container;
+
+  ApplicationDetailController controllerUnderTest() {
+    container = ProviderContainer(
+      overrides: <Override>[
+        applicationRepositoryProvider.overrideWithValue(repository),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    return container.read(applicationDetailControllerProvider(_ref).notifier);
+  }
+
+  ApplicationDetailState currentState() =>
+      container.read(applicationDetailControllerProvider(_ref));
+
+  void answerGetWith(Result<Application> result) {
+    when(
+      () => repository.getById(
+        scopeId: any(named: 'scopeId'),
+        id: any(named: 'id'),
+        includeDeleted: any(named: 'includeDeleted'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  void answerUpdateWith(Result<Application> result) {
+    when(
+      () => repository.update(
+        scopeId: any(named: 'scopeId'),
+        id: any(named: 'id'),
+        name: any(named: 'name'),
+        ownerId: any(named: 'ownerId'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  setUp(() {
+    repository = _MockApplicationRepository();
+  });
+
+  test('GivenAnApplication_WhenLoaded_ThenTheRecordIsShown', () async {
+    // Given
+    answerGetWith(const Success<Application>(_billing));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    expect(
+      (currentState() as ApplicationDetailLoaded).application.name,
+      'Billing',
+    );
+  });
+
+  test('GivenAnApplication_WhenLoaded_ThenBothIdentifiersAreUsed', () async {
+    // Given
+    answerGetWith(const Success<Application>(_billing));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    verify(() => repository.getById(scopeId: 'scope-1', id: 'app-1')).called(1);
+  });
+
+  // AF-22a — no such application.
+  test('GivenAMissingApplication_WhenLoaded_ThenStateIsNotFound', () async {
+    // Given
+    answerGetWith(
+      const FailureResult<Application>(
+        Failure(kind: FailureKind.notFound, errors: <String>[]),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    expect((currentState() as ApplicationDetailUnavailable).isNotFound, isTrue);
+  });
+
+  // AF-22b — out of this role's reach.
+  test('GivenAForbiddenApplication_WhenLoaded_ThenStateIsForbidden', () async {
+    // Given
+    answerGetWith(
+      const FailureResult<Application>(
+        Failure(kind: FailureKind.forbidden, errors: <String>[]),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    expect(
+      (currentState() as ApplicationDetailUnavailable).isForbidden,
+      isTrue,
+    );
+  });
+
+  test('GivenAnEdit_WhenSaved_ThenTheNewValuesAreSent', () async {
+    // Given
+    answerGetWith(const Success<Application>(_billing));
+    answerUpdateWith(
+      const Success<Application>(
+        Application(id: 'app-1', name: 'Invoicing', ownerId: 'person-2'),
+      ),
+    );
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.save(name: 'Invoicing', ownerId: 'person-2');
+
+    // Then
+    verify(
+      () => repository.update(
+        scopeId: 'scope-1',
+        id: 'app-1',
+        name: 'Invoicing',
+        ownerId: 'person-2',
+      ),
+    ).called(1);
+  });
+
+  // AF-22c — a refusal keeps the record and carries the API's own errors.
+  test('GivenARejectedUpdate_WhenSaved_ThenApiErrorsAreKept', () async {
+    // Given
+    answerGetWith(const Success<Application>(_billing));
+    answerUpdateWith(
+      const FailureResult<Application>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['An application with that name already exists.'],
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.save(name: 'Invoicing', ownerId: 'person-1');
+
+    // Then
+    final state = currentState() as ApplicationDetailLoaded;
+    expect(state.saveFailure?.errors, <String>[
+      'An application with that name already exists.',
+    ]);
+    expect(state.application.name, 'Billing');
+  });
+
+  // AF-22d — a deleted application is read-only.
+  test('GivenADeletedApplication_WhenLoaded_ThenItIsReadOnly', () async {
+    // Given
+    answerGetWith(const Success<Application>(_deleted));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    expect((currentState() as ApplicationDetailLoaded).isReadOnly, isTrue);
+  });
+
+  test('GivenADeletedApplication_WhenSaved_ThenNoRequestIsMade', () async {
+    // Given
+    answerGetWith(const Success<Application>(_deleted));
+    answerUpdateWith(const Success<Application>(_deleted));
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.save(name: 'Anything', ownerId: 'person-2');
+
+    // Then
+    verifyNever(
+      () => repository.update(
+        scopeId: any(named: 'scopeId'),
+        id: any(named: 'id'),
+        name: any(named: 'name'),
+        ownerId: any(named: 'ownerId'),
+      ),
+    );
+  });
+
+  // AF-22e — saving with nothing changed is a no-op.
+  test('GivenNoChange_WhenSaved_ThenNoRequestIsMade', () async {
+    // Given
+    answerGetWith(const Success<Application>(_billing));
+    answerUpdateWith(const Success<Application>(_billing));
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.save(name: 'Billing', ownerId: 'person-1');
+
+    // Then
+    verifyNever(
+      () => repository.update(
+        scopeId: any(named: 'scopeId'),
+        id: any(named: 'id'),
+        name: any(named: 'name'),
+        ownerId: any(named: 'ownerId'),
+      ),
+    );
+  });
+
+  test('GivenASavedApplication_WhenAcknowledged_ThenTheNoticeClears', () async {
+    // Given
+    answerGetWith(const Success<Application>(_billing));
+    answerUpdateWith(
+      const Success<Application>(
+        Application(id: 'app-1', name: 'Invoicing', ownerId: 'person-1'),
+      ),
+    );
+    final controller = controllerUnderTest();
+    await controller.load();
+    await controller.save(name: 'Invoicing', ownerId: 'person-1');
+
+    // When
+    controller.acknowledgeSave();
+
+    // Then
+    expect((currentState() as ApplicationDetailLoaded).saved, isFalse);
+  });
+
+  // Two applications in two scopes are two states, not one.
+  test('GivenTwoApplications_WhenKeyed_ThenTheirStatesAreSeparate', () async {
+    // Given
+    answerGetWith(const Success<Application>(_billing));
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    final other = container.read(
+      applicationDetailControllerProvider(
+        const ApplicationRef(scopeId: 'scope-2', applicationId: 'app-2'),
+      ),
+    );
+
+    // Then
+    expect(other, isA<ApplicationDetailLoading>());
+  });
+}

--- a/test/features/applications/presentation/application_detail_screen_test.dart
+++ b/test/features/applications/presentation/application_detail_screen_test.dart
@@ -1,0 +1,484 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:heimdall_ui/app/theme.dart';
+import 'package:heimdall_ui/core/network/envelope.dart' as envelope;
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/core/storage/token_store.dart';
+import 'package:heimdall_ui/features/applications/domain/application.dart';
+import 'package:heimdall_ui/features/applications/domain/application_repository.dart';
+import 'package:heimdall_ui/features/applications/presentation/application_detail_screen.dart';
+import 'package:heimdall_ui/features/auth/domain/session.dart';
+import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
+import 'package:heimdall_ui/features/persons/domain/person.dart';
+import 'package:heimdall_ui/features/persons/domain/person_repository.dart';
+import 'package:heimdall_ui/features/profile/presentation/profile_controller.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockApplicationRepository extends Mock
+    implements ApplicationRepository {}
+
+class _MockPersonRepository extends Mock implements PersonRepository {}
+
+String _jwt() {
+  final payload = base64Url.encode(
+    utf8.encode(
+      jsonEncode(<String, dynamic>{
+        'sub': 'person-9',
+        'email': 'admin@example.com',
+        'role': 1,
+      }),
+    ),
+  );
+
+  return 'header.$payload.signature';
+}
+
+const _ada = Person(
+  id: 'person-1',
+  name: 'Ada',
+  email: 'ada@example.com',
+  role: Role.user,
+);
+
+const _grace = Person(
+  id: 'person-2',
+  name: 'Grace',
+  email: 'grace@example.com',
+  role: Role.scopeAdmin,
+);
+
+const _billing = Application(
+  id: 'app-1',
+  name: 'Billing',
+  ownerId: 'person-1',
+  scopeId: 'scope-1',
+);
+
+const _deleted = Application(
+  id: 'app-1',
+  name: 'Billing',
+  ownerId: 'person-1',
+  scopeId: 'scope-1',
+  isDeleted: true,
+);
+
+envelope.Page<Person> _people(List<Person> items) => envelope.Page<Person>(
+  items: items,
+  pageNumber: 1,
+  pageSize: 100,
+  totalItems: items.length,
+  totalPages: 1,
+);
+
+const Size _compact = Size(400, 900);
+const Size _medium = Size(800, 900);
+const Size _expanded = Size(1400, 900);
+
+void main() {
+  late _MockApplicationRepository applications;
+  late _MockPersonRepository persons;
+  late InMemoryTokenStore store;
+  late ProviderContainer container;
+  late GoRouter router;
+
+  Future<void> pump(
+    WidgetTester tester, {
+    Size size = _expanded,
+    ThemeData? theme,
+  }) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await store.write(AuthToken(value: _jwt(), expiresAt: DateTime.utc(2030)));
+
+    container = ProviderContainer(
+      overrides: <Override>[
+        applicationRepositoryProvider.overrideWithValue(applications),
+        personRepositoryProvider.overrideWithValue(persons),
+        tokenStoreProvider.overrideWithValue(store),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(sessionControllerProvider.notifier).restore();
+
+    router = GoRouter(
+      initialLocation: '/scopes/scope-1/applications/app-1',
+      routes: <RouteBase>[
+        GoRoute(
+          path: '/scopes/:scopeId/applications',
+          builder: (context, state) => const Scaffold(body: Text('listing')),
+        ),
+        GoRoute(
+          path: '/scopes/:scopeId/applications/:applicationId',
+          builder: (context, state) => ApplicationDetailScreen(
+            scopeId: state.pathParameters['scopeId']!,
+            applicationId: state.pathParameters['applicationId']!,
+          ),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(
+          theme: theme ?? buildLightTheme(),
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  void answerGetWith(Result<Application> result) {
+    when(
+      () => applications.getById(
+        scopeId: any(named: 'scopeId'),
+        id: any(named: 'id'),
+        includeDeleted: any(named: 'includeDeleted'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  void answerUpdateWith(Result<Application> result) {
+    when(
+      () => applications.update(
+        scopeId: any(named: 'scopeId'),
+        id: any(named: 'id'),
+        name: any(named: 'name'),
+        ownerId: any(named: 'ownerId'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  void answerMembersWith(List<Person> members) {
+    when(
+      () => persons.listScopePersons(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer((_) async => Success<envelope.Page<Person>>(_people(members)));
+    when(
+      () => persons.listScopeOwners(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer(
+      (_) async => Success<envelope.Page<Person>>(_people(const <Person>[])),
+    );
+  }
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    applications = _MockApplicationRepository();
+    persons = _MockPersonRepository();
+    store = InMemoryTokenStore();
+    answerMembersWith(<Person>[_ada, _grace]);
+  });
+
+  testWidgets('GivenAnApplication_WhenOpened_ThenTheRecordIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Application>(_billing));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.widgetWithText(TextFormField, 'Billing'), findsOneWidget);
+  });
+
+  testWidgets('GivenAnApplication_WhenOpened_ThenItsOwnerIsSelected', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Application>(_billing));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(
+      tester
+          .widget<DropdownButtonFormField<String>>(
+            find.byType(DropdownButtonFormField<String>),
+          )
+          .initialValue,
+      'person-1',
+    );
+  });
+
+  testWidgets('GivenAnEdit_WhenSaved_ThenTheNewValuesAreSent', (tester) async {
+    // Given
+    answerGetWith(const Success<Application>(_billing));
+    answerUpdateWith(
+      const Success<Application>(
+        Application(id: 'app-1', name: 'Invoicing', ownerId: 'person-1'),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Billing'),
+      'Invoicing',
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, 'Save changes'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => applications.update(
+        scopeId: 'scope-1',
+        id: 'app-1',
+        name: 'Invoicing',
+        ownerId: 'person-1',
+      ),
+    ).called(1);
+  });
+
+  testWidgets('GivenAnOwnerChange_WhenSaved_ThenTheNewOwnerIsSent', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Application>(_billing));
+    answerUpdateWith(
+      const Success<Application>(
+        Application(id: 'app-1', name: 'Billing', ownerId: 'person-2'),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await tester.tap(find.byType(DropdownButtonFormField<String>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Grace (grace@example.com)').last);
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, 'Save changes'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => applications.update(
+        scopeId: 'scope-1',
+        id: 'app-1',
+        name: 'Billing',
+        ownerId: 'person-2',
+      ),
+    ).called(1);
+  });
+
+  // AF-22a — no such application.
+  testWidgets('GivenAMissingApplication_WhenOpened_ThenNotFoundIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(
+      const FailureResult<Application>(
+        Failure(kind: FailureKind.notFound, errors: <String>[]),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Application not found'), findsOneWidget);
+  });
+
+  testWidgets('GivenAMissingApplication_WhenBackTapped_ThenTheListingOpens', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(
+      const FailureResult<Application>(
+        Failure(kind: FailureKind.notFound, errors: <String>[]),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Back to the listing'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('listing'), findsOneWidget);
+  });
+
+  // AF-22b — out of this role's reach.
+  testWidgets('GivenAForbiddenApplication_WhenOpened_ThenTheRolePanelIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(
+      const FailureResult<Application>(
+        Failure(kind: FailureKind.forbidden, errors: <String>[]),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Not available for your role'), findsOneWidget);
+  });
+
+  // AF-22c — the API's own errors, with the typed input kept.
+  testWidgets('GivenARejectedUpdate_WhenSaved_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Application>(_billing));
+    answerUpdateWith(
+      const FailureResult<Application>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['An application with that name already exists.'],
+        ),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Billing'),
+      'Invoicing',
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, 'Save changes'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(
+      find.text('An application with that name already exists.'),
+      findsOneWidget,
+    );
+    expect(find.widgetWithText(TextFormField, 'Invoicing'), findsOneWidget);
+  });
+
+  // AF-22d — a deleted application is shown, marked, and read-only.
+  testWidgets('GivenADeletedApplication_WhenOpened_ThenItIsMarkedDeleted', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Application>(_deleted));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.textContaining('This application is deleted'), findsOneWidget);
+  });
+
+  testWidgets('GivenADeletedApplication_WhenOpened_ThenSavingIsNotOffered', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Application>(_deleted));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.widgetWithText(FilledButton, 'Save changes'), findsNothing);
+    expect(find.byType(DropdownButtonFormField<String>), findsNothing);
+  });
+
+  // AF-22e — nothing changed, so there is nothing to save.
+  testWidgets('GivenNoEdit_WhenRendered_ThenSaveIsDisabled', (tester) async {
+    // Given
+    answerGetWith(const Success<Application>(_billing));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(
+      tester
+          .widget<FilledButton>(
+            find.widgetWithText(FilledButton, 'Save changes'),
+          )
+          .onPressed,
+      isNull,
+    );
+  });
+
+  testWidgets('GivenAnEdit_WhenTyped_ThenSaveIsEnabled', (tester) async {
+    // Given
+    answerGetWith(const Success<Application>(_billing));
+    await pump(tester);
+
+    // When
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Billing'),
+      'Invoicing',
+    );
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(
+      tester
+          .widget<FilledButton>(
+            find.widgetWithText(FilledButton, 'Save changes'),
+          )
+          .onPressed,
+      isNotNull,
+    );
+  });
+
+  testWidgets('GivenACompactWindow_WhenRendered_ThenTheDetailIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Application>(_billing));
+
+    // When
+    await pump(tester, size: _compact);
+
+    // Then
+    expect(find.widgetWithText(TextFormField, 'Billing'), findsOneWidget);
+  });
+
+  testWidgets('GivenAMediumWindow_WhenRendered_ThenTheDetailIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Application>(_billing));
+
+    // When
+    await pump(tester, size: _medium);
+
+    // Then
+    expect(find.widgetWithText(TextFormField, 'Billing'), findsOneWidget);
+  });
+
+  testWidgets('GivenTheDarkTheme_WhenRendered_ThenTheDetailIsStillShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Application>(_billing));
+
+    // When
+    await pump(tester, theme: buildDarkTheme());
+
+    // Then
+    expect(find.widgetWithText(TextFormField, 'Billing'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #22

Implements UI-22 — `/scopes/:scopeId/applications/:applicationId` over `GET` (FR-AP-04) and `PUT /api/scopes/{scopeId}/applications/{id}` (FR-AP-05).

## Flows

| Flow | How it is handled |
| --- | --- |
| Main | The record is read on open with its owner; name and owner are both editable. |
| AF-22a | A `404` shows a not-found panel with a way back to the listing. |
| AF-22b | A `403` shows the not-available-for-your-role panel. |
| AF-22c | A refused update shows the API's strings; the record and the chosen owner are untouched. |
| AF-22d | A deleted application is shown, marked, and read-only, with the owner as a fact. |
| AF-22e | The save control is disabled until a field differs, and the controller repeats the check. |

The owner is the selector UI-21 built, over the scope's own people. An owner the listing does not contain — someone since removed from the scope — leaves the selector unset rather than silently choosing somebody else, and the read-only view falls back to the identifier as UI-20's rows do (FR-AP-08).

The controller's family key is the scope and the application together, since an application is identified by both; a test asserts two such keys are two separate states.

## Verification

`dart format --set-exit-if-changed .`, `flutter analyze`, and `flutter test` all pass — **693 tests**, 26 of them new. No presentation file imports `package:heimdall_api_client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)