### PR TITLE
feat(ui-23): delete an application, logically and permanently

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ the board is where an item's status changes as it moves.
 | UI-20: Browse applications in a scope | ✅ | [#20](https://github.com/artur-rios/heimdall-ui/issues/20) |
 | UI-21: Create an application | ✅ | [#21](https://github.com/artur-rios/heimdall-ui/issues/21) |
 | UI-22: View and update an application | ✅ | [#22](https://github.com/artur-rios/heimdall-ui/issues/22) |
-| UI-23: Delete an application, logically and permanently | ⬜ | [#23](https://github.com/artur-rios/heimdall-ui/issues/23) |
+| UI-23: Delete an application, logically and permanently | ✅ | [#23](https://github.com/artur-rios/heimdall-ui/issues/23) |
 
 ### Scope Permission Management
 

--- a/lib/features/applications/data/application_repository_impl.dart
+++ b/lib/features/applications/data/application_repository_impl.dart
@@ -188,6 +188,53 @@ class ApiApplicationRepository implements ApplicationRepository {
     }
   }
 
+  @override
+  Future<Result<void>> delete({
+    required String scopeId,
+    required String id,
+  }) async {
+    try {
+      final response = await _client.applicationDelete(
+        scopeId: scopeId,
+        id: id,
+      );
+
+      // AF-23b: the API refuses an application it will not delete, and its own
+      // strings say why.
+      return _acknowledgement(response.success, response.errors);
+    } on DioException catch (error) {
+      return FailureResult<void>(failureFromDioException(error));
+    }
+  }
+
+  @override
+  Future<Result<void>> hardDelete({
+    required String scopeId,
+    required String id,
+  }) async {
+    try {
+      final response = await _client.applicationHardDelete(
+        scopeId: scopeId,
+        id: id,
+      );
+
+      return _acknowledgement(response.success, response.errors);
+    } on DioException catch (error) {
+      return FailureResult<void>(failureFromDioException(error));
+    }
+  }
+
+  /// A command whose only interesting answer is whether it worked.
+  static Result<void> _acknowledgement(bool? success, List<String>? errors) =>
+      success == true
+      ? const Success<void>(null)
+      : FailureResult<void>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: errors ?? const <String>[],
+          ),
+        );
+
   static String? _filter(String? value) =>
       (value?.trim().isEmpty ?? true) ? null : value!.trim();
 }

--- a/lib/features/applications/domain/application_repository.dart
+++ b/lib/features/applications/domain/application_repository.dart
@@ -44,6 +44,17 @@ abstract interface class ApplicationRepository {
     required String name,
     required String ownerId,
   });
+
+  /// Logically deletes an application. The record is kept and the API can
+  /// restore it.
+  Future<Result<void>> delete({required String scopeId, required String id});
+
+  /// Permanently deletes an application. Only a System Admin may, which is why
+  /// UI-23 shows the control to nobody else.
+  Future<Result<void>> hardDelete({
+    required String scopeId,
+    required String id,
+  });
 }
 
 /// Overridden at start-up with the client-backed implementation, and in tests

--- a/lib/features/applications/presentation/application_detail_controller.dart
+++ b/lib/features/applications/presentation/application_detail_controller.dart
@@ -44,6 +44,11 @@ final class ApplicationDetailUnavailable extends ApplicationDetailState {
   bool get isForbidden => failure.kind == FailureKind.forbidden;
 }
 
+/// The application is gone, and the screen returns to the listing.
+final class ApplicationDeleted extends ApplicationDetailState {
+  const ApplicationDeleted();
+}
+
 /// The record is on screen.
 final class ApplicationDetailLoaded extends ApplicationDetailState {
   const ApplicationDetailLoaded(
@@ -51,12 +56,20 @@ final class ApplicationDetailLoaded extends ApplicationDetailState {
     this.saving = false,
     this.saveFailure,
     this.saved = false,
+    this.deleting = false,
+    this.deleteFailure,
   });
 
   final Application application;
   final bool saving;
   final Failure? saveFailure;
   final bool saved;
+
+  /// A deletion is on its way. Both controls are disabled while it is.
+  final bool deleting;
+
+  /// AF-23b — the API refused to delete, and the application stays open.
+  final Failure? deleteFailure;
 
   /// AF-22d — a logically deleted application is shown, but nothing about it
   /// may be changed from here.
@@ -68,11 +81,18 @@ final class ApplicationDetailLoaded extends ApplicationDetailState {
     Failure? saveFailure,
     bool clearSaveFailure = false,
     bool? saved,
+    bool? deleting,
+    Failure? deleteFailure,
+    bool clearDeleteFailure = false,
   }) => ApplicationDetailLoaded(
     application ?? this.application,
     saving: saving ?? this.saving,
     saveFailure: clearSaveFailure ? null : (saveFailure ?? this.saveFailure),
     saved: saved ?? this.saved,
+    deleting: deleting ?? this.deleting,
+    deleteFailure: clearDeleteFailure
+        ? null
+        : (deleteFailure ?? this.deleteFailure),
   );
 }
 
@@ -156,6 +176,44 @@ class ApplicationDetailController
   void acknowledgeSave() {
     if (state case final ApplicationDetailLoaded loaded) {
       state = loaded.copyWith(saved: false);
+    }
+  }
+
+  /// Logically deletes the application. The record is kept and the API can
+  /// restore it, which is what the confirmation says before this is called.
+  Future<void> delete() => _delete(
+    (repository) =>
+        repository.delete(scopeId: arg.scopeId, id: arg.applicationId),
+  );
+
+  /// Permanently deletes the application.
+  Future<void> deletePermanently() => _delete(
+    (repository) =>
+        repository.hardDelete(scopeId: arg.scopeId, id: arg.applicationId),
+  );
+
+  Future<void> _delete(
+    Future<Result<void>> Function(ApplicationRepository repository) send,
+  ) async {
+    final current = state;
+
+    if (current is! ApplicationDetailLoaded || current.deleting) {
+      return;
+    }
+
+    state = current.copyWith(deleting: true, clearDeleteFailure: true);
+
+    final result = await send(ref.read(applicationRepositoryProvider));
+
+    switch (result) {
+      case Success<void>():
+        state = const ApplicationDeleted();
+      case FailureResult<void>(:final failure):
+        // Somebody already deleted it, which is the outcome that was asked
+        // for.
+        state = failure.kind == FailureKind.notFound
+            ? const ApplicationDeleted()
+            : current.copyWith(deleting: false, deleteFailure: failure);
     }
   }
 }

--- a/lib/features/applications/presentation/application_detail_screen.dart
+++ b/lib/features/applications/presentation/application_detail_screen.dart
@@ -5,11 +5,15 @@ import 'package:go_router/go_router.dart';
 import '../../../core/result/result.dart';
 import '../../../shared/layout/app_shell.dart';
 import '../../../shared/widgets/collection_states.dart';
+import '../../../shared/widgets/confirm_dialog.dart';
 import '../../../shared/widgets/failure_banner.dart';
 import '../../persons/domain/person.dart';
 import '../../persons/presentation/scope_members.dart';
+import '../../auth/domain/session.dart';
+import '../../auth/presentation/session_controller.dart';
 import '../domain/application.dart';
 import 'application_detail_controller.dart';
+import 'application_list_controller.dart';
 
 /// UI-22 — one application: what it is called and who owns it.
 class ApplicationDetailScreen extends ConsumerStatefulWidget {
@@ -75,6 +79,51 @@ class _ApplicationDetailScreenState
       _name.text.trim() != application.name ||
       (_ownerId ?? '') != application.ownerId;
 
+  /// AF-23d — only a System Admin erases an application permanently.
+  bool get _maySeeHardDelete {
+    final session = ref.watch(sessionControllerProvider);
+
+    return session is Authenticated && session.principal.isSystemAdmin;
+  }
+
+  /// AF-23a — a dialog the user closes sends nothing.
+  Future<void> _confirmDelete(Application application) async {
+    final confirmed = await showConfirm(
+      context: context,
+      title: 'Delete ${application.name}?',
+      message:
+          '${application.name} will be marked deleted. The record is '
+          'kept and the API can restore it.',
+      confirmLabel: 'Delete',
+    );
+
+    if (confirmed && mounted) {
+      await ref
+          .read(applicationDetailControllerProvider(_ref).notifier)
+          .delete();
+    }
+  }
+
+  /// AF-23c — the confirm control stays disabled until the name matches.
+  Future<void> _confirmDeletePermanently(Application application) async {
+    final confirmed = await showTypeToConfirm(
+      context: context,
+      title: 'Delete ${application.name} permanently?',
+      message:
+          'The application and everything recorded against it are '
+          'erased. This cannot be undone. Type its name to confirm:',
+      confirmationValue: application.name,
+      fieldLabel: 'Application name',
+      confirmLabel: 'Delete permanently',
+    );
+
+    if (confirmed && mounted) {
+      await ref
+          .read(applicationDetailControllerProvider(_ref).notifier)
+          .deletePermanently();
+    }
+  }
+
   Future<void> _save() async {
     if (!(_formKey.currentState?.validate() ?? false)) {
       return;
@@ -98,6 +147,19 @@ class _ApplicationDetailScreenState
       applicationDetailControllerProvider(_ref).notifier,
     );
     final backToListing = '/scopes/${widget.scopeId}/applications';
+
+    // A deleted application returns to the listing, which is now stale.
+    ref.listen<ApplicationDetailState>(
+      applicationDetailControllerProvider(_ref),
+      (previous, next) {
+        if (next is ApplicationDeleted) {
+          ref
+              .read(applicationListControllerProvider(widget.scopeId).notifier)
+              .load();
+          context.go(backToListing);
+        }
+      },
+    );
 
     return AppShell(
       currentRoute: '/scopes',
@@ -139,6 +201,11 @@ class _ApplicationDetailScreenState
         ApplicationDetailUnavailable(:final failure) => CollectionFailed(
           failure: failure,
           onRetry: controller.load,
+        ),
+        // The listing is where a deleted application leaves the user; this is
+        // the frame in between.
+        ApplicationDeleted() => const Center(
+          child: CircularProgressIndicator(),
         ),
         final ApplicationDetailLoaded loaded => _detail(loaded),
       },
@@ -221,6 +288,18 @@ class _ApplicationDetailScreenState
                   ],
                 ),
               ),
+              // AF-22d leaves a deleted application nothing left to delete.
+              if (!state.isReadOnly) ...<Widget>[
+                const SizedBox(height: 24),
+                _DangerZone(
+                  application: application,
+                  deleting: state.deleting,
+                  failure: state.deleteFailure,
+                  mayDeletePermanently: _maySeeHardDelete,
+                  onDelete: _confirmDelete,
+                  onDeletePermanently: _confirmDeletePermanently,
+                ),
+              ],
               const SizedBox(height: 24),
               Card(
                 child: Padding(
@@ -376,4 +455,81 @@ class _Fact extends StatelessWidget {
       ],
     ),
   );
+}
+
+/// The two deletions, kept apart from the rest of the screen because neither
+/// is an ordinary edit.
+class _DangerZone extends StatelessWidget {
+  const _DangerZone({
+    required this.application,
+    required this.deleting,
+    required this.failure,
+    required this.mayDeletePermanently,
+    required this.onDelete,
+    required this.onDeletePermanently,
+  });
+
+  final Application application;
+  final bool deleting;
+  final Failure? failure;
+
+  /// AF-23d — a Scope Admin never sees the permanent deletion.
+  final bool mayDeletePermanently;
+
+  final Future<void> Function(Application application) onDelete;
+  final Future<void> Function(Application application) onDeletePermanently;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Card(
+      color: theme.colorScheme.errorContainer,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              'Delete this application',
+              style: theme.textTheme.titleMedium?.copyWith(
+                color: theme.colorScheme.onErrorContainer,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Deleting keeps the record and can be undone by the API. '
+              'Deleting permanently erases it.',
+              style: TextStyle(color: theme.colorScheme.onErrorContainer),
+            ),
+            // AF-23b — the API refused, and the application is still open.
+            if (failure case final refusal?) ...<Widget>[
+              const SizedBox(height: 16),
+              ErrorBanner(failure: refusal),
+            ],
+            const SizedBox(height: 16),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: <Widget>[
+                OutlinedButton.icon(
+                  onPressed: deleting ? null : () => onDelete(application),
+                  icon: const Icon(Icons.delete_outline),
+                  label: const Text('Delete application'),
+                ),
+                if (mayDeletePermanently)
+                  FilledButton.icon(
+                    onPressed: deleting
+                        ? null
+                        : () => onDeletePermanently(application),
+                    icon: const Icon(Icons.delete_forever_outlined),
+                    label: const Text('Delete permanently'),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }

--- a/test/features/applications/presentation/application_detail_controller_test.dart
+++ b/test/features/applications/presentation/application_detail_controller_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:heimdall_ui/core/result/result.dart';
@@ -50,6 +52,24 @@ void main() {
         scopeId: any(named: 'scopeId'),
         id: any(named: 'id'),
         includeDeleted: any(named: 'includeDeleted'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  void answerDeleteWith(Result<void> result) {
+    when(
+      () => repository.delete(
+        scopeId: any(named: 'scopeId'),
+        id: any(named: 'id'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  void answerHardDeleteWith(Result<void> result) {
+    when(
+      () => repository.hardDelete(
+        scopeId: any(named: 'scopeId'),
+        id: any(named: 'id'),
       ),
     ).thenAnswer((_) async => result);
   }
@@ -275,5 +295,105 @@ void main() {
 
     // Then
     expect(other, isA<ApplicationDetailLoading>());
+  });
+
+  test('GivenAnOpenApplication_WhenDeleted_ThenItIsDeleted', () async {
+    // Given
+    answerGetWith(const Success<Application>(_billing));
+    answerDeleteWith(const Success<void>(null));
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.delete();
+
+    // Then
+    verify(() => repository.delete(scopeId: 'scope-1', id: 'app-1')).called(1);
+    expect(currentState(), isA<ApplicationDeleted>());
+  });
+
+  test('GivenAnOpenApplication_WhenErased_ThenTheHardEndpointIsUsed', () async {
+    // Given
+    answerGetWith(const Success<Application>(_billing));
+    answerHardDeleteWith(const Success<void>(null));
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.deletePermanently();
+
+    // Then
+    verify(
+      () => repository.hardDelete(scopeId: 'scope-1', id: 'app-1'),
+    ).called(1);
+  });
+
+  // AF-23b — the API refused, and the application stays open.
+  test('GivenARefusedDeletion_WhenDeleted_ThenItStaysOpen', () async {
+    // Given
+    answerGetWith(const Success<Application>(_billing));
+    answerDeleteWith(
+      const FailureResult<void>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['That application is still in use.'],
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.delete();
+
+    // Then
+    final state = currentState() as ApplicationDetailLoaded;
+    expect(state.deleteFailure?.errors, <String>[
+      'That application is still in use.',
+    ]);
+  });
+
+  test(
+    'GivenAnAlreadyDeletedApplication_WhenDeleted_ThenItCountsAsDone',
+    () async {
+      // Given
+      answerGetWith(const Success<Application>(_billing));
+      answerDeleteWith(
+        const FailureResult<void>(
+          Failure(kind: FailureKind.notFound, errors: <String>[]),
+        ),
+      );
+      final controller = controllerUnderTest();
+      await controller.load();
+
+      // When
+      await controller.delete();
+
+      // Then
+      expect(currentState(), isA<ApplicationDeleted>());
+    },
+  );
+
+  test('GivenADeletionInFlight_WhenAskedAgain_ThenOnlyOneIsSent', () async {
+    // Given
+    answerGetWith(const Success<Application>(_billing));
+    final pending = Completer<Result<void>>();
+    when(
+      () => repository.delete(
+        scopeId: any(named: 'scopeId'),
+        id: any(named: 'id'),
+      ),
+    ).thenAnswer((_) => pending.future);
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    final first = controller.delete();
+    final second = controller.delete();
+    pending.complete(const Success<void>(null));
+    await Future.wait<void>(<Future<void>>[first, second]);
+
+    // Then
+    verify(() => repository.delete(scopeId: 'scope-1', id: 'app-1')).called(1);
   });
 }

--- a/test/features/applications/presentation/application_detail_screen_test.dart
+++ b/test/features/applications/presentation/application_detail_screen_test.dart
@@ -24,13 +24,14 @@ class _MockApplicationRepository extends Mock
 
 class _MockPersonRepository extends Mock implements PersonRepository {}
 
-String _jwt() {
+/// A token naming a person of [role]: 1 System Admin, 2 Scope Admin.
+String _jwt({int role = 1}) {
   final payload = base64Url.encode(
     utf8.encode(
       jsonEncode(<String, dynamic>{
         'sub': 'person-9',
         'email': 'admin@example.com',
-        'role': 1,
+        'role': role,
       }),
     ),
   );
@@ -90,12 +91,18 @@ void main() {
     WidgetTester tester, {
     Size size = _expanded,
     ThemeData? theme,
+    int role = 1,
   }) async {
     tester.view.physicalSize = size;
     tester.view.devicePixelRatio = 1;
     addTearDown(tester.view.reset);
 
-    await store.write(AuthToken(value: _jwt(), expiresAt: DateTime.utc(2030)));
+    await store.write(
+      AuthToken(
+        value: _jwt(role: role),
+        expiresAt: DateTime.utc(2030),
+      ),
+    );
 
     container = ProviderContainer(
       overrides: <Override>[
@@ -145,6 +152,52 @@ void main() {
         includeDeleted: any(named: 'includeDeleted'),
       ),
     ).thenAnswer((_) async => result);
+  }
+
+  /// The deletion controls sit at the bottom of a scrolling detail, so they
+  /// are not on screen until the view is brought to them.
+  Future<void> tapAfterScrolling(WidgetTester tester, Finder finder) async {
+    await tester.ensureVisible(finder);
+    await tester.pumpAndSettle();
+    await tester.tap(finder);
+    await tester.pumpAndSettle();
+  }
+
+  void answerDeleteWith(Result<void> result) {
+    when(
+      () => applications.delete(
+        scopeId: any(named: 'scopeId'),
+        id: any(named: 'id'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  void answerHardDeleteWith(Result<void> result) {
+    when(
+      () => applications.hardDelete(
+        scopeId: any(named: 'scopeId'),
+        id: any(named: 'id'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  /// The listing behind the detail is reloaded after a deletion; what it
+  /// answers does not matter here, only that it answers.
+  void answerListWith() {
+    when(
+      () => applications.list(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        ownerId: any(named: 'ownerId'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer(
+      (_) async => const FailureResult<envelope.Page<Application>>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
   }
 
   void answerUpdateWith(Result<Application> result) {
@@ -480,5 +533,256 @@ void main() {
 
     // Then
     expect(find.widgetWithText(TextFormField, 'Billing'), findsOneWidget);
+  });
+
+  testWidgets('GivenASystemAdmin_WhenOpened_ThenBothDeletionsAreOffered', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Application>(_billing));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(
+      find.widgetWithText(OutlinedButton, 'Delete application'),
+      findsOneWidget,
+    );
+    expect(
+      find.widgetWithText(FilledButton, 'Delete permanently'),
+      findsOneWidget,
+    );
+  });
+
+  // AF-23d — a Scope Admin never sees the permanent deletion.
+  testWidgets('GivenAScopeAdmin_WhenOpened_ThenOnlyTheLogicalOneIsOffered', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Application>(_billing));
+
+    // When
+    await pump(tester, role: 2);
+
+    // Then
+    expect(
+      find.widgetWithText(OutlinedButton, 'Delete application'),
+      findsOneWidget,
+    );
+    expect(
+      find.widgetWithText(FilledButton, 'Delete permanently'),
+      findsNothing,
+    );
+  });
+
+  // AF-22d — a deleted application has nothing left to delete.
+  testWidgets('GivenADeletedApplication_WhenOpened_ThenDeletionIsNotOffered', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Application>(_deleted));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(
+      find.widgetWithText(OutlinedButton, 'Delete application'),
+      findsNothing,
+    );
+  });
+
+  testWidgets('GivenTheDeleteControl_WhenTapped_ThenConfirmationIsAsked', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Application>(_billing));
+    await pump(tester);
+
+    // When
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(OutlinedButton, 'Delete application'),
+    );
+
+    // Then
+    expect(find.text('Delete Billing?'), findsOneWidget);
+  });
+
+  testWidgets('GivenAConfirmedDeletion_WhenConfirmed_ThenItIsDeleted', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Application>(_billing));
+    answerDeleteWith(const Success<void>(null));
+    answerListWith();
+    await pump(tester);
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(OutlinedButton, 'Delete application'),
+    );
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => applications.delete(scopeId: 'scope-1', id: 'app-1'),
+    ).called(1);
+  });
+
+  testWidgets('GivenADeletedApplication_WhenDeleted_ThenTheListingOpens', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Application>(_billing));
+    answerDeleteWith(const Success<void>(null));
+    answerListWith();
+    await pump(tester);
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(OutlinedButton, 'Delete application'),
+    );
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('listing'), findsOneWidget);
+  });
+
+  // AF-23a — the dialog closes and nothing is sent.
+  testWidgets('GivenTheDeleteDialog_WhenCancelled_ThenNothingIsSent', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Application>(_billing));
+    answerDeleteWith(const Success<void>(null));
+    await pump(tester);
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(OutlinedButton, 'Delete application'),
+    );
+
+    // When
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verifyNever(
+      () => applications.delete(
+        scopeId: any(named: 'scopeId'),
+        id: any(named: 'id'),
+      ),
+    );
+  });
+
+  // AF-23b — the API refused, and the application stays open.
+  testWidgets('GivenARefusedDeletion_WhenConfirmed_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Application>(_billing));
+    answerDeleteWith(
+      const FailureResult<void>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['That application is still in use.'],
+        ),
+      ),
+    );
+    await pump(tester);
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(OutlinedButton, 'Delete application'),
+    );
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('That application is still in use.'), findsOneWidget);
+  });
+
+  // AF-23c — the confirm control stays disabled until the name matches.
+  testWidgets('GivenTheHardDeleteDialog_WhenOpened_ThenConfirmIsDisabled', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Application>(_billing));
+    await pump(tester);
+
+    // When
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(FilledButton, 'Delete permanently'),
+    );
+
+    // Then
+    expect(
+      tester
+          .widget<FilledButton>(
+            find.widgetWithText(FilledButton, 'Delete permanently').last,
+          )
+          .onPressed,
+      isNull,
+    );
+  });
+
+  testWidgets('GivenAMistypedName_WhenTyped_ThenConfirmStaysDisabled', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Application>(_billing));
+    await pump(tester);
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(FilledButton, 'Delete permanently'),
+    );
+
+    // When
+    await tester.enterText(find.byType(TextField).last, 'billing');
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(
+      tester
+          .widget<FilledButton>(
+            find.widgetWithText(FilledButton, 'Delete permanently').last,
+          )
+          .onPressed,
+      isNull,
+    );
+  });
+
+  testWidgets('GivenTheTypedName_WhenItMatches_ThenTheApplicationIsErased', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Application>(_billing));
+    answerHardDeleteWith(const Success<void>(null));
+    answerListWith();
+    await pump(tester);
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(FilledButton, 'Delete permanently'),
+    );
+    await tester.enterText(find.byType(TextField).last, 'Billing');
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(
+      find.widgetWithText(FilledButton, 'Delete permanently').last,
+    );
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => applications.hardDelete(scopeId: 'scope-1', id: 'app-1'),
+    ).called(1);
   });
 }


### PR DESCRIPTION
Closes #23

Implements UI-23 — both deletions from the application detail, over `DELETE /api/scopes/{scopeId}/applications/{id}` (FR-AP-06) and its `/hard` counterpart (FR-AP-07).

## Flows

| Flow | How it is handled |
| --- | --- |
| Main — logical | A dialog names the application and says the record is kept; on success the listing reopens. |
| Main — permanent | A dialog requires the application's name to be typed. |
| AF-23a | Closing either dialog sends nothing. |
| AF-23b | A refusal shows the API's strings and leaves the application open. |
| AF-23c | The confirm control stays disabled until the name matches exactly. |
| AF-23d | Only a System Admin is shown the permanent deletion. |

A `404` is treated as done, as UI-13 and UI-19 treat it.

## Verification

`dart format --set-exit-if-changed .`, `flutter analyze`, and `flutter test` all pass — **709 tests**, 16 of them new. No presentation file imports `package:heimdall_api_client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)