### PR TITLE
feat(ui-26): view and update a scope permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ the board is where an item's status changes as it moves.
 | --- | --- | --- |
 | UI-24: Browse scope permissions | ✅ | [#24](https://github.com/artur-rios/heimdall-ui/issues/24) |
 | UI-25: Create a scope permission | ✅ | [#25](https://github.com/artur-rios/heimdall-ui/issues/25) |
-| UI-26: View and update a scope permission | ⬜ | [#26](https://github.com/artur-rios/heimdall-ui/issues/26) |
+| UI-26: View and update a scope permission | ✅ | [#26](https://github.com/artur-rios/heimdall-ui/issues/26) |
 | UI-27: Delete a scope permission, logically and permanently | ⬜ | [#27](https://github.com/artur-rios/heimdall-ui/issues/27) |
 
 ### Google Users

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -14,6 +14,7 @@ import '../features/auth/presentation/two_factor_screen.dart';
 import '../features/auth/presentation/verify_email_screen.dart';
 import '../features/home/presentation/home_screen.dart';
 import '../features/permissions/presentation/permission_create_screen.dart';
+import '../features/permissions/presentation/permission_detail_screen.dart';
 import '../features/permissions/presentation/permission_list_screen.dart';
 import '../features/persons/presentation/person_create_screen.dart';
 import '../features/persons/presentation/person_detail_screen.dart';
@@ -165,6 +166,13 @@ final Provider<GoRouter> routerProvider = Provider<GoRouter>((ref) {
         path: '/scopes/:scopeId/permissions/new',
         builder: (context, state) =>
             PermissionCreateScreen(scopeId: state.pathParameters['scopeId']!),
+      ),
+      GoRoute(
+        path: '/scopes/:scopeId/permissions/:permissionId',
+        builder: (context, state) => PermissionDetailScreen(
+          scopeId: state.pathParameters['scopeId']!,
+          permissionId: state.pathParameters['permissionId']!,
+        ),
       ),
       GoRoute(
         path: '/scopes/:scopeId/owners',

--- a/lib/features/permissions/data/scope_permission_repository_impl.dart
+++ b/lib/features/permissions/data/scope_permission_repository_impl.dart
@@ -109,6 +109,95 @@ class ApiScopePermissionRepository implements ScopePermissionRepository {
       return FailureResult<ScopePermission>(failureFromDioException(error));
     }
   }
+
+  @override
+  Future<Result<ScopePermission>> getById({
+    required String scopeId,
+    required String id,
+    bool includeDeleted = true,
+  }) async {
+    try {
+      final response = await _client.scopePermissionGetById(
+        scopeId: scopeId,
+        id: id,
+        includeDeleted: includeDeleted,
+      );
+
+      if (response.success != true) {
+        return FailureResult<ScopePermission>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: response.errors ?? const <String>[],
+          ),
+        );
+      }
+
+      final data = response.data;
+
+      if (data == null) {
+        return const FailureResult<ScopePermission>(_incompleteResponse);
+      }
+
+      return Success<ScopePermission>(scopePermissionFromOutput(data));
+    } on DioException catch (error) {
+      // AF-26a and AF-26b depend on this: a `404` and a `403` are different
+      // panels, and only the kind tells them apart.
+      return FailureResult<ScopePermission>(failureFromDioException(error));
+    }
+  }
+
+  @override
+  Future<Result<ScopePermission>> update({
+    required String scopeId,
+    required String id,
+    required String name,
+    required String description,
+    required bool includeAsJwtClaim,
+  }) async {
+    try {
+      final response = await _client.scopePermissionUpdate(
+        scopeId: scopeId,
+        id: id,
+        body: UpdateScopePermissionCommand(
+          name: name,
+          description: description,
+          includeAsJwtClaim: includeAsJwtClaim,
+        ),
+      );
+
+      if (response.success != true) {
+        // AF-26c: a duplicate name, in the API's own words.
+        return FailureResult<ScopePermission>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: response.errors ?? const <String>[],
+          ),
+        );
+      }
+
+      final data = response.data;
+
+      if (data == null) {
+        return const FailureResult<ScopePermission>(_incompleteResponse);
+      }
+
+      // The update endpoint answers with its own output type, which carries no
+      // `isDeleted`: a permission the API just updated is not a deleted one.
+      return Success<ScopePermission>(
+        ScopePermission(
+          id: data.id ?? id,
+          name: data.name ?? name,
+          description: data.description ?? description,
+          includeAsJwtClaim: data.includeAsJwtClaim ?? includeAsJwtClaim,
+          scopeId: data.scopeId ?? scopeId,
+          createdAt: data.createdAt,
+          updatedAt: data.updatedAt,
+        ),
+      );
+    } on DioException catch (error) {
+      return FailureResult<ScopePermission>(failureFromDioException(error));
+    }
+  }
 }
 
 /// A successful envelope that nonetheless lacks what the flow needs. It should

--- a/lib/features/permissions/domain/scope_permission_repository.dart
+++ b/lib/features/permissions/domain/scope_permission_repository.dart
@@ -22,6 +22,26 @@ abstract interface class ScopePermissionRepository {
     required String description,
     required bool includeAsJwtClaim,
   });
+
+  /// Reads one permission.
+  ///
+  /// [includeDeleted] is on by default for the detail screen: AF-26d shows a
+  /// logically deleted permission read-only, and it cannot do that if the API
+  /// is asked to pretend it is gone.
+  Future<Result<ScopePermission>> getById({
+    required String scopeId,
+    required String id,
+    bool includeDeleted = true,
+  });
+
+  /// Updates a permission's name, description, and claim flag.
+  Future<Result<ScopePermission>> update({
+    required String scopeId,
+    required String id,
+    required String name,
+    required String description,
+    required bool includeAsJwtClaim,
+  });
 }
 
 /// Overridden at start-up with the client-backed implementation, and in tests

--- a/lib/features/permissions/presentation/permission_detail_controller.dart
+++ b/lib/features/permissions/presentation/permission_detail_controller.dart
@@ -1,0 +1,178 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/result/result.dart';
+import '../domain/scope_permission.dart';
+import '../domain/scope_permission_repository.dart';
+
+/// Which permission a detail screen is showing.
+///
+/// A permission is identified by its scope as well as itself, so the family is
+/// keyed by both rather than by the identifier alone.
+class PermissionRef {
+  const PermissionRef({required this.scopeId, required this.permissionId});
+
+  final String scopeId;
+  final String permissionId;
+
+  @override
+  bool operator ==(Object other) =>
+      other is PermissionRef &&
+      other.scopeId == scopeId &&
+      other.permissionId == permissionId;
+
+  @override
+  int get hashCode => Object.hash(scopeId, permissionId);
+}
+
+/// How far the permission detail has got.
+sealed class PermissionDetailState {
+  const PermissionDetailState();
+}
+
+/// The record is being read.
+final class PermissionDetailLoading extends PermissionDetailState {
+  const PermissionDetailLoading();
+}
+
+/// AF-26a and AF-26b — the record could not be read.
+final class PermissionDetailUnavailable extends PermissionDetailState {
+  const PermissionDetailUnavailable(this.failure);
+
+  final Failure failure;
+
+  bool get isNotFound => failure.kind == FailureKind.notFound;
+  bool get isForbidden => failure.kind == FailureKind.forbidden;
+}
+
+/// The record is on screen.
+final class PermissionDetailLoaded extends PermissionDetailState {
+  const PermissionDetailLoaded(
+    this.permission, {
+    this.saving = false,
+    this.saveFailure,
+    this.saved = false,
+    this.claimChanged = false,
+  });
+
+  final ScopePermission permission;
+  final bool saving;
+  final Failure? saveFailure;
+  final bool saved;
+
+  /// AF-26e — the claim flag differs from what it was before the save, which
+  /// is what the confirmation has to explain.
+  final bool claimChanged;
+
+  /// AF-26d — a logically deleted permission is shown, but nothing about it
+  /// may be changed from here.
+  bool get isReadOnly => permission.isDeleted;
+
+  PermissionDetailLoaded copyWith({
+    ScopePermission? permission,
+    bool? saving,
+    Failure? saveFailure,
+    bool clearSaveFailure = false,
+    bool? saved,
+    bool? claimChanged,
+  }) => PermissionDetailLoaded(
+    permission ?? this.permission,
+    saving: saving ?? this.saving,
+    saveFailure: clearSaveFailure ? null : (saveFailure ?? this.saveFailure),
+    saved: saved ?? this.saved,
+    claimChanged: claimChanged ?? this.claimChanged,
+  );
+}
+
+final NotifierProviderFamily<
+  PermissionDetailController,
+  PermissionDetailState,
+  PermissionRef
+>
+permissionDetailControllerProvider =
+    NotifierProvider.family<
+      PermissionDetailController,
+      PermissionDetailState,
+      PermissionRef
+    >(PermissionDetailController.new);
+
+/// Owns one permission's detail: reading it, and saving edits to it.
+class PermissionDetailController
+    extends FamilyNotifier<PermissionDetailState, PermissionRef> {
+  @override
+  PermissionDetailState build(PermissionRef ref) =>
+      const PermissionDetailLoading();
+
+  Future<void> load() async {
+    state = const PermissionDetailLoading();
+
+    final result = await ref
+        .read(scopePermissionRepositoryProvider)
+        .getById(scopeId: arg.scopeId, id: arg.permissionId);
+
+    state = result.fold(
+      onSuccess: PermissionDetailLoaded.new,
+      onFailure: PermissionDetailUnavailable.new,
+    );
+  }
+
+  Future<void> save({
+    required String name,
+    required String description,
+    required bool includeAsJwtClaim,
+  }) async {
+    final current = state;
+
+    if (current is! PermissionDetailLoaded ||
+        current.saving ||
+        current.isReadOnly) {
+      return;
+    }
+
+    final previous = current.permission;
+
+    if (name == previous.name &&
+        description == previous.description &&
+        includeAsJwtClaim == previous.includeAsJwtClaim) {
+      return;
+    }
+
+    state = current.copyWith(
+      saving: true,
+      clearSaveFailure: true,
+      saved: false,
+    );
+
+    final result = await ref
+        .read(scopePermissionRepositoryProvider)
+        .update(
+          scopeId: arg.scopeId,
+          id: arg.permissionId,
+          name: name,
+          description: description,
+          includeAsJwtClaim: includeAsJwtClaim,
+        );
+
+    state = result.fold(
+      onSuccess: (permission) => PermissionDetailLoaded(
+        permission,
+        saved: true,
+        // AF-26e: the tokens issued from now on carry the change, and the
+        // ones already out there do not — which is worth saying only when the
+        // flag actually moved.
+        claimChanged:
+            permission.includeAsJwtClaim != previous.includeAsJwtClaim,
+      ),
+      // AF-26c: the refusal is kept as it came back, and the record on screen
+      // is still the one the API last confirmed.
+      onFailure: (failure) =>
+          current.copyWith(saving: false, saveFailure: failure),
+    );
+  }
+
+  /// Drops the "saved" acknowledgement so a later edit starts clean.
+  void acknowledgeSave() {
+    if (state case final PermissionDetailLoaded loaded) {
+      state = loaded.copyWith(saved: false, claimChanged: false);
+    }
+  }
+}

--- a/lib/features/permissions/presentation/permission_detail_screen.dart
+++ b/lib/features/permissions/presentation/permission_detail_screen.dart
@@ -1,0 +1,300 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../core/result/result.dart';
+import '../../../shared/layout/app_shell.dart';
+import '../../../shared/widgets/collection_states.dart';
+import '../../../shared/widgets/failure_banner.dart';
+import '../domain/scope_permission.dart';
+import 'permission_detail_controller.dart';
+
+/// UI-26 — one scope permission.
+class PermissionDetailScreen extends ConsumerStatefulWidget {
+  const PermissionDetailScreen({
+    required this.scopeId,
+    required this.permissionId,
+    super.key,
+  });
+
+  final String scopeId;
+  final String permissionId;
+
+  @override
+  ConsumerState<PermissionDetailScreen> createState() =>
+      _PermissionDetailScreenState();
+}
+
+class _PermissionDetailScreenState
+    extends ConsumerState<PermissionDetailScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _name = TextEditingController();
+  final _description = TextEditingController();
+  bool _includeAsJwtClaim = false;
+
+  /// The record the fields were last seeded from, which is what AF-26e
+  /// compares against.
+  ScopePermission? _seeded;
+
+  PermissionRef get _ref =>
+      PermissionRef(scopeId: widget.scopeId, permissionId: widget.permissionId);
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => ref.read(permissionDetailControllerProvider(_ref).notifier).load(),
+    );
+  }
+
+  @override
+  void dispose() {
+    _name.dispose();
+    _description.dispose();
+    super.dispose();
+  }
+
+  /// Copies a freshly read or freshly saved record into the fields.
+  ///
+  /// AF-26c is why this only runs when the record itself changed: a refused
+  /// save must leave what the user entered exactly where it was.
+  void _seed(ScopePermission permission) {
+    if (identical(_seeded, permission)) {
+      return;
+    }
+
+    _seeded = permission;
+    _name.text = permission.name;
+    _description.text = permission.description;
+    _includeAsJwtClaim = permission.includeAsJwtClaim;
+  }
+
+  bool _differsFrom(ScopePermission permission) =>
+      _name.text.trim() != permission.name ||
+      _description.text.trim() != permission.description ||
+      _includeAsJwtClaim != permission.includeAsJwtClaim;
+
+  Future<void> _save() async {
+    if (!(_formKey.currentState?.validate() ?? false)) {
+      return;
+    }
+
+    await ref
+        .read(permissionDetailControllerProvider(_ref).notifier)
+        .save(
+          name: _name.text.trim(),
+          description: _description.text.trim(),
+          includeAsJwtClaim: _includeAsJwtClaim,
+        );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(permissionDetailControllerProvider(_ref));
+    final controller = ref.read(
+      permissionDetailControllerProvider(_ref).notifier,
+    );
+    final backToListing = '/scopes/${widget.scopeId}/permissions';
+
+    return AppShell(
+      currentRoute: '/scopes',
+      title: Text(switch (state) {
+        PermissionDetailLoaded(:final permission) => permission.name,
+        _ => 'Permission',
+      }),
+      actions: <Widget>[
+        IconButton(
+          tooltip: 'Back to the listing',
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.go(backToListing),
+        ),
+      ],
+      body: switch (state) {
+        PermissionDetailLoading() => const Center(
+          child: CircularProgressIndicator(),
+        ),
+        // AF-26a — no such permission.
+        PermissionDetailUnavailable(isNotFound: true) => CollectionEmpty(
+          title: 'Permission not found',
+          message:
+              'There is no permission with that identifier. It may have '
+              'been permanently deleted.',
+          icon: Icons.search_off_outlined,
+          actionLabel: 'Back to the listing',
+          onAction: () => context.go(backToListing),
+        ),
+        // AF-26b — out of this role's reach.
+        PermissionDetailUnavailable(isForbidden: true) => CollectionEmpty(
+          title: 'Not available for your role',
+          message:
+              'This permission is not one you administer. Nothing is '
+              'wrong with your session.',
+          icon: Icons.lock_person_outlined,
+          actionLabel: 'Back to the listing',
+          onAction: () => context.go(backToListing),
+        ),
+        PermissionDetailUnavailable(:final failure) => CollectionFailed(
+          failure: failure,
+          onRetry: controller.load,
+        ),
+        final PermissionDetailLoaded loaded => _detail(loaded),
+      },
+    );
+  }
+
+  Widget _detail(PermissionDetailLoaded state) {
+    _seed(state.permission);
+    final permission = state.permission;
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(24),
+      child: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 640),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              // AF-26d — a deleted permission says so before anything else.
+              if (state.isReadOnly) ...<Widget>[
+                const _Notice(
+                  icon: Icons.delete_outline,
+                  message:
+                      'This permission is deleted. It is shown for '
+                      'reference and cannot be changed from here.',
+                  destructive: true,
+                ),
+                const SizedBox(height: 16),
+              ],
+              Form(
+                key: _formKey,
+                onChanged: () => setState(() {}),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: <Widget>[
+                    if (state.saveFailure
+                        case final Failure failure) ...<Widget>[
+                      if (failure.kind == FailureKind.network)
+                        RetryBanner(onRetry: state.saving ? null : _save)
+                      else
+                        // AF-26c: the API's own strings, as returned.
+                        ErrorBanner(failure: failure),
+                      const SizedBox(height: 16),
+                    ],
+                    if (state.saved) ...<Widget>[
+                      _Notice(
+                        icon: Icons.check_circle_outline,
+                        // AF-26e — the tokens already out there are unchanged,
+                        // which is the part that is easy to assume otherwise.
+                        message: state.claimChanged
+                            ? (permission.includeAsJwtClaim
+                                  ? 'Saved. Tokens this scope issues from now '
+                                        'on carry this permission; tokens '
+                                        'already issued do not.'
+                                  : 'Saved. Tokens this scope issues from now '
+                                        'on omit this permission; tokens '
+                                        'already issued still carry it until '
+                                        'they expire.')
+                            : 'Saved.',
+                      ),
+                      const SizedBox(height: 16),
+                    ],
+                    TextFormField(
+                      controller: _name,
+                      readOnly: state.isReadOnly,
+                      decoration: const InputDecoration(labelText: 'Name'),
+                      validator: (value) => (value?.trim().isEmpty ?? true)
+                          ? 'Enter a name for the permission.'
+                          : null,
+                    ),
+                    const SizedBox(height: 16),
+                    TextFormField(
+                      controller: _description,
+                      readOnly: state.isReadOnly,
+                      minLines: 2,
+                      maxLines: 4,
+                      decoration: const InputDecoration(
+                        labelText: 'Description',
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    // FR-PM-04 — what the flag means, wherever it is shown.
+                    SwitchListTile(
+                      contentPadding: EdgeInsets.zero,
+                      title: const Text('Include in tokens'),
+                      subtitle: const Text(
+                        'Every token this scope issues from now on carries '
+                        'this permission as a claim. Tokens already issued are '
+                        'unaffected until they expire.',
+                      ),
+                      value: _includeAsJwtClaim,
+                      onChanged: (state.saving || state.isReadOnly)
+                          ? null
+                          : (value) =>
+                                setState(() => _includeAsJwtClaim = value),
+                    ),
+                    const SizedBox(height: 16),
+                    if (!state.isReadOnly)
+                      FilledButton(
+                        onPressed: (state.saving || !_differsFrom(permission))
+                            ? null
+                            : _save,
+                        child: state.saving
+                            ? const SizedBox.square(
+                                dimension: 20,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
+                              )
+                            : const Text('Save changes'),
+                      ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// A one-line panel: what a deleted record and a saved edit each say.
+class _Notice extends StatelessWidget {
+  const _Notice({
+    required this.icon,
+    required this.message,
+    this.destructive = false,
+  });
+
+  final IconData icon;
+  final String message;
+  final bool destructive;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final background = destructive
+        ? scheme.errorContainer
+        : scheme.secondaryContainer;
+    final foreground = destructive
+        ? scheme.onErrorContainer
+        : scheme.onSecondaryContainer;
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: <Widget>[
+          Icon(icon, color: foreground),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(message, style: TextStyle(color: foreground)),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/features/permissions/presentation/permission_detail_controller_test.dart
+++ b/test/features/permissions/presentation/permission_detail_controller_test.dart
@@ -1,0 +1,334 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/features/permissions/domain/scope_permission.dart';
+import 'package:heimdall_ui/features/permissions/domain/scope_permission_repository.dart';
+import 'package:heimdall_ui/features/permissions/presentation/permission_detail_controller.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockScopePermissionRepository extends Mock
+    implements ScopePermissionRepository {}
+
+const _readInvoices = ScopePermission(
+  id: 'permission-1',
+  name: 'read:invoices',
+  description: 'May read invoices',
+  scopeId: 'scope-1',
+);
+
+const _deleted = ScopePermission(
+  id: 'permission-1',
+  name: 'read:invoices',
+  description: 'May read invoices',
+  scopeId: 'scope-1',
+  isDeleted: true,
+);
+
+const _ref = PermissionRef(scopeId: 'scope-1', permissionId: 'permission-1');
+
+void main() {
+  late _MockScopePermissionRepository repository;
+  late ProviderContainer container;
+
+  PermissionDetailController controllerUnderTest() {
+    container = ProviderContainer(
+      overrides: <Override>[
+        scopePermissionRepositoryProvider.overrideWithValue(repository),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    return container.read(permissionDetailControllerProvider(_ref).notifier);
+  }
+
+  PermissionDetailState currentState() =>
+      container.read(permissionDetailControllerProvider(_ref));
+
+  void answerGetWith(Result<ScopePermission> result) {
+    when(
+      () => repository.getById(
+        scopeId: any(named: 'scopeId'),
+        id: any(named: 'id'),
+        includeDeleted: any(named: 'includeDeleted'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  void answerUpdateWith(Result<ScopePermission> result) {
+    when(
+      () => repository.update(
+        scopeId: any(named: 'scopeId'),
+        id: any(named: 'id'),
+        name: any(named: 'name'),
+        description: any(named: 'description'),
+        includeAsJwtClaim: any(named: 'includeAsJwtClaim'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  setUp(() {
+    repository = _MockScopePermissionRepository();
+  });
+
+  test('GivenAPermission_WhenLoaded_ThenTheRecordIsShown', () async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_readInvoices));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    expect(
+      (currentState() as PermissionDetailLoaded).permission.name,
+      'read:invoices',
+    );
+  });
+
+  // AF-26a — no such permission.
+  test('GivenAMissingPermission_WhenLoaded_ThenStateIsNotFound', () async {
+    // Given
+    answerGetWith(
+      const FailureResult<ScopePermission>(
+        Failure(kind: FailureKind.notFound, errors: <String>[]),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    expect((currentState() as PermissionDetailUnavailable).isNotFound, isTrue);
+  });
+
+  // AF-26b — out of this role's reach.
+  test('GivenAForbiddenPermission_WhenLoaded_ThenStateIsForbidden', () async {
+    // Given
+    answerGetWith(
+      const FailureResult<ScopePermission>(
+        Failure(kind: FailureKind.forbidden, errors: <String>[]),
+      ),
+    );
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    expect((currentState() as PermissionDetailUnavailable).isForbidden, isTrue);
+  });
+
+  test('GivenAnEdit_WhenSaved_ThenTheNewValuesAreSent', () async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_readInvoices));
+    answerUpdateWith(
+      const Success<ScopePermission>(
+        ScopePermission(
+          id: 'permission-1',
+          name: 'read:all-invoices',
+          description: 'May read invoices',
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.save(
+      name: 'read:all-invoices',
+      description: 'May read invoices',
+      includeAsJwtClaim: false,
+    );
+
+    // Then
+    verify(
+      () => repository.update(
+        scopeId: 'scope-1',
+        id: 'permission-1',
+        name: 'read:all-invoices',
+        description: 'May read invoices',
+        includeAsJwtClaim: false,
+      ),
+    ).called(1);
+  });
+
+  // AF-26e — the claim flag moved, which the confirmation has to explain.
+  test('GivenAChangedClaimFlag_WhenSaved_ThenTheChangeIsFlagged', () async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_readInvoices));
+    answerUpdateWith(
+      const Success<ScopePermission>(
+        ScopePermission(
+          id: 'permission-1',
+          name: 'read:invoices',
+          description: 'May read invoices',
+          includeAsJwtClaim: true,
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.save(
+      name: 'read:invoices',
+      description: 'May read invoices',
+      includeAsJwtClaim: true,
+    );
+
+    // Then
+    expect((currentState() as PermissionDetailLoaded).claimChanged, isTrue);
+  });
+
+  test('GivenAnUnchangedClaimFlag_WhenSaved_ThenNoChangeIsFlagged', () async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_readInvoices));
+    answerUpdateWith(
+      const Success<ScopePermission>(
+        ScopePermission(
+          id: 'permission-1',
+          name: 'read:all-invoices',
+          description: 'May read invoices',
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.save(
+      name: 'read:all-invoices',
+      description: 'May read invoices',
+      includeAsJwtClaim: false,
+    );
+
+    // Then
+    expect((currentState() as PermissionDetailLoaded).claimChanged, isFalse);
+  });
+
+  // AF-26c — a refusal keeps the record and carries the API's own errors.
+  test('GivenARejectedUpdate_WhenSaved_ThenApiErrorsAreKept', () async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_readInvoices));
+    answerUpdateWith(
+      const FailureResult<ScopePermission>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['A permission with that name already exists.'],
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.save(
+      name: 'read:all',
+      description: 'May read invoices',
+      includeAsJwtClaim: false,
+    );
+
+    // Then
+    final state = currentState() as PermissionDetailLoaded;
+    expect(state.saveFailure?.errors, <String>[
+      'A permission with that name already exists.',
+    ]);
+    expect(state.permission.name, 'read:invoices');
+  });
+
+  // AF-26d — a deleted permission is read-only.
+  test('GivenADeletedPermission_WhenLoaded_ThenItIsReadOnly', () async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_deleted));
+    final controller = controllerUnderTest();
+
+    // When
+    await controller.load();
+
+    // Then
+    expect((currentState() as PermissionDetailLoaded).isReadOnly, isTrue);
+  });
+
+  test('GivenADeletedPermission_WhenSaved_ThenNoRequestIsMade', () async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_deleted));
+    answerUpdateWith(const Success<ScopePermission>(_deleted));
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.save(
+      name: 'anything',
+      description: 'anything',
+      includeAsJwtClaim: true,
+    );
+
+    // Then
+    verifyNever(
+      () => repository.update(
+        scopeId: any(named: 'scopeId'),
+        id: any(named: 'id'),
+        name: any(named: 'name'),
+        description: any(named: 'description'),
+        includeAsJwtClaim: any(named: 'includeAsJwtClaim'),
+      ),
+    );
+  });
+
+  test('GivenNoChange_WhenSaved_ThenNoRequestIsMade', () async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_readInvoices));
+    answerUpdateWith(const Success<ScopePermission>(_readInvoices));
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.save(
+      name: 'read:invoices',
+      description: 'May read invoices',
+      includeAsJwtClaim: false,
+    );
+
+    // Then
+    verifyNever(
+      () => repository.update(
+        scopeId: any(named: 'scopeId'),
+        id: any(named: 'id'),
+        name: any(named: 'name'),
+        description: any(named: 'description'),
+        includeAsJwtClaim: any(named: 'includeAsJwtClaim'),
+      ),
+    );
+  });
+
+  test('GivenASavedPermission_WhenAcknowledged_ThenTheNoticeClears', () async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_readInvoices));
+    answerUpdateWith(
+      const Success<ScopePermission>(
+        ScopePermission(
+          id: 'permission-1',
+          name: 'read:invoices',
+          description: 'May read invoices',
+          includeAsJwtClaim: true,
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+    await controller.load();
+    await controller.save(
+      name: 'read:invoices',
+      description: 'May read invoices',
+      includeAsJwtClaim: true,
+    );
+
+    // When
+    controller.acknowledgeSave();
+
+    // Then
+    final state = currentState() as PermissionDetailLoaded;
+    expect(state.saved, isFalse);
+    expect(state.claimChanged, isFalse);
+  });
+}

--- a/test/features/permissions/presentation/permission_detail_screen_test.dart
+++ b/test/features/permissions/presentation/permission_detail_screen_test.dart
@@ -1,0 +1,457 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:heimdall_ui/app/theme.dart';
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/core/storage/token_store.dart';
+import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
+import 'package:heimdall_ui/features/permissions/domain/scope_permission.dart';
+import 'package:heimdall_ui/features/permissions/domain/scope_permission_repository.dart';
+import 'package:heimdall_ui/features/permissions/presentation/permission_detail_screen.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockScopePermissionRepository extends Mock
+    implements ScopePermissionRepository {}
+
+String _jwt() {
+  final payload = base64Url.encode(
+    utf8.encode(
+      jsonEncode(<String, dynamic>{
+        'sub': 'person-9',
+        'email': 'admin@example.com',
+        'role': 1,
+      }),
+    ),
+  );
+
+  return 'header.$payload.signature';
+}
+
+const _readInvoices = ScopePermission(
+  id: 'permission-1',
+  name: 'read:invoices',
+  description: 'May read invoices',
+  scopeId: 'scope-1',
+);
+
+const _deleted = ScopePermission(
+  id: 'permission-1',
+  name: 'read:invoices',
+  description: 'May read invoices',
+  scopeId: 'scope-1',
+  isDeleted: true,
+);
+
+const Size _compact = Size(400, 900);
+const Size _medium = Size(800, 900);
+const Size _expanded = Size(1400, 900);
+
+void main() {
+  late _MockScopePermissionRepository repository;
+  late InMemoryTokenStore store;
+  late ProviderContainer container;
+  late GoRouter router;
+
+  Future<void> pump(
+    WidgetTester tester, {
+    Size size = _expanded,
+    ThemeData? theme,
+  }) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await store.write(AuthToken(value: _jwt(), expiresAt: DateTime.utc(2030)));
+
+    container = ProviderContainer(
+      overrides: <Override>[
+        scopePermissionRepositoryProvider.overrideWithValue(repository),
+        tokenStoreProvider.overrideWithValue(store),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(sessionControllerProvider.notifier).restore();
+
+    router = GoRouter(
+      initialLocation: '/scopes/scope-1/permissions/permission-1',
+      routes: <RouteBase>[
+        GoRoute(
+          path: '/scopes/:scopeId/permissions',
+          builder: (context, state) => const Scaffold(body: Text('listing')),
+        ),
+        GoRoute(
+          path: '/scopes/:scopeId/permissions/:permissionId',
+          builder: (context, state) => PermissionDetailScreen(
+            scopeId: state.pathParameters['scopeId']!,
+            permissionId: state.pathParameters['permissionId']!,
+          ),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(
+          theme: theme ?? buildLightTheme(),
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  void answerGetWith(Result<ScopePermission> result) {
+    when(
+      () => repository.getById(
+        scopeId: any(named: 'scopeId'),
+        id: any(named: 'id'),
+        includeDeleted: any(named: 'includeDeleted'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  void answerUpdateWith(Result<ScopePermission> result) {
+    when(
+      () => repository.update(
+        scopeId: any(named: 'scopeId'),
+        id: any(named: 'id'),
+        name: any(named: 'name'),
+        description: any(named: 'description'),
+        includeAsJwtClaim: any(named: 'includeAsJwtClaim'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    repository = _MockScopePermissionRepository();
+    store = InMemoryTokenStore();
+  });
+
+  testWidgets('GivenAPermission_WhenOpened_ThenTheRecordIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_readInvoices));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.widgetWithText(TextFormField, 'read:invoices'), findsOneWidget);
+  });
+
+  testWidgets('GivenAnEdit_WhenSaved_ThenTheNewValuesAreSent', (tester) async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_readInvoices));
+    answerUpdateWith(
+      const Success<ScopePermission>(
+        ScopePermission(
+          id: 'permission-1',
+          name: 'read:all',
+          description: 'May read invoices',
+        ),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'read:invoices'),
+      'read:all',
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, 'Save changes'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => repository.update(
+        scopeId: 'scope-1',
+        id: 'permission-1',
+        name: 'read:all',
+        description: 'May read invoices',
+        includeAsJwtClaim: false,
+      ),
+    ).called(1);
+  });
+
+  // AF-26e — the tokens already issued are unchanged, and the confirmation
+  // says so.
+  testWidgets('GivenTheClaimFlagTurnedOn_WhenSaved_ThenTheEffectIsExplained', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_readInvoices));
+    answerUpdateWith(
+      const Success<ScopePermission>(
+        ScopePermission(
+          id: 'permission-1',
+          name: 'read:invoices',
+          description: 'May read invoices',
+          includeAsJwtClaim: true,
+        ),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await tester.tap(find.byType(SwitchListTile));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, 'Save changes'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.textContaining('tokens already issued do not'), findsOneWidget);
+  });
+
+  testWidgets('GivenTheClaimFlagTurnedOff_WhenSaved_ThenTheEffectIsExplained', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(
+      const Success<ScopePermission>(
+        ScopePermission(
+          id: 'permission-1',
+          name: 'read:invoices',
+          description: 'May read invoices',
+          scopeId: 'scope-1',
+          includeAsJwtClaim: true,
+        ),
+      ),
+    );
+    answerUpdateWith(
+      const Success<ScopePermission>(
+        ScopePermission(
+          id: 'permission-1',
+          name: 'read:invoices',
+          description: 'May read invoices',
+        ),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await tester.tap(find.byType(SwitchListTile));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, 'Save changes'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(
+      find.textContaining('still carry it until they expire'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('GivenOnlyANameChange_WhenSaved_ThenOnlySavedIsSaid', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_readInvoices));
+    answerUpdateWith(
+      const Success<ScopePermission>(
+        ScopePermission(
+          id: 'permission-1',
+          name: 'read:all',
+          description: 'May read invoices',
+        ),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'read:invoices'),
+      'read:all',
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, 'Save changes'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('Saved.'), findsOneWidget);
+  });
+
+  // AF-26a — no such permission.
+  testWidgets('GivenAMissingPermission_WhenOpened_ThenNotFoundIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(
+      const FailureResult<ScopePermission>(
+        Failure(kind: FailureKind.notFound, errors: <String>[]),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Permission not found'), findsOneWidget);
+  });
+
+  testWidgets('GivenAMissingPermission_WhenBackTapped_ThenTheListingOpens', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(
+      const FailureResult<ScopePermission>(
+        Failure(kind: FailureKind.notFound, errors: <String>[]),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Back to the listing'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('listing'), findsOneWidget);
+  });
+
+  // AF-26b — out of this role's reach.
+  testWidgets('GivenAForbiddenPermission_WhenOpened_ThenTheRolePanelIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(
+      const FailureResult<ScopePermission>(
+        Failure(kind: FailureKind.forbidden, errors: <String>[]),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Not available for your role'), findsOneWidget);
+  });
+
+  // AF-26c — the API's own errors, with the typed input kept.
+  testWidgets('GivenARejectedUpdate_WhenSaved_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_readInvoices));
+    answerUpdateWith(
+      const FailureResult<ScopePermission>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['A permission with that name already exists.'],
+        ),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'read:invoices'),
+      'read:all',
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, 'Save changes'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(
+      find.text('A permission with that name already exists.'),
+      findsOneWidget,
+    );
+    expect(find.widgetWithText(TextFormField, 'read:all'), findsOneWidget);
+  });
+
+  // AF-26d — a deleted permission is shown, marked, and read-only.
+  testWidgets('GivenADeletedPermission_WhenOpened_ThenItIsMarkedDeleted', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_deleted));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.textContaining('This permission is deleted'), findsOneWidget);
+  });
+
+  testWidgets('GivenADeletedPermission_WhenOpened_ThenSavingIsNotOffered', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_deleted));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.widgetWithText(FilledButton, 'Save changes'), findsNothing);
+    expect(
+      tester.widget<SwitchListTile>(find.byType(SwitchListTile)).onChanged,
+      isNull,
+    );
+  });
+
+  testWidgets('GivenNoEdit_WhenRendered_ThenSaveIsDisabled', (tester) async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_readInvoices));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(
+      tester
+          .widget<FilledButton>(
+            find.widgetWithText(FilledButton, 'Save changes'),
+          )
+          .onPressed,
+      isNull,
+    );
+  });
+
+  testWidgets('GivenACompactWindow_WhenRendered_ThenTheDetailIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_readInvoices));
+
+    // When
+    await pump(tester, size: _compact);
+
+    // Then
+    expect(find.widgetWithText(TextFormField, 'read:invoices'), findsOneWidget);
+  });
+
+  testWidgets('GivenAMediumWindow_WhenRendered_ThenTheDetailIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_readInvoices));
+
+    // When
+    await pump(tester, size: _medium);
+
+    // Then
+    expect(find.widgetWithText(TextFormField, 'read:invoices'), findsOneWidget);
+  });
+
+  testWidgets('GivenTheDarkTheme_WhenRendered_ThenTheDetailIsStillShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_readInvoices));
+
+    // When
+    await pump(tester, theme: buildDarkTheme());
+
+    // Then
+    expect(find.widgetWithText(TextFormField, 'read:invoices'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #26

Implements UI-26 — `/scopes/:scopeId/permissions/:permissionId` over `GET` (FR-PM-05) and `PUT /api/scopes/{scopeId}/permissions/{id}` (FR-PM-06).

## Flows

| Flow | How it is handled |
| --- | --- |
| Main | The record is read on open; name, description and the claim flag are all editable. |
| AF-26a | A `404` shows a not-found panel with a way back to the listing. |
| AF-26b | A `403` shows the not-available-for-your-role panel. |
| AF-26c | A refused update shows the API's strings; the record and typed input are untouched. |
| AF-26d | A deleted permission is shown, marked, and read-only — claim switch included. |
| AF-26e | A changed claim flag is explained in the confirmation. |

**On AF-26e:** when the flag actually moves, the confirmation says which direction and what it means for tokens — turned on, the tokens issued from then on carry the permission and the ones already out there do not; turned off, the ones already issued keep carrying it until they expire. A save that did not touch the flag says only "Saved.", because there is nothing to warn about. Both directions and the no-change case have widget tests.

## Verification

`dart format --set-exit-if-changed .`, `flutter analyze`, and `flutter test` all pass — **775 tests**, 26 of them new. No presentation file imports `package:heimdall_api_client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)