### PR TITLE
feat(ui-27): delete a scope permission, logically and permanently

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ the board is where an item's status changes as it moves.
 | UI-24: Browse scope permissions | ✅ | [#24](https://github.com/artur-rios/heimdall-ui/issues/24) |
 | UI-25: Create a scope permission | ✅ | [#25](https://github.com/artur-rios/heimdall-ui/issues/25) |
 | UI-26: View and update a scope permission | ✅ | [#26](https://github.com/artur-rios/heimdall-ui/issues/26) |
-| UI-27: Delete a scope permission, logically and permanently | ⬜ | [#27](https://github.com/artur-rios/heimdall-ui/issues/27) |
+| UI-27: Delete a scope permission, logically and permanently | ✅ | [#27](https://github.com/artur-rios/heimdall-ui/issues/27) |
 
 ### Google Users
 

--- a/lib/features/permissions/data/scope_permission_repository_impl.dart
+++ b/lib/features/permissions/data/scope_permission_repository_impl.dart
@@ -198,6 +198,53 @@ class ApiScopePermissionRepository implements ScopePermissionRepository {
       return FailureResult<ScopePermission>(failureFromDioException(error));
     }
   }
+
+  @override
+  Future<Result<void>> delete({
+    required String scopeId,
+    required String id,
+  }) async {
+    try {
+      final response = await _client.scopePermissionDelete(
+        scopeId: scopeId,
+        id: id,
+      );
+
+      // AF-27b: the API refuses a permission it will not delete, and its own
+      // strings say why.
+      return _acknowledgement(response.success, response.errors);
+    } on DioException catch (error) {
+      return FailureResult<void>(failureFromDioException(error));
+    }
+  }
+
+  @override
+  Future<Result<void>> hardDelete({
+    required String scopeId,
+    required String id,
+  }) async {
+    try {
+      final response = await _client.scopePermissionHardDelete(
+        scopeId: scopeId,
+        id: id,
+      );
+
+      return _acknowledgement(response.success, response.errors);
+    } on DioException catch (error) {
+      return FailureResult<void>(failureFromDioException(error));
+    }
+  }
+
+  /// A command whose only interesting answer is whether it worked.
+  static Result<void> _acknowledgement(bool? success, List<String>? errors) =>
+      success == true
+      ? const Success<void>(null)
+      : FailureResult<void>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: errors ?? const <String>[],
+          ),
+        );
 }
 
 /// A successful envelope that nonetheless lacks what the flow needs. It should

--- a/lib/features/permissions/domain/scope_permission_repository.dart
+++ b/lib/features/permissions/domain/scope_permission_repository.dart
@@ -42,6 +42,17 @@ abstract interface class ScopePermissionRepository {
     required String description,
     required bool includeAsJwtClaim,
   });
+
+  /// Logically deletes a permission. The record is kept and the API can
+  /// restore it.
+  Future<Result<void>> delete({required String scopeId, required String id});
+
+  /// Permanently deletes a permission. Only a System Admin may, which is why
+  /// UI-27 shows the control to nobody else.
+  Future<Result<void>> hardDelete({
+    required String scopeId,
+    required String id,
+  });
 }
 
 /// Overridden at start-up with the client-backed implementation, and in tests

--- a/lib/features/permissions/presentation/permission_detail_controller.dart
+++ b/lib/features/permissions/presentation/permission_detail_controller.dart
@@ -44,6 +44,11 @@ final class PermissionDetailUnavailable extends PermissionDetailState {
   bool get isForbidden => failure.kind == FailureKind.forbidden;
 }
 
+/// The permission is gone, and the screen returns to the listing.
+final class PermissionDeleted extends PermissionDetailState {
+  const PermissionDeleted();
+}
+
 /// The record is on screen.
 final class PermissionDetailLoaded extends PermissionDetailState {
   const PermissionDetailLoaded(
@@ -52,12 +57,20 @@ final class PermissionDetailLoaded extends PermissionDetailState {
     this.saveFailure,
     this.saved = false,
     this.claimChanged = false,
+    this.deleting = false,
+    this.deleteFailure,
   });
 
   final ScopePermission permission;
   final bool saving;
   final Failure? saveFailure;
   final bool saved;
+
+  /// A deletion is on its way. Both controls are disabled while it is.
+  final bool deleting;
+
+  /// AF-27b — the API refused to delete, and the permission stays open.
+  final Failure? deleteFailure;
 
   /// AF-26e — the claim flag differs from what it was before the save, which
   /// is what the confirmation has to explain.
@@ -74,12 +87,19 @@ final class PermissionDetailLoaded extends PermissionDetailState {
     bool clearSaveFailure = false,
     bool? saved,
     bool? claimChanged,
+    bool? deleting,
+    Failure? deleteFailure,
+    bool clearDeleteFailure = false,
   }) => PermissionDetailLoaded(
     permission ?? this.permission,
     saving: saving ?? this.saving,
     saveFailure: clearSaveFailure ? null : (saveFailure ?? this.saveFailure),
     saved: saved ?? this.saved,
     claimChanged: claimChanged ?? this.claimChanged,
+    deleting: deleting ?? this.deleting,
+    deleteFailure: clearDeleteFailure
+        ? null
+        : (deleteFailure ?? this.deleteFailure),
   );
 }
 
@@ -173,6 +193,44 @@ class PermissionDetailController
   void acknowledgeSave() {
     if (state case final PermissionDetailLoaded loaded) {
       state = loaded.copyWith(saved: false, claimChanged: false);
+    }
+  }
+
+  /// Logically deletes the permission. The record is kept and the API can
+  /// restore it, which is what the confirmation says before this is called.
+  Future<void> delete() => _delete(
+    (repository) =>
+        repository.delete(scopeId: arg.scopeId, id: arg.permissionId),
+  );
+
+  /// Permanently deletes the permission.
+  Future<void> deletePermanently() => _delete(
+    (repository) =>
+        repository.hardDelete(scopeId: arg.scopeId, id: arg.permissionId),
+  );
+
+  Future<void> _delete(
+    Future<Result<void>> Function(ScopePermissionRepository repository) send,
+  ) async {
+    final current = state;
+
+    if (current is! PermissionDetailLoaded || current.deleting) {
+      return;
+    }
+
+    state = current.copyWith(deleting: true, clearDeleteFailure: true);
+
+    final result = await send(ref.read(scopePermissionRepositoryProvider));
+
+    switch (result) {
+      case Success<void>():
+        state = const PermissionDeleted();
+      case FailureResult<void>(:final failure):
+        // Somebody already deleted it, which is the outcome that was asked
+        // for.
+        state = failure.kind == FailureKind.notFound
+            ? const PermissionDeleted()
+            : current.copyWith(deleting: false, deleteFailure: failure);
     }
   }
 }

--- a/lib/features/permissions/presentation/permission_detail_screen.dart
+++ b/lib/features/permissions/presentation/permission_detail_screen.dart
@@ -5,9 +5,13 @@ import 'package:go_router/go_router.dart';
 import '../../../core/result/result.dart';
 import '../../../shared/layout/app_shell.dart';
 import '../../../shared/widgets/collection_states.dart';
+import '../../../shared/widgets/confirm_dialog.dart';
 import '../../../shared/widgets/failure_banner.dart';
+import '../../auth/domain/session.dart';
+import '../../auth/presentation/session_controller.dart';
 import '../domain/scope_permission.dart';
 import 'permission_detail_controller.dart';
+import 'permission_list_controller.dart';
 
 /// UI-26 — one scope permission.
 class PermissionDetailScreen extends ConsumerStatefulWidget {
@@ -74,6 +78,52 @@ class _PermissionDetailScreenState
       _description.text.trim() != permission.description ||
       _includeAsJwtClaim != permission.includeAsJwtClaim;
 
+  /// AF-27d — only a System Admin erases a permission permanently.
+  bool get _maySeeHardDelete {
+    final session = ref.watch(sessionControllerProvider);
+
+    return session is Authenticated && session.principal.isSystemAdmin;
+  }
+
+  /// AF-27a — a dialog the user closes sends nothing.
+  Future<void> _confirmDelete(ScopePermission permission) async {
+    final confirmed = await showConfirm(
+      context: context,
+      title: 'Delete ${permission.name}?',
+      message:
+          '${permission.name} will be marked deleted. The record is kept '
+          'and the API can restore it.',
+      confirmLabel: 'Delete',
+    );
+
+    if (confirmed && mounted) {
+      await ref
+          .read(permissionDetailControllerProvider(_ref).notifier)
+          .delete();
+    }
+  }
+
+  /// AF-27c — the confirm control stays disabled until the name matches.
+  Future<void> _confirmDeletePermanently(ScopePermission permission) async {
+    final confirmed = await showTypeToConfirm(
+      context: context,
+      title: 'Delete ${permission.name} permanently?',
+      message:
+          'The permission is erased. Tokens already issued that carry it '
+          'keep doing so until they expire. This cannot be undone. Type its '
+          'name to confirm:',
+      confirmationValue: permission.name,
+      fieldLabel: 'Permission name',
+      confirmLabel: 'Delete permanently',
+    );
+
+    if (confirmed && mounted) {
+      await ref
+          .read(permissionDetailControllerProvider(_ref).notifier)
+          .deletePermanently();
+    }
+  }
+
   Future<void> _save() async {
     if (!(_formKey.currentState?.validate() ?? false)) {
       return;
@@ -95,6 +145,19 @@ class _PermissionDetailScreenState
       permissionDetailControllerProvider(_ref).notifier,
     );
     final backToListing = '/scopes/${widget.scopeId}/permissions';
+
+    // A deleted permission returns to the listing, which is now stale.
+    ref.listen<PermissionDetailState>(
+      permissionDetailControllerProvider(_ref),
+      (previous, next) {
+        if (next is PermissionDeleted) {
+          ref
+              .read(permissionListControllerProvider(widget.scopeId).notifier)
+              .load();
+          context.go(backToListing);
+        }
+      },
+    );
 
     return AppShell(
       currentRoute: '/scopes',
@@ -137,6 +200,9 @@ class _PermissionDetailScreenState
           failure: failure,
           onRetry: controller.load,
         ),
+        // The listing is where a deleted permission leaves the user; this is
+        // the frame in between.
+        PermissionDeleted() => const Center(child: CircularProgressIndicator()),
         final PermissionDetailLoaded loaded => _detail(loaded),
       },
     );
@@ -250,8 +316,97 @@ class _PermissionDetailScreenState
                   ],
                 ),
               ),
+              // AF-26d leaves a deleted permission nothing left to delete.
+              if (!state.isReadOnly) ...<Widget>[
+                const SizedBox(height: 24),
+                _DangerZone(
+                  permission: permission,
+                  deleting: state.deleting,
+                  failure: state.deleteFailure,
+                  mayDeletePermanently: _maySeeHardDelete,
+                  onDelete: _confirmDelete,
+                  onDeletePermanently: _confirmDeletePermanently,
+                ),
+              ],
             ],
           ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The two deletions, kept apart from the rest of the screen because neither
+/// is an ordinary edit.
+class _DangerZone extends StatelessWidget {
+  const _DangerZone({
+    required this.permission,
+    required this.deleting,
+    required this.failure,
+    required this.mayDeletePermanently,
+    required this.onDelete,
+    required this.onDeletePermanently,
+  });
+
+  final ScopePermission permission;
+  final bool deleting;
+  final Failure? failure;
+
+  /// AF-27d — a Scope Admin never sees the permanent deletion.
+  final bool mayDeletePermanently;
+
+  final Future<void> Function(ScopePermission permission) onDelete;
+  final Future<void> Function(ScopePermission permission) onDeletePermanently;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Card(
+      color: theme.colorScheme.errorContainer,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              'Delete this permission',
+              style: theme.textTheme.titleMedium?.copyWith(
+                color: theme.colorScheme.onErrorContainer,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Deleting keeps the record and can be undone by the API. '
+              'Deleting permanently erases it.',
+              style: TextStyle(color: theme.colorScheme.onErrorContainer),
+            ),
+            // AF-27b — the API refused, and the permission is still open.
+            if (failure case final refusal?) ...<Widget>[
+              const SizedBox(height: 16),
+              ErrorBanner(failure: refusal),
+            ],
+            const SizedBox(height: 16),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: <Widget>[
+                OutlinedButton.icon(
+                  onPressed: deleting ? null : () => onDelete(permission),
+                  icon: const Icon(Icons.delete_outline),
+                  label: const Text('Delete permission'),
+                ),
+                if (mayDeletePermanently)
+                  FilledButton.icon(
+                    onPressed: deleting
+                        ? null
+                        : () => onDeletePermanently(permission),
+                    icon: const Icon(Icons.delete_forever_outlined),
+                    label: const Text('Delete permanently'),
+                  ),
+              ],
+            ),
+          ],
         ),
       ),
     );

--- a/test/features/permissions/presentation/permission_detail_controller_test.dart
+++ b/test/features/permissions/presentation/permission_detail_controller_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:heimdall_ui/core/result/result.dart';
@@ -50,6 +52,24 @@ void main() {
         scopeId: any(named: 'scopeId'),
         id: any(named: 'id'),
         includeDeleted: any(named: 'includeDeleted'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  void answerDeleteWith(Result<void> result) {
+    when(
+      () => repository.delete(
+        scopeId: any(named: 'scopeId'),
+        id: any(named: 'id'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  void answerHardDeleteWith(Result<void> result) {
+    when(
+      () => repository.hardDelete(
+        scopeId: any(named: 'scopeId'),
+        id: any(named: 'id'),
       ),
     ).thenAnswer((_) async => result);
   }
@@ -330,5 +350,109 @@ void main() {
     final state = currentState() as PermissionDetailLoaded;
     expect(state.saved, isFalse);
     expect(state.claimChanged, isFalse);
+  });
+
+  test('GivenAnOpenPermission_WhenDeleted_ThenItIsDeleted', () async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_readInvoices));
+    answerDeleteWith(const Success<void>(null));
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.delete();
+
+    // Then
+    verify(
+      () => repository.delete(scopeId: 'scope-1', id: 'permission-1'),
+    ).called(1);
+    expect(currentState(), isA<PermissionDeleted>());
+  });
+
+  test('GivenAnOpenPermission_WhenErased_ThenTheHardEndpointIsUsed', () async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_readInvoices));
+    answerHardDeleteWith(const Success<void>(null));
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.deletePermanently();
+
+    // Then
+    verify(
+      () => repository.hardDelete(scopeId: 'scope-1', id: 'permission-1'),
+    ).called(1);
+  });
+
+  // AF-27b — the API refused, and the permission stays open.
+  test('GivenARefusedDeletion_WhenDeleted_ThenItStaysOpen', () async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_readInvoices));
+    answerDeleteWith(
+      const FailureResult<void>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['That permission is still granted to somebody.'],
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.delete();
+
+    // Then
+    final state = currentState() as PermissionDetailLoaded;
+    expect(state.deleteFailure?.errors, <String>[
+      'That permission is still granted to somebody.',
+    ]);
+  });
+
+  test(
+    'GivenAnAlreadyDeletedPermission_WhenDeleted_ThenItCountsAsDone',
+    () async {
+      // Given
+      answerGetWith(const Success<ScopePermission>(_readInvoices));
+      answerDeleteWith(
+        const FailureResult<void>(
+          Failure(kind: FailureKind.notFound, errors: <String>[]),
+        ),
+      );
+      final controller = controllerUnderTest();
+      await controller.load();
+
+      // When
+      await controller.delete();
+
+      // Then
+      expect(currentState(), isA<PermissionDeleted>());
+    },
+  );
+
+  test('GivenADeletionInFlight_WhenAskedAgain_ThenOnlyOneIsSent', () async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_readInvoices));
+    final pending = Completer<Result<void>>();
+    when(
+      () => repository.delete(
+        scopeId: any(named: 'scopeId'),
+        id: any(named: 'id'),
+      ),
+    ).thenAnswer((_) => pending.future);
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    final first = controller.delete();
+    final second = controller.delete();
+    pending.complete(const Success<void>(null));
+    await Future.wait<void>(<Future<void>>[first, second]);
+
+    // Then
+    verify(
+      () => repository.delete(scopeId: 'scope-1', id: 'permission-1'),
+    ).called(1);
   });
 }

--- a/test/features/permissions/presentation/permission_detail_screen_test.dart
+++ b/test/features/permissions/presentation/permission_detail_screen_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:heimdall_ui/app/theme.dart';
+import 'package:heimdall_ui/core/network/envelope.dart' as envelope;
 import 'package:heimdall_ui/core/result/result.dart';
 import 'package:heimdall_ui/core/storage/token_store.dart';
 import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
@@ -17,13 +18,14 @@ import 'package:shared_preferences/shared_preferences.dart';
 class _MockScopePermissionRepository extends Mock
     implements ScopePermissionRepository {}
 
-String _jwt() {
+/// A token naming a person of [role]: 1 System Admin, 2 Scope Admin.
+String _jwt({int role = 1}) {
   final payload = base64Url.encode(
     utf8.encode(
       jsonEncode(<String, dynamic>{
         'sub': 'person-9',
         'email': 'admin@example.com',
-        'role': 1,
+        'role': role,
       }),
     ),
   );
@@ -60,12 +62,18 @@ void main() {
     WidgetTester tester, {
     Size size = _expanded,
     ThemeData? theme,
+    int role = 1,
   }) async {
     tester.view.physicalSize = size;
     tester.view.devicePixelRatio = 1;
     addTearDown(tester.view.reset);
 
-    await store.write(AuthToken(value: _jwt(), expiresAt: DateTime.utc(2030)));
+    await store.write(
+      AuthToken(
+        value: _jwt(role: role),
+        expiresAt: DateTime.utc(2030),
+      ),
+    );
 
     container = ProviderContainer(
       overrides: <Override>[
@@ -114,6 +122,51 @@ void main() {
         includeDeleted: any(named: 'includeDeleted'),
       ),
     ).thenAnswer((_) async => result);
+  }
+
+  /// The deletion controls sit at the bottom of a scrolling detail, so they
+  /// are not on screen until the view is brought to them.
+  Future<void> tapAfterScrolling(WidgetTester tester, Finder finder) async {
+    await tester.ensureVisible(finder);
+    await tester.pumpAndSettle();
+    await tester.tap(finder);
+    await tester.pumpAndSettle();
+  }
+
+  void answerDeleteWith(Result<void> result) {
+    when(
+      () => repository.delete(
+        scopeId: any(named: 'scopeId'),
+        id: any(named: 'id'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  void answerHardDeleteWith(Result<void> result) {
+    when(
+      () => repository.hardDelete(
+        scopeId: any(named: 'scopeId'),
+        id: any(named: 'id'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  /// The listing behind the detail is reloaded after a deletion; what it
+  /// answers does not matter here, only that it answers.
+  void answerListWith() {
+    when(
+      () => repository.list(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer(
+      (_) async => const FailureResult<envelope.Page<ScopePermission>>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
   }
 
   void answerUpdateWith(Result<ScopePermission> result) {
@@ -453,5 +506,259 @@ void main() {
 
     // Then
     expect(find.widgetWithText(TextFormField, 'read:invoices'), findsOneWidget);
+  });
+
+  testWidgets('GivenASystemAdmin_WhenOpened_ThenBothDeletionsAreOffered', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_readInvoices));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(
+      find.widgetWithText(OutlinedButton, 'Delete permission'),
+      findsOneWidget,
+    );
+    expect(
+      find.widgetWithText(FilledButton, 'Delete permanently'),
+      findsOneWidget,
+    );
+  });
+
+  // AF-27d — a Scope Admin never sees the permanent deletion.
+  testWidgets('GivenAScopeAdmin_WhenOpened_ThenOnlyTheLogicalOneIsOffered', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_readInvoices));
+
+    // When
+    await pump(tester, role: 2);
+
+    // Then
+    expect(
+      find.widgetWithText(OutlinedButton, 'Delete permission'),
+      findsOneWidget,
+    );
+    expect(
+      find.widgetWithText(FilledButton, 'Delete permanently'),
+      findsNothing,
+    );
+  });
+
+  // AF-26d — a deleted permission has nothing left to delete.
+  testWidgets('GivenADeletedPermission_WhenOpened_ThenDeletionIsNotOffered', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_deleted));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(
+      find.widgetWithText(OutlinedButton, 'Delete permission'),
+      findsNothing,
+    );
+  });
+
+  testWidgets('GivenTheDeleteControl_WhenTapped_ThenConfirmationIsAsked', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_readInvoices));
+    await pump(tester);
+
+    // When
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(OutlinedButton, 'Delete permission'),
+    );
+
+    // Then
+    expect(find.text('Delete read:invoices?'), findsOneWidget);
+  });
+
+  testWidgets('GivenAConfirmedDeletion_WhenConfirmed_ThenItIsDeleted', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_readInvoices));
+    answerDeleteWith(const Success<void>(null));
+    answerListWith();
+    await pump(tester);
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(OutlinedButton, 'Delete permission'),
+    );
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => repository.delete(scopeId: 'scope-1', id: 'permission-1'),
+    ).called(1);
+  });
+
+  testWidgets('GivenADeletedPermission_WhenDeleted_ThenTheListingOpens', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_readInvoices));
+    answerDeleteWith(const Success<void>(null));
+    answerListWith();
+    await pump(tester);
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(OutlinedButton, 'Delete permission'),
+    );
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('listing'), findsOneWidget);
+  });
+
+  // AF-27a — the dialog closes and nothing is sent.
+  testWidgets('GivenTheDeleteDialog_WhenCancelled_ThenNothingIsSent', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_readInvoices));
+    answerDeleteWith(const Success<void>(null));
+    await pump(tester);
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(OutlinedButton, 'Delete permission'),
+    );
+
+    // When
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verifyNever(
+      () => repository.delete(
+        scopeId: any(named: 'scopeId'),
+        id: any(named: 'id'),
+      ),
+    );
+  });
+
+  // AF-27b — the API refused, and the permission stays open.
+  testWidgets('GivenARefusedDeletion_WhenConfirmed_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_readInvoices));
+    answerDeleteWith(
+      const FailureResult<void>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['That permission is still granted to somebody.'],
+        ),
+      ),
+    );
+    await pump(tester);
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(OutlinedButton, 'Delete permission'),
+    );
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(
+      find.text('That permission is still granted to somebody.'),
+      findsOneWidget,
+    );
+  });
+
+  // AF-27c — the confirm control stays disabled until the name matches.
+  testWidgets('GivenTheHardDeleteDialog_WhenOpened_ThenConfirmIsDisabled', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_readInvoices));
+    await pump(tester);
+
+    // When
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(FilledButton, 'Delete permanently'),
+    );
+
+    // Then
+    expect(
+      tester
+          .widget<FilledButton>(
+            find.widgetWithText(FilledButton, 'Delete permanently').last,
+          )
+          .onPressed,
+      isNull,
+    );
+  });
+
+  testWidgets('GivenAMistypedName_WhenTyped_ThenConfirmStaysDisabled', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_readInvoices));
+    await pump(tester);
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(FilledButton, 'Delete permanently'),
+    );
+
+    // When
+    await tester.enterText(find.byType(TextField).last, 'read:invoice');
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(
+      tester
+          .widget<FilledButton>(
+            find.widgetWithText(FilledButton, 'Delete permanently').last,
+          )
+          .onPressed,
+      isNull,
+    );
+  });
+
+  testWidgets('GivenTheTypedName_WhenItMatches_ThenThePermissionIsErased', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<ScopePermission>(_readInvoices));
+    answerHardDeleteWith(const Success<void>(null));
+    answerListWith();
+    await pump(tester);
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(FilledButton, 'Delete permanently'),
+    );
+    await tester.enterText(find.byType(TextField).last, 'read:invoices');
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(
+      find.widgetWithText(FilledButton, 'Delete permanently').last,
+    );
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => repository.hardDelete(scopeId: 'scope-1', id: 'permission-1'),
+    ).called(1);
   });
 }


### PR DESCRIPTION
Closes #27

Implements UI-27 — both deletions from the permission detail, over `DELETE /api/scopes/{scopeId}/permissions/{id}` (FR-PM-07) and its `/hard` counterpart (FR-PM-08).

## Flows

| Flow | How it is handled |
| --- | --- |
| Main — logical | A dialog names the permission and says the record is kept; on success the listing reopens. |
| Main — permanent | A dialog requires the permission's name to be typed. |
| AF-27a | Closing either dialog sends nothing. |
| AF-27b | A refusal shows the API's strings and leaves the permission open. |
| AF-27c | The confirm control stays disabled until the name matches exactly. |
| AF-27d | Only a System Admin is shown the permanent deletion. |

The permanent-deletion dialog states what erasing a permission does *not* undo: tokens already issued that carry it keep carrying it until they expire — the same care UI-26's claim-flag confirmation takes.

## Verification

`dart format --set-exit-if-changed .`, `flutter analyze`, and `flutter test` all pass — **791 tests**, 16 of them new. No presentation file imports `package:heimdall_api_client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)