### PR TITLE
feat(ui-25): create a scope permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ the board is where an item's status changes as it moves.
 | Use case | Status | Issue |
 | --- | --- | --- |
 | UI-24: Browse scope permissions | ✅ | [#24](https://github.com/artur-rios/heimdall-ui/issues/24) |
-| UI-25: Create a scope permission | ⬜ | [#25](https://github.com/artur-rios/heimdall-ui/issues/25) |
+| UI-25: Create a scope permission | ✅ | [#25](https://github.com/artur-rios/heimdall-ui/issues/25) |
 | UI-26: View and update a scope permission | ⬜ | [#26](https://github.com/artur-rios/heimdall-ui/issues/26) |
 | UI-27: Delete a scope permission, logically and permanently | ⬜ | [#27](https://github.com/artur-rios/heimdall-ui/issues/27) |
 

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -13,6 +13,7 @@ import '../features/auth/presentation/session_controller.dart';
 import '../features/auth/presentation/two_factor_screen.dart';
 import '../features/auth/presentation/verify_email_screen.dart';
 import '../features/home/presentation/home_screen.dart';
+import '../features/permissions/presentation/permission_create_screen.dart';
 import '../features/permissions/presentation/permission_list_screen.dart';
 import '../features/persons/presentation/person_create_screen.dart';
 import '../features/persons/presentation/person_detail_screen.dart';
@@ -159,6 +160,11 @@ final Provider<GoRouter> routerProvider = Provider<GoRouter>((ref) {
         path: '/scopes/:scopeId/permissions',
         builder: (context, state) =>
             PermissionListScreen(scopeId: state.pathParameters['scopeId']!),
+      ),
+      GoRoute(
+        path: '/scopes/:scopeId/permissions/new',
+        builder: (context, state) =>
+            PermissionCreateScreen(scopeId: state.pathParameters['scopeId']!),
       ),
       GoRoute(
         path: '/scopes/:scopeId/owners',

--- a/lib/features/permissions/data/scope_permission_repository_impl.dart
+++ b/lib/features/permissions/data/scope_permission_repository_impl.dart
@@ -61,7 +61,62 @@ class ApiScopePermissionRepository implements ScopePermissionRepository {
       );
     }
   }
+
+  @override
+  Future<Result<ScopePermission>> create({
+    required String scopeId,
+    required String name,
+    required String description,
+    required bool includeAsJwtClaim,
+  }) async {
+    try {
+      final response = await _client.scopePermissionCreate(
+        scopeId: scopeId,
+        body: CreateScopePermissionCommand(
+          name: name,
+          description: description,
+          includeAsJwtClaim: includeAsJwtClaim,
+        ),
+      );
+
+      if (response.success != true) {
+        // AF-25b: a name already used in this scope, in the API's own words.
+        return FailureResult<ScopePermission>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: response.errors ?? const <String>[],
+          ),
+        );
+      }
+
+      final data = response.data;
+
+      if (data == null) {
+        return const FailureResult<ScopePermission>(_incompleteResponse);
+      }
+
+      return Success<ScopePermission>(
+        ScopePermission(
+          id: data.id ?? '',
+          name: data.name ?? name,
+          description: data.description ?? description,
+          includeAsJwtClaim: data.includeAsJwtClaim ?? includeAsJwtClaim,
+          scopeId: data.scopeId ?? scopeId,
+          createdAt: data.createdAt,
+        ),
+      );
+    } on DioException catch (error) {
+      return FailureResult<ScopePermission>(failureFromDioException(error));
+    }
+  }
 }
+
+/// A successful envelope that nonetheless lacks what the flow needs. It should
+/// not happen; saying so plainly beats a null dereference if it ever does.
+const Failure _incompleteResponse = Failure(
+  kind: FailureKind.unknown,
+  errors: <String>['The API returned an incomplete response.'],
+);
 
 /// Maps the generated output onto the domain entity.
 ScopePermission scopePermissionFromOutput(ScopePermissionOutput output) =>

--- a/lib/features/permissions/domain/scope_permission_repository.dart
+++ b/lib/features/permissions/domain/scope_permission_repository.dart
@@ -14,6 +14,14 @@ abstract interface class ScopePermissionRepository {
     int pageNumber = 1,
     int pageSize = 20,
   });
+
+  /// Creates a permission within a scope.
+  Future<Result<ScopePermission>> create({
+    required String scopeId,
+    required String name,
+    required String description,
+    required bool includeAsJwtClaim,
+  });
 }
 
 /// Overridden at start-up with the client-backed implementation, and in tests

--- a/lib/features/permissions/presentation/permission_create_controller.dart
+++ b/lib/features/permissions/presentation/permission_create_controller.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/result/result.dart';
+import '../domain/scope_permission.dart';
+import '../domain/scope_permission_repository.dart';
+
+/// How far a create attempt has got.
+sealed class PermissionCreateState {
+  const PermissionCreateState();
+}
+
+/// The form is being filled in.
+final class PermissionCreateEditing extends PermissionCreateState {
+  const PermissionCreateEditing();
+}
+
+/// A request is in flight. The form refuses a second submission in this state.
+final class PermissionCreateSending extends PermissionCreateState {
+  const PermissionCreateSending();
+}
+
+/// The permission exists. The screen opens its detail from here.
+final class PermissionCreated extends PermissionCreateState {
+  const PermissionCreated(this.permission);
+
+  final ScopePermission permission;
+}
+
+/// AF-25b — the API refused. The form keeps everything typed.
+final class PermissionCreateRejected extends PermissionCreateState {
+  const PermissionCreateRejected(this.failure);
+
+  final Failure failure;
+}
+
+final NotifierProviderFamily<
+  PermissionCreateController,
+  PermissionCreateState,
+  String
+>
+permissionCreateControllerProvider =
+    NotifierProvider.family<
+      PermissionCreateController,
+      PermissionCreateState,
+      String
+    >(PermissionCreateController.new);
+
+/// Owns one create attempt from filled in to created.
+class PermissionCreateController
+    extends FamilyNotifier<PermissionCreateState, String> {
+  @override
+  PermissionCreateState build(String scopeId) =>
+      const PermissionCreateEditing();
+
+  Future<void> create({
+    required String name,
+    required String description,
+    required bool includeAsJwtClaim,
+  }) async {
+    if (state is PermissionCreateSending) {
+      return;
+    }
+
+    state = const PermissionCreateSending();
+
+    final result = await ref
+        .read(scopePermissionRepositoryProvider)
+        .create(
+          scopeId: arg,
+          name: name,
+          description: description,
+          includeAsJwtClaim: includeAsJwtClaim,
+        );
+
+    state = result.fold(
+      onSuccess: PermissionCreated.new,
+      onFailure: PermissionCreateRejected.new,
+    );
+  }
+}

--- a/lib/features/permissions/presentation/permission_create_screen.dart
+++ b/lib/features/permissions/presentation/permission_create_screen.dart
@@ -1,0 +1,180 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../core/result/result.dart';
+import '../../../shared/layout/app_shell.dart';
+import '../../../shared/widgets/confirm_dialog.dart';
+import '../../../shared/widgets/failure_banner.dart';
+import 'permission_create_controller.dart';
+import 'permission_list_controller.dart';
+
+/// UI-25 — the create-permission form.
+class PermissionCreateScreen extends ConsumerStatefulWidget {
+  const PermissionCreateScreen({required this.scopeId, super.key});
+
+  final String scopeId;
+
+  @override
+  ConsumerState<PermissionCreateScreen> createState() =>
+      _PermissionCreateScreenState();
+}
+
+class _PermissionCreateScreenState
+    extends ConsumerState<PermissionCreateScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _name = TextEditingController();
+  final _description = TextEditingController();
+  bool _includeAsJwtClaim = false;
+
+  @override
+  void dispose() {
+    _name.dispose();
+    _description.dispose();
+    super.dispose();
+  }
+
+  /// Whether anything has been entered, which is what AF-25c asks about.
+  bool get _isDirty =>
+      _name.text.trim().isNotEmpty ||
+      _description.text.trim().isNotEmpty ||
+      _includeAsJwtClaim;
+
+  Future<void> _submit() async {
+    // AF-25a: an empty name never reaches the API.
+    if (!(_formKey.currentState?.validate() ?? false)) {
+      return;
+    }
+
+    await ref
+        .read(permissionCreateControllerProvider(widget.scopeId).notifier)
+        .create(
+          name: _name.text.trim(),
+          description: _description.text.trim(),
+          includeAsJwtClaim: _includeAsJwtClaim,
+        );
+  }
+
+  /// AF-25c — leaving a modified form asks first.
+  Future<void> _cancel() async {
+    final leave =
+        !_isDirty ||
+        await showConfirm(
+          context: context,
+          title: 'Discard this permission?',
+          message: 'What you have entered has not been saved and will be lost.',
+          confirmLabel: 'Discard',
+          cancelLabel: 'Keep editing',
+        );
+
+    if (leave && mounted) {
+      context.go('/scopes/${widget.scopeId}/permissions');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final state = ref.watch(permissionCreateControllerProvider(widget.scopeId));
+    final sending = state is PermissionCreateSending;
+
+    ref.listen<PermissionCreateState>(
+      permissionCreateControllerProvider(widget.scopeId),
+      (previous, next) {
+        if (next case PermissionCreated(:final permission)) {
+          // The listing behind this form is now stale.
+          ref
+              .read(permissionListControllerProvider(widget.scopeId).notifier)
+              .load();
+          context.go('/scopes/${widget.scopeId}/permissions/${permission.id}');
+        }
+      },
+    );
+
+    return AppShell(
+      currentRoute: '/scopes',
+      title: const Text('New permission'),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 560),
+            child: Form(
+              key: _formKey,
+              onChanged: () => setState(() {}),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  Text(
+                    'Create a permission',
+                    style: theme.textTheme.headlineSmall,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'A permission is something this scope’s applications can '
+                    'check for.',
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                  const SizedBox(height: 24),
+                  if (state is PermissionCreateRejected) ...<Widget>[
+                    if (state.failure.kind == FailureKind.network)
+                      RetryBanner(onRetry: sending ? null : _submit)
+                    else
+                      // AF-25b: the API's own strings, as returned.
+                      ErrorBanner(failure: state.failure),
+                    const SizedBox(height: 16),
+                  ],
+                  TextFormField(
+                    controller: _name,
+                    decoration: const InputDecoration(labelText: 'Name'),
+                    validator: (value) => (value?.trim().isEmpty ?? true)
+                        ? 'Enter a name for the permission.'
+                        : null,
+                  ),
+                  const SizedBox(height: 16),
+                  TextFormField(
+                    controller: _description,
+                    minLines: 2,
+                    maxLines: 4,
+                    decoration: const InputDecoration(labelText: 'Description'),
+                  ),
+                  const SizedBox(height: 16),
+                  // AF-25d and FR-PM-04 — what setting this actually does is
+                  // said here, not left to be discovered in a token.
+                  SwitchListTile(
+                    contentPadding: EdgeInsets.zero,
+                    title: const Text('Include in tokens'),
+                    subtitle: const Text(
+                      'Every token this scope issues from now on carries this '
+                      'permission as a claim, so its applications can read it '
+                      'without asking the API again.',
+                    ),
+                    value: _includeAsJwtClaim,
+                    onChanged: sending
+                        ? null
+                        : (value) => setState(() => _includeAsJwtClaim = value),
+                  ),
+                  const SizedBox(height: 24),
+                  FilledButton(
+                    onPressed: sending ? null : _submit,
+                    child: sending
+                        ? const SizedBox.square(
+                            dimension: 20,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Text('Create permission'),
+                  ),
+                  const SizedBox(height: 8),
+                  TextButton(
+                    onPressed: sending ? null : _cancel,
+                    child: const Text('Cancel'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/permissions/presentation/permission_create_screen_test.dart
+++ b/test/features/permissions/presentation/permission_create_screen_test.dart
@@ -1,0 +1,380 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:heimdall_ui/app/theme.dart';
+import 'package:heimdall_ui/core/network/envelope.dart' as envelope;
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/core/storage/token_store.dart';
+import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
+import 'package:heimdall_ui/features/permissions/domain/scope_permission.dart';
+import 'package:heimdall_ui/features/permissions/domain/scope_permission_repository.dart';
+import 'package:heimdall_ui/features/permissions/presentation/permission_create_screen.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockScopePermissionRepository extends Mock
+    implements ScopePermissionRepository {}
+
+String _jwt() {
+  final payload = base64Url.encode(
+    utf8.encode(
+      jsonEncode(<String, dynamic>{
+        'sub': 'person-9',
+        'email': 'admin@example.com',
+        'role': 1,
+      }),
+    ),
+  );
+
+  return 'header.$payload.signature';
+}
+
+const _created = ScopePermission(
+  id: 'permission-9',
+  name: 'read:invoices',
+  description: 'May read invoices',
+);
+
+const Size _compact = Size(400, 900);
+const Size _medium = Size(800, 900);
+const Size _expanded = Size(1400, 900);
+
+void main() {
+  late _MockScopePermissionRepository repository;
+  late InMemoryTokenStore store;
+  late ProviderContainer container;
+  late GoRouter router;
+
+  Future<void> pump(
+    WidgetTester tester, {
+    Size size = _expanded,
+    ThemeData? theme,
+  }) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await store.write(AuthToken(value: _jwt(), expiresAt: DateTime.utc(2030)));
+
+    container = ProviderContainer(
+      overrides: <Override>[
+        scopePermissionRepositoryProvider.overrideWithValue(repository),
+        tokenStoreProvider.overrideWithValue(store),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(sessionControllerProvider.notifier).restore();
+
+    router = GoRouter(
+      initialLocation: '/scopes/scope-1/permissions/new',
+      routes: <RouteBase>[
+        GoRoute(
+          path: '/scopes/:scopeId/permissions',
+          builder: (context, state) => const Scaffold(body: Text('listing')),
+        ),
+        GoRoute(
+          path: '/scopes/:scopeId/permissions/new',
+          builder: (context, state) =>
+              PermissionCreateScreen(scopeId: state.pathParameters['scopeId']!),
+        ),
+        GoRoute(
+          path: '/scopes/:scopeId/permissions/:permissionId',
+          builder: (context, state) => Scaffold(
+            body: Text('detail ${state.pathParameters['permissionId']}'),
+          ),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(
+          theme: theme ?? buildLightTheme(),
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  void answerCreateWith(Result<ScopePermission> result) {
+    when(
+      () => repository.create(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        description: any(named: 'description'),
+        includeAsJwtClaim: any(named: 'includeAsJwtClaim'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    repository = _MockScopePermissionRepository();
+    store = InMemoryTokenStore();
+    answerCreateWith(const Success<ScopePermission>(_created));
+    when(
+      () => repository.list(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer(
+      (_) async => const FailureResult<envelope.Page<ScopePermission>>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
+  });
+
+  testWidgets('GivenACompleteForm_WhenSubmitted_ThenThePermissionIsCreated', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Name'),
+      'read:invoices',
+    );
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create permission'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => repository.create(
+        scopeId: 'scope-1',
+        name: 'read:invoices',
+        description: '',
+        includeAsJwtClaim: false,
+      ),
+    ).called(1);
+  });
+
+  testWidgets('GivenACreatedPermission_WhenCreated_ThenItsDetailOpens', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Name'),
+      'read:invoices',
+    );
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create permission'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('detail permission-9'), findsOneWidget);
+  });
+
+  testWidgets('GivenTheClaimSwitch_WhenSet_ThenItIsSent', (tester) async {
+    // Given
+    await pump(tester);
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Name'),
+      'read:invoices',
+    );
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(find.byType(SwitchListTile));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, 'Create permission'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => repository.create(
+        scopeId: 'scope-1',
+        name: 'read:invoices',
+        description: '',
+        includeAsJwtClaim: true,
+      ),
+    ).called(1);
+  });
+
+  // AF-25d — what including the permission as a claim actually does.
+  testWidgets('GivenTheForm_WhenRendered_ThenTheClaimEffectIsExplained', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester);
+
+    // Then
+    expect(
+      find.textContaining('Every token this scope issues from now on'),
+      findsOneWidget,
+    );
+  });
+
+  // AF-25a — an empty name never reaches the API.
+  testWidgets('GivenNoName_WhenSubmitted_ThenNoRequestIsMade', (tester) async {
+    // Given
+    await pump(tester);
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create permission'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verifyNever(
+      () => repository.create(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        description: any(named: 'description'),
+        includeAsJwtClaim: any(named: 'includeAsJwtClaim'),
+      ),
+    );
+  });
+
+  // AF-25b — a duplicate name, in the API's own words.
+  testWidgets('GivenADuplicateName_WhenSubmitted_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerCreateWith(
+      const FailureResult<ScopePermission>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['A permission with that name already exists.'],
+        ),
+      ),
+    );
+    await pump(tester);
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Name'),
+      'read:invoices',
+    );
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create permission'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(
+      find.text('A permission with that name already exists.'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('GivenARejectedCreate_WhenSubmitted_ThenTheInputIsKept', (
+    tester,
+  ) async {
+    // Given
+    answerCreateWith(
+      const FailureResult<ScopePermission>(
+        Failure(kind: FailureKind.validation, errors: <String>['No.']),
+      ),
+    );
+    await pump(tester);
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Name'),
+      'read:invoices',
+    );
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create permission'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.widgetWithText(TextFormField, 'read:invoices'), findsOneWidget);
+  });
+
+  // AF-25c — leaving a modified form asks first.
+  testWidgets('GivenAModifiedForm_WhenCancelled_ThenConfirmationIsAsked', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Name'),
+      'read:invoices',
+    );
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('Discard this permission?'), findsOneWidget);
+  });
+
+  testWidgets('GivenAModifiedForm_WhenDiscardConfirmed_ThenTheListingOpens', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Name'),
+      'read:invoices',
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Discard'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('listing'), findsOneWidget);
+  });
+
+  testWidgets('GivenAnUntouchedForm_WhenCancelled_ThenTheListingOpensAtOnce', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+
+    // When
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('listing'), findsOneWidget);
+  });
+
+  testWidgets('GivenACompactWindow_WhenRendered_ThenTheFormIsShown', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, size: _compact);
+
+    // Then
+    expect(find.text('Create a permission'), findsOneWidget);
+  });
+
+  testWidgets('GivenAMediumWindow_WhenRendered_ThenTheFormIsShown', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, size: _medium);
+
+    // Then
+    expect(find.text('Create a permission'), findsOneWidget);
+  });
+
+  testWidgets('GivenTheDarkTheme_WhenRendered_ThenTheFormIsStillShown', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, theme: buildDarkTheme());
+
+    // Then
+    expect(find.text('Create a permission'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #25

Implements UI-25 — `/scopes/:scopeId/permissions/new` over `POST /api/scopes/{scopeId}/permissions` (FR-PM-03).

## Flows

| Flow | How it is handled |
| --- | --- |
| Main | Name, description and the claim flag; on success the new permission's detail opens. |
| AF-25a | An empty name blocks submission. |
| AF-25b | A name already used in the scope comes back as the API's own strings. |
| AF-25c | Leaving a modified form asks for confirmation first. |
| AF-25d | The claim switch states what setting it does. |

**On AF-25d and FR-PM-04:** the switch's subtitle says that every token the scope issues from then on carries the permission as a claim, so its applications can read it without asking the API again. That is said on the form rather than left to be discovered in a token later, and a widget test asserts the wording is present.

## Verification

`dart format --set-exit-if-changed .`, `flutter analyze`, and `flutter test` all pass — **749 tests**, 13 of them new. No presentation file imports `package:heimdall_api_client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)