### PR TITLE
feat(ui-24): browse scope permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ the board is where an item's status changes as it moves.
 
 | Use case | Status | Issue |
 | --- | --- | --- |
-| UI-24: Browse scope permissions | ⬜ | [#24](https://github.com/artur-rios/heimdall-ui/issues/24) |
+| UI-24: Browse scope permissions | ✅ | [#24](https://github.com/artur-rios/heimdall-ui/issues/24) |
 | UI-25: Create a scope permission | ⬜ | [#25](https://github.com/artur-rios/heimdall-ui/issues/25) |
 | UI-26: View and update a scope permission | ⬜ | [#26](https://github.com/artur-rios/heimdall-ui/issues/26) |
 | UI-27: Delete a scope permission, logically and permanently | ⬜ | [#27](https://github.com/artur-rios/heimdall-ui/issues/27) |

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -13,6 +13,7 @@ import '../features/auth/presentation/session_controller.dart';
 import '../features/auth/presentation/two_factor_screen.dart';
 import '../features/auth/presentation/verify_email_screen.dart';
 import '../features/home/presentation/home_screen.dart';
+import '../features/permissions/presentation/permission_list_screen.dart';
 import '../features/persons/presentation/person_create_screen.dart';
 import '../features/persons/presentation/person_detail_screen.dart';
 import '../features/persons/presentation/person_list_screen.dart';
@@ -153,6 +154,11 @@ final Provider<GoRouter> routerProvider = Provider<GoRouter>((ref) {
           scopeId: state.pathParameters['scopeId']!,
           applicationId: state.pathParameters['applicationId']!,
         ),
+      ),
+      GoRoute(
+        path: '/scopes/:scopeId/permissions',
+        builder: (context, state) =>
+            PermissionListScreen(scopeId: state.pathParameters['scopeId']!),
       ),
       GoRoute(
         path: '/scopes/:scopeId/owners',

--- a/lib/features/permissions/data/scope_permission_repository_impl.dart
+++ b/lib/features/permissions/data/scope_permission_repository_impl.dart
@@ -1,0 +1,77 @@
+import 'package:dio/dio.dart';
+import 'package:heimdall_api_client/export.dart';
+
+import '../../../core/network/envelope.dart';
+import '../../../core/result/result.dart';
+import '../domain/scope_permission.dart';
+import '../domain/scope_permission_repository.dart';
+
+/// [ScopePermissionRepository] over the generated client.
+class ApiScopePermissionRepository implements ScopePermissionRepository {
+  const ApiScopePermissionRepository(this._client);
+
+  final ScopePermissionClient _client;
+
+  @override
+  Future<Result<Page<ScopePermission>>> list({
+    required String scopeId,
+    String? name,
+    bool includeDeleted = false,
+    int pageNumber = 1,
+    int pageSize = 20,
+  }) async {
+    try {
+      final response = await _client.scopePermissionList(
+        scopeId: scopeId,
+        // An empty filter is no filter: sending it would ask the API to match
+        // the empty string rather than to stop filtering.
+        name: (name?.trim().isEmpty ?? true) ? null : name!.trim(),
+        includeDeleted: includeDeleted,
+        pageNumber: pageNumber,
+        pageSize: pageSize,
+      );
+
+      if (response.success != true) {
+        return FailureResult<Page<ScopePermission>>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: response.errors ?? const <String>[],
+          ),
+        );
+      }
+
+      final items = (response.data ?? const <ScopePermissionOutput>[])
+          .map(scopePermissionFromOutput)
+          .toList(growable: false);
+
+      return Success<Page<ScopePermission>>(
+        Page<ScopePermission>(
+          items: items,
+          pageNumber: response.pageNumber ?? pageNumber,
+          pageSize: response.pageSize ?? pageSize,
+          totalItems: response.totalItems ?? items.length,
+          totalPages: response.totalPages ?? 1,
+        ),
+      );
+    } on DioException catch (error) {
+      // AF-24b and AF-24c depend on this: a transport failure and a `403` are
+      // different panels, and only the kind tells them apart.
+      return FailureResult<Page<ScopePermission>>(
+        failureFromDioException(error),
+      );
+    }
+  }
+}
+
+/// Maps the generated output onto the domain entity.
+ScopePermission scopePermissionFromOutput(ScopePermissionOutput output) =>
+    ScopePermission(
+      id: output.id ?? '',
+      name: output.name ?? '',
+      description: output.description ?? '',
+      includeAsJwtClaim: output.includeAsJwtClaim ?? false,
+      scopeId: output.scopeId,
+      isDeleted: output.isDeleted ?? false,
+      createdAt: output.createdAt,
+      updatedAt: output.updatedAt,
+    );

--- a/lib/features/permissions/domain/scope_permission.dart
+++ b/lib/features/permissions/domain/scope_permission.dart
@@ -1,0 +1,27 @@
+/// A scope permission as the API describes one.
+class ScopePermission {
+  const ScopePermission({
+    required this.id,
+    required this.name,
+    required this.description,
+    this.includeAsJwtClaim = false,
+    this.scopeId,
+    this.isDeleted = false,
+    this.createdAt,
+    this.updatedAt,
+  });
+
+  final String id;
+  final String name;
+  final String description;
+
+  /// Whether the permission is issued in the scope's tokens. FR-PM-04: the
+  /// interface says so where it is set, because it is the difference between a
+  /// record and something the scope's users actually carry.
+  final bool includeAsJwtClaim;
+
+  final String? scopeId;
+  final bool isDeleted;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+}

--- a/lib/features/permissions/domain/scope_permission_repository.dart
+++ b/lib/features/permissions/domain/scope_permission_repository.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/network/envelope.dart';
+import '../../../core/result/result.dart';
+import 'scope_permission.dart';
+
+/// The scope permission operations the interface depends on.
+abstract interface class ScopePermissionRepository {
+  /// Reads one page of a scope's permissions.
+  Future<Result<Page<ScopePermission>>> list({
+    required String scopeId,
+    String? name,
+    bool includeDeleted = false,
+    int pageNumber = 1,
+    int pageSize = 20,
+  });
+}
+
+/// Overridden at start-up with the client-backed implementation, and in tests
+/// with a fake.
+final Provider<ScopePermissionRepository> scopePermissionRepositoryProvider =
+    Provider<ScopePermissionRepository>(
+      (ref) => throw UnimplementedError(
+        'scopePermissionRepositoryProvider must be overridden',
+      ),
+    );

--- a/lib/features/permissions/presentation/permission_list_controller.dart
+++ b/lib/features/permissions/presentation/permission_list_controller.dart
@@ -1,0 +1,133 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/network/envelope.dart';
+import '../../../core/result/result.dart';
+import '../domain/scope_permission.dart';
+import '../domain/scope_permission_repository.dart';
+
+/// What the listing is currently asking the API for.
+class PermissionQuery {
+  const PermissionQuery({
+    this.name = '',
+    this.includeDeleted = false,
+    this.pageNumber = 1,
+  });
+
+  final String name;
+  final bool includeDeleted;
+  final int pageNumber;
+
+  /// Whether the user has narrowed the listing at all, which is what tells an
+  /// empty result from an unfiltered empty collection (AF-24a).
+  bool get isFiltered => name.trim().isNotEmpty || includeDeleted;
+
+  PermissionQuery copyWith({
+    String? name,
+    bool? includeDeleted,
+    int? pageNumber,
+  }) => PermissionQuery(
+    name: name ?? this.name,
+    includeDeleted: includeDeleted ?? this.includeDeleted,
+    pageNumber: pageNumber ?? this.pageNumber,
+  );
+}
+
+/// How far the listing has got. The query travels with every state, so the
+/// filters survive a failure and a retry.
+sealed class PermissionListState {
+  const PermissionListState(this.query);
+
+  final PermissionQuery query;
+}
+
+/// The first page is on its way and the list shows a placeholder.
+final class PermissionListLoading extends PermissionListState {
+  const PermissionListLoading(super.query);
+}
+
+/// A page arrived.
+final class PermissionListLoaded extends PermissionListState {
+  const PermissionListLoaded(super.query, this.page, {this.busy = false});
+
+  final Page<ScopePermission> page;
+  final bool busy;
+}
+
+/// AF-24b and AF-24c — the request failed, and the query that failed is kept.
+final class PermissionListFailed extends PermissionListState {
+  const PermissionListFailed(super.query, this.failure);
+
+  final Failure failure;
+
+  /// AF-24c — a scope this admin does not own.
+  bool get isForbidden => failure.kind == FailureKind.forbidden;
+}
+
+final NotifierProviderFamily<
+  PermissionListController,
+  PermissionListState,
+  String
+>
+permissionListControllerProvider =
+    NotifierProvider.family<
+      PermissionListController,
+      PermissionListState,
+      String
+    >(PermissionListController.new);
+
+/// Owns one scope's permission listing.
+class PermissionListController
+    extends FamilyNotifier<PermissionListState, String> {
+  bool _inFlight = false;
+
+  @override
+  PermissionListState build(String scopeId) =>
+      const PermissionListLoading(PermissionQuery());
+
+  Future<void> load() => _fetch(state.query);
+
+  /// A new search starts at the first page.
+  Future<void> search(String name) =>
+      _fetch(state.query.copyWith(name: name, pageNumber: 1));
+
+  Future<void> setIncludeDeleted(bool includeDeleted) => _fetch(
+    state.query.copyWith(includeDeleted: includeDeleted, pageNumber: 1),
+  );
+
+  Future<void> goToPage(int pageNumber) =>
+      _fetch(state.query.copyWith(pageNumber: pageNumber));
+
+  /// AF-24a — returns to the unfiltered listing from the empty-result panel.
+  Future<void> clearFilters() => _fetch(const PermissionQuery());
+
+  Future<void> _fetch(PermissionQuery query) async {
+    if (_inFlight) {
+      return;
+    }
+
+    final current = state;
+    _inFlight = true;
+
+    state = current is PermissionListLoaded
+        ? PermissionListLoaded(query, current.page, busy: true)
+        : PermissionListLoading(query);
+
+    try {
+      final result = await ref
+          .read(scopePermissionRepositoryProvider)
+          .list(
+            scopeId: arg,
+            name: query.name,
+            includeDeleted: query.includeDeleted,
+            pageNumber: query.pageNumber,
+          );
+
+      state = result.fold(
+        onSuccess: (page) => PermissionListLoaded(query, page),
+        onFailure: (failure) => PermissionListFailed(query, failure),
+      );
+    } finally {
+      _inFlight = false;
+    }
+  }
+}

--- a/lib/features/permissions/presentation/permission_list_screen.dart
+++ b/lib/features/permissions/presentation/permission_list_screen.dart
@@ -1,0 +1,205 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../shared/layout/app_shell.dart';
+import '../../../shared/widgets/adaptive_collection.dart';
+import '../../../shared/widgets/collection_states.dart';
+import '../domain/scope_permission.dart';
+import 'permission_list_controller.dart';
+
+/// UI-24 — the permissions of one scope.
+class PermissionListScreen extends ConsumerStatefulWidget {
+  const PermissionListScreen({required this.scopeId, super.key});
+
+  final String scopeId;
+
+  @override
+  ConsumerState<PermissionListScreen> createState() =>
+      _PermissionListScreenState();
+}
+
+class _PermissionListScreenState extends ConsumerState<PermissionListScreen> {
+  final _search = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => ref
+          .read(permissionListControllerProvider(widget.scopeId).notifier)
+          .load(),
+    );
+  }
+
+  @override
+  void dispose() {
+    _search.dispose();
+    super.dispose();
+  }
+
+  PermissionListController get _controller =>
+      ref.read(permissionListControllerProvider(widget.scopeId).notifier);
+
+  void _clearFilters() {
+    _search.clear();
+    _controller.clearFilters();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(permissionListControllerProvider(widget.scopeId));
+    final createRoute = '/scopes/${widget.scopeId}/permissions/new';
+
+    return AppShell(
+      currentRoute: '/scopes',
+      title: const Text('Permissions'),
+      actions: <Widget>[
+        IconButton(
+          tooltip: 'Back to the scope',
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.go('/scopes/${widget.scopeId}'),
+        ),
+      ],
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () => context.go(createRoute),
+        icon: const Icon(Icons.add),
+        label: const Text('New permission'),
+      ),
+      body: Column(
+        children: <Widget>[
+          _Filters(
+            search: _search,
+            includeDeleted: state.query.includeDeleted,
+            onSearch: () => _controller.search(_search.text),
+            onIncludeDeletedChanged: _controller.setIncludeDeleted,
+          ),
+          Expanded(
+            child: switch (state) {
+              PermissionListLoading() => const CollectionLoading(),
+              // AF-24c — the scope is not one this admin owns.
+              PermissionListFailed(isForbidden: true) => CollectionEmpty(
+                title: 'Not available for your role',
+                message:
+                    'This scope is not one you administer. Nothing is '
+                    'wrong with your session.',
+                icon: Icons.lock_person_outlined,
+                actionLabel: 'Back to scopes',
+                onAction: () => context.go('/scopes'),
+              ),
+              // AF-24b — the returned errors, with a retry.
+              PermissionListFailed(:final failure) => CollectionFailed(
+                failure: failure,
+                onRetry: _controller.load,
+              ),
+              PermissionListLoaded(:final page, :final query)
+                  when page.items.isEmpty =>
+                _empty(query, createRoute),
+              final PermissionListLoaded loaded =>
+                AdaptiveCollection<ScopePermission>(
+                  items: loaded.page.items,
+                  busy: loaded.busy,
+                  reservesFloatingAction: true,
+                  pageNumber: loaded.page.pageNumber,
+                  totalPages: loaded.page.totalPages,
+                  totalItems: loaded.page.totalItems,
+                  onPageChanged: _controller.goToPage,
+                  onTap: (permission) => context.go(
+                    '/scopes/${widget.scopeId}/permissions/${permission.id}',
+                  ),
+                  title: (permission) => permission.name,
+                  subtitle: (permission) => permission.description,
+                  columns: <CollectionColumn<ScopePermission>>[
+                    CollectionColumn<ScopePermission>(
+                      label: 'In tokens',
+                      // FR-PM-04: a permission issued in the scope's tokens is
+                      // a different thing from one that is only recorded.
+                      cell: (permission) =>
+                          Text(permission.includeAsJwtClaim ? 'Yes' : 'No'),
+                    ),
+                    CollectionColumn<ScopePermission>(
+                      label: 'State',
+                      cell: (permission) =>
+                          Text(permission.isDeleted ? 'Deleted' : 'Active'),
+                    ),
+                  ],
+                ),
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// AF-24a — an empty scope and an empty search are different situations.
+  Widget _empty(PermissionQuery query, String createRoute) => query.isFiltered
+      ? CollectionEmpty(
+          title: 'No permissions matched',
+          message:
+              'Nothing here matches what you searched for. Clearing the '
+              'filters shows them all again.',
+          icon: Icons.search_off_outlined,
+          actionLabel: 'Clear filters',
+          onAction: _clearFilters,
+        )
+      : CollectionEmpty(
+          title: 'No permissions yet',
+          message:
+              'A permission is something this scope’s applications can '
+              'check for. Create the first one to get started.',
+          icon: Icons.key_outlined,
+          actionLabel: 'New permission',
+          onAction: () => context.go(createRoute),
+        );
+}
+
+/// The search field and the include-deleted switch.
+class _Filters extends StatelessWidget {
+  const _Filters({
+    required this.search,
+    required this.includeDeleted,
+    required this.onSearch,
+    required this.onIncludeDeletedChanged,
+  });
+
+  final TextEditingController search;
+  final bool includeDeleted;
+  final VoidCallback onSearch;
+  final ValueChanged<bool> onIncludeDeletedChanged;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.fromLTRB(12, 12, 12, 0),
+    child: Wrap(
+      spacing: 16,
+      runSpacing: 8,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: <Widget>[
+        SizedBox(
+          width: 320,
+          child: TextField(
+            controller: search,
+            decoration: InputDecoration(
+              labelText: 'Search by name',
+              prefixIcon: const Icon(Icons.search),
+              suffixIcon: IconButton(
+                tooltip: 'Search',
+                icon: const Icon(Icons.arrow_forward),
+                onPressed: onSearch,
+              ),
+            ),
+            onSubmitted: (_) => onSearch(),
+          ),
+        ),
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Switch(value: includeDeleted, onChanged: onIncludeDeletedChanged),
+            const SizedBox(width: 8),
+            const Text('Include deleted'),
+          ],
+        ),
+      ],
+    ),
+  );
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,8 @@ import 'features/auth/data/google_sign_in_gateway_impl.dart';
 import 'features/auth/presentation/session_controller.dart';
 import 'features/google_users/data/google_user_repository_impl.dart';
 import 'features/google_users/domain/google_user_repository.dart';
+import 'features/permissions/data/scope_permission_repository_impl.dart';
+import 'features/permissions/domain/scope_permission_repository.dart';
 import 'features/persons/data/person_repository_impl.dart';
 import 'features/profile/presentation/profile_controller.dart';
 import 'features/scopes/data/scope_repository_impl.dart';
@@ -54,6 +56,11 @@ void main() {
         googleUserRepositoryProvider.overrideWith(
           (ref) =>
               ApiGoogleUserRepository(GoogleUserClient(ref.watch(dioProvider))),
+        ),
+        scopePermissionRepositoryProvider.overrideWith(
+          (ref) => ApiScopePermissionRepository(
+            ScopePermissionClient(ref.watch(dioProvider)),
+          ),
         ),
         scopeRepositoryProvider.overrideWith(
           (ref) => ApiScopeRepository(ScopeClient(ref.watch(dioProvider))),

--- a/test/features/permissions/presentation/permission_list_controller_test.dart
+++ b/test/features/permissions/presentation/permission_list_controller_test.dart
@@ -1,0 +1,309 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdall_ui/core/network/envelope.dart';
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/features/permissions/domain/scope_permission.dart';
+import 'package:heimdall_ui/features/permissions/domain/scope_permission_repository.dart';
+import 'package:heimdall_ui/features/permissions/presentation/permission_list_controller.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockScopePermissionRepository extends Mock
+    implements ScopePermissionRepository {}
+
+const _readInvoices = ScopePermission(
+  id: 'permission-1',
+  name: 'read:invoices',
+  description: 'May read invoices',
+  includeAsJwtClaim: true,
+);
+
+Page<ScopePermission> _page({
+  List<ScopePermission> items = const <ScopePermission>[_readInvoices],
+  int pageNumber = 1,
+  int totalPages = 1,
+}) => Page<ScopePermission>(
+  items: items,
+  pageNumber: pageNumber,
+  pageSize: 20,
+  totalItems: items.length,
+  totalPages: totalPages,
+);
+
+void main() {
+  late _MockScopePermissionRepository repository;
+  late ProviderContainer container;
+
+  PermissionListController controllerUnderTest() {
+    container = ProviderContainer(
+      overrides: <Override>[
+        scopePermissionRepositoryProvider.overrideWithValue(repository),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    return container.read(permissionListControllerProvider('scope-1').notifier);
+  }
+
+  PermissionListState currentState() =>
+      container.read(permissionListControllerProvider('scope-1'));
+
+  void answerWith(Result<Page<ScopePermission>> result) {
+    when(
+      () => repository.list(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  setUp(() {
+    repository = _MockScopePermissionRepository();
+  });
+
+  test('GivenAPage_WhenLoaded_ThenThePermissionsAreShown', () async {
+    // Given
+    answerWith(Success<Page<ScopePermission>>(_page()));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    expect(
+      (currentState() as PermissionListLoaded).page.items.single.name,
+      'read:invoices',
+    );
+  });
+
+  test('GivenAScope_WhenLoaded_ThenThatScopeIsRead', () async {
+    // Given
+    answerWith(Success<Page<ScopePermission>>(_page()));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    verify(
+      () => repository.list(
+        scopeId: 'scope-1',
+        name: '',
+        includeDeleted: false,
+        pageNumber: 1,
+      ),
+    ).called(1);
+  });
+
+  test('GivenASearch_WhenSubmitted_ThenTheNameIsSent', () async {
+    // Given
+    answerWith(Success<Page<ScopePermission>>(_page()));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.search('read');
+
+    // Then
+    verify(
+      () => repository.list(
+        scopeId: 'scope-1',
+        name: 'read',
+        includeDeleted: false,
+        pageNumber: 1,
+      ),
+    ).called(1);
+  });
+
+  test('GivenAPageOtherThanTheFirst_WhenSearched_ThenPagingResets', () async {
+    // Given
+    answerWith(Success<Page<ScopePermission>>(_page(totalPages: 5)));
+    final controller = controllerUnderTest();
+    await controller.load();
+    await controller.goToPage(3);
+
+    // When
+    await controller.search('read');
+
+    // Then
+    expect(currentState().query.pageNumber, 1);
+  });
+
+  test('GivenIncludeDeleted_WhenToggled_ThenTheFlagIsSent', () async {
+    // Given
+    answerWith(Success<Page<ScopePermission>>(_page()));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.setIncludeDeleted(true);
+
+    // Then
+    verify(
+      () => repository.list(
+        scopeId: 'scope-1',
+        name: '',
+        includeDeleted: true,
+        pageNumber: 1,
+      ),
+    ).called(1);
+  });
+
+  test('GivenAPageChange_WhenRequested_ThenThatPageIsRead', () async {
+    // Given
+    answerWith(Success<Page<ScopePermission>>(_page(totalPages: 4)));
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.goToPage(2);
+
+    // Then
+    verify(
+      () => repository.list(
+        scopeId: 'scope-1',
+        name: '',
+        includeDeleted: false,
+        pageNumber: 2,
+      ),
+    ).called(1);
+  });
+
+  // AF-24b — the query that failed is kept, so the retry asks it again.
+  test('GivenAFailedRequest_WhenSearched_ThenTheFiltersSurvive', () async {
+    // Given
+    answerWith(
+      const FailureResult<Page<ScopePermission>>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.search('read');
+
+    // Then
+    expect(currentState().query.name, 'read');
+  });
+
+  test('GivenARefusedListing_WhenLoaded_ThenApiErrorsAreKept', () async {
+    // Given
+    answerWith(
+      const FailureResult<Page<ScopePermission>>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['Page size is too large.'],
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    expect((currentState() as PermissionListFailed).failure.errors, <String>[
+      'Page size is too large.',
+    ]);
+  });
+
+  // AF-24c — a scope this admin does not own.
+  test('GivenAForbiddenScope_WhenLoaded_ThenStateIsForbidden', () async {
+    // Given
+    answerWith(
+      const FailureResult<Page<ScopePermission>>(
+        Failure(kind: FailureKind.forbidden, errors: <String>[]),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    expect((currentState() as PermissionListFailed).isForbidden, isTrue);
+  });
+
+  // AF-24a — a filtered listing knows it is filtered.
+  test('GivenASearch_WhenApplied_ThenTheQueryIsFiltered', () async {
+    // Given
+    answerWith(
+      Success<Page<ScopePermission>>(_page(items: const <ScopePermission>[])),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.search('nothing');
+
+    // Then
+    expect(currentState().query.isFiltered, isTrue);
+  });
+
+  test('GivenNoFilters_WhenLoaded_ThenTheQueryIsUnfiltered', () async {
+    // Given
+    answerWith(
+      Success<Page<ScopePermission>>(_page(items: const <ScopePermission>[])),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    expect(currentState().query.isFiltered, isFalse);
+  });
+
+  test('GivenFilters_WhenCleared_ThenTheFullListingIsRead', () async {
+    // Given
+    answerWith(Success<Page<ScopePermission>>(_page()));
+    final controller = controllerUnderTest();
+    await controller.search('read');
+
+    // When
+    await controller.clearFilters();
+
+    // Then
+    verify(
+      () => repository.list(
+        scopeId: 'scope-1',
+        name: '',
+        includeDeleted: false,
+        pageNumber: 1,
+      ),
+    ).called(1);
+  });
+
+  test('GivenARequestInFlight_WhenAskedAgain_ThenOnlyOneIsSent', () async {
+    // Given
+    final pending = Completer<Result<Page<ScopePermission>>>();
+    when(
+      () => repository.list(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer((_) => pending.future);
+    final controller = controllerUnderTest();
+
+    // When
+    final first = controller.goToPage(2);
+    final second = controller.goToPage(3);
+    pending.complete(Success<Page<ScopePermission>>(_page()));
+    await Future.wait<void>(<Future<void>>[first, second]);
+
+    // Then
+    verify(
+      () => repository.list(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).called(1);
+  });
+}

--- a/test/features/permissions/presentation/permission_list_screen_test.dart
+++ b/test/features/permissions/presentation/permission_list_screen_test.dart
@@ -1,0 +1,371 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:heimdall_ui/app/theme.dart';
+import 'package:heimdall_ui/core/network/envelope.dart' as envelope;
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/core/storage/token_store.dart';
+import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
+import 'package:heimdall_ui/features/permissions/domain/scope_permission.dart';
+import 'package:heimdall_ui/features/permissions/domain/scope_permission_repository.dart';
+import 'package:heimdall_ui/features/permissions/presentation/permission_list_screen.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockScopePermissionRepository extends Mock
+    implements ScopePermissionRepository {}
+
+String _jwt() {
+  final payload = base64Url.encode(
+    utf8.encode(
+      jsonEncode(<String, dynamic>{
+        'sub': 'person-9',
+        'email': 'admin@example.com',
+        'role': 1,
+      }),
+    ),
+  );
+
+  return 'header.$payload.signature';
+}
+
+const _readInvoices = ScopePermission(
+  id: 'permission-1',
+  name: 'read:invoices',
+  description: 'May read invoices',
+  includeAsJwtClaim: true,
+);
+
+envelope.Page<ScopePermission> _page({
+  List<ScopePermission> items = const <ScopePermission>[_readInvoices],
+  int pageNumber = 1,
+  int totalPages = 1,
+}) => envelope.Page<ScopePermission>(
+  items: items,
+  pageNumber: pageNumber,
+  pageSize: 20,
+  totalItems: items.length,
+  totalPages: totalPages,
+);
+
+const Size _compact = Size(400, 900);
+const Size _medium = Size(800, 900);
+const Size _expanded = Size(1400, 900);
+
+void main() {
+  late _MockScopePermissionRepository repository;
+  late InMemoryTokenStore store;
+  late ProviderContainer container;
+  late GoRouter router;
+
+  Future<void> pump(
+    WidgetTester tester, {
+    Size size = _expanded,
+    ThemeData? theme,
+  }) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await store.write(AuthToken(value: _jwt(), expiresAt: DateTime.utc(2030)));
+
+    container = ProviderContainer(
+      overrides: <Override>[
+        scopePermissionRepositoryProvider.overrideWithValue(repository),
+        tokenStoreProvider.overrideWithValue(store),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(sessionControllerProvider.notifier).restore();
+
+    router = GoRouter(
+      initialLocation: '/scopes/scope-1/permissions',
+      routes: <RouteBase>[
+        GoRoute(
+          path: '/scopes',
+          builder: (context, state) => const Scaffold(body: Text('scopes')),
+        ),
+        GoRoute(
+          path: '/scopes/:scopeId',
+          builder: (context, state) => const Scaffold(body: Text('scope')),
+        ),
+        GoRoute(
+          path: '/scopes/:scopeId/permissions',
+          builder: (context, state) =>
+              PermissionListScreen(scopeId: state.pathParameters['scopeId']!),
+        ),
+        GoRoute(
+          path: '/scopes/:scopeId/permissions/new',
+          builder: (context, state) => const Scaffold(body: Text('create')),
+        ),
+        GoRoute(
+          path: '/scopes/:scopeId/permissions/:permissionId',
+          builder: (context, state) => Scaffold(
+            body: Text('detail ${state.pathParameters['permissionId']}'),
+          ),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(
+          theme: theme ?? buildLightTheme(),
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  void answerWith(Result<envelope.Page<ScopePermission>> result) {
+    when(
+      () => repository.list(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    repository = _MockScopePermissionRepository();
+    store = InMemoryTokenStore();
+  });
+
+  testWidgets('GivenAPage_WhenOpened_ThenThePermissionsAreListed', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<ScopePermission>>(_page()));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('read:invoices'), findsOneWidget);
+  });
+
+  // FR-PM-04 — a permission issued in the scope's tokens says so.
+  testWidgets('GivenAClaimPermission_WhenListed_ThenItSaysItIsInTokens', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<ScopePermission>>(_page()));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Yes'), findsOneWidget);
+  });
+
+  // FR-UX-04 — a table when the window is wide, cards when it is not.
+  testWidgets('GivenAnExpandedWindow_WhenListed_ThenATableIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<ScopePermission>>(_page()));
+
+    // When
+    await pump(tester, size: _expanded);
+
+    // Then
+    expect(find.byType(DataTable), findsOneWidget);
+  });
+
+  testWidgets('GivenAMediumWindow_WhenListed_ThenATableIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<ScopePermission>>(_page()));
+
+    // When
+    await pump(tester, size: _medium);
+
+    // Then
+    expect(find.byType(DataTable), findsOneWidget);
+  });
+
+  testWidgets('GivenACompactWindow_WhenListed_ThenCardsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<ScopePermission>>(_page()));
+
+    // When
+    await pump(tester, size: _compact);
+
+    // Then
+    expect(find.byType(DataTable), findsNothing);
+    expect(find.byType(Card), findsOneWidget);
+  });
+
+  testWidgets('GivenAPermission_WhenTapped_ThenItsDetailOpens', (tester) async {
+    // Given
+    answerWith(Success<envelope.Page<ScopePermission>>(_page()));
+    await pump(tester, size: _compact);
+
+    // When
+    await tester.tap(find.text('read:invoices'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('detail permission-1'), findsOneWidget);
+  });
+
+  // AF-24a — none yet, which offers UI-25.
+  testWidgets('GivenNoneAndNoFilter_WhenListed_ThenCreateIsOffered', (
+    tester,
+  ) async {
+    // Given
+    answerWith(
+      Success<envelope.Page<ScopePermission>>(
+        _page(items: const <ScopePermission>[]),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('No permissions yet'), findsOneWidget);
+  });
+
+  // AF-24a — no matches, which offers to clear the filter.
+  testWidgets('GivenNoMatches_WhenSearched_ThenClearingIsOffered', (
+    tester,
+  ) async {
+    // Given
+    answerWith(
+      Success<envelope.Page<ScopePermission>>(
+        _page(items: const <ScopePermission>[]),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await tester.enterText(find.byType(TextField), 'nothing');
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('No permissions matched'), findsOneWidget);
+  });
+
+  // AF-24b — the returned errors, with a retry.
+  testWidgets('GivenARefusedListing_WhenOpened_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(
+      const FailureResult<envelope.Page<ScopePermission>>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['Page size is too large.'],
+        ),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Page size is too large.'), findsOneWidget);
+  });
+
+  testWidgets('GivenATransportFailure_WhenOpened_ThenARetryIsOffered', (
+    tester,
+  ) async {
+    // Given
+    answerWith(
+      const FailureResult<envelope.Page<ScopePermission>>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.widgetWithText(TextButton, 'Retry'), findsOneWidget);
+  });
+
+  // AF-24c — a scope this admin does not own.
+  testWidgets('GivenAForbiddenScope_WhenOpened_ThenTheRolePanelIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(
+      const FailureResult<envelope.Page<ScopePermission>>(
+        Failure(kind: FailureKind.forbidden, errors: <String>[]),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Not available for your role'), findsOneWidget);
+  });
+
+  testWidgets('GivenIncludeDeleted_WhenToggled_ThenTheFlagIsSent', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<ScopePermission>>(_page()));
+    await pump(tester);
+
+    // When
+    await tester.tap(find.byType(Switch));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => repository.list(
+        scopeId: 'scope-1',
+        name: '',
+        includeDeleted: true,
+        pageNumber: 1,
+      ),
+    ).called(1);
+  });
+
+  testWidgets('GivenTheCreateControl_WhenTapped_ThenTheFormOpens', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<ScopePermission>>(_page()));
+    await pump(tester);
+
+    // When
+    await tester.tap(
+      find.widgetWithText(FloatingActionButton, 'New permission'),
+    );
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('create'), findsOneWidget);
+  });
+
+  testWidgets('GivenTheDarkTheme_WhenListed_ThenThePermissionsAreStillShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(Success<envelope.Page<ScopePermission>>(_page()));
+
+    // When
+    await pump(tester, theme: buildDarkTheme());
+
+    // Then
+    expect(find.text('read:invoices'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #24

Implements UI-24 — `/scopes/:scopeId/permissions` over `GET /api/scopes/{scopeId}/permissions` (FR-PM-01, FR-PM-02).

## Flows

| Flow | How it is handled |
| --- | --- |
| Main | The page is read on open with each permission's name, description, claim state and deletion state. |
| AF-24a | "No permissions yet" offers UI-25; "No permissions matched" offers to clear the filters. |
| AF-24b | The returned errors, or a retry for a transport failure, with the failing query kept. |
| AF-24c | A `403` shows the not-available-for-your-role panel. |

Each row states whether the permission is issued in the scope's tokens (FR-PM-04) — the difference between a permission that is merely recorded and one the scope's users actually carry.

## Verification

`dart format --set-exit-if-changed .`, `flutter analyze`, and `flutter test` all pass — **736 tests**, 27 of them new. No presentation file imports `package:heimdall_api_client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)