### PR TITLE
feat(ui-28): browse and view Google users

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ the board is where an item's status changes as it moves.
 
 | Use case | Status | Issue |
 | --- | --- | --- |
-| UI-28: Browse and view Google users | ⬜ | [#28](https://github.com/artur-rios/heimdall-ui/issues/28) |
+| UI-28: Browse and view Google users | ✅ | [#28](https://github.com/artur-rios/heimdall-ui/issues/28) |
 | UI-29: Delete a Google user, logically and permanently | ⬜ | [#29](https://github.com/artur-rios/heimdall-ui/issues/29) |
 
 ### Platform

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -13,6 +13,8 @@ import '../features/auth/presentation/session_controller.dart';
 import '../features/auth/presentation/two_factor_screen.dart';
 import '../features/auth/presentation/verify_email_screen.dart';
 import '../features/home/presentation/home_screen.dart';
+import '../features/google_users/presentation/google_user_detail_screen.dart';
+import '../features/google_users/presentation/google_user_list_screen.dart';
 import '../features/permissions/presentation/permission_create_screen.dart';
 import '../features/permissions/presentation/permission_detail_screen.dart';
 import '../features/permissions/presentation/permission_list_screen.dart';
@@ -172,6 +174,18 @@ final Provider<GoRouter> routerProvider = Provider<GoRouter>((ref) {
         builder: (context, state) => PermissionDetailScreen(
           scopeId: state.pathParameters['scopeId']!,
           permissionId: state.pathParameters['permissionId']!,
+        ),
+      ),
+      GoRoute(
+        path: '/scopes/:scopeId/google-users',
+        builder: (context, state) =>
+            GoogleUserListScreen(scopeId: state.pathParameters['scopeId']!),
+      ),
+      GoRoute(
+        path: '/scopes/:scopeId/google-users/:googleUserId',
+        builder: (context, state) => GoogleUserDetailScreen(
+          scopeId: state.pathParameters['scopeId']!,
+          googleUserId: state.pathParameters['googleUserId']!,
         ),
       ),
       GoRoute(

--- a/lib/features/google_users/data/google_user_repository_impl.dart
+++ b/lib/features/google_users/data/google_user_repository_impl.dart
@@ -3,6 +3,7 @@ import 'package:heimdall_api_client/export.dart';
 
 import '../../../core/network/envelope.dart';
 import '../../../core/result/result.dart';
+import '../domain/google_user.dart';
 import '../domain/google_user_repository.dart';
 
 /// [GoogleUserRepository] over the generated client.
@@ -36,4 +37,110 @@ class ApiGoogleUserRepository implements GoogleUserRepository {
       return FailureResult<int>(failureFromDioException(error));
     }
   }
+
+  @override
+  Future<Result<Page<GoogleUser>>> list({
+    required String scopeId,
+    String? name,
+    String? email,
+    bool includeDeleted = false,
+    int pageNumber = 1,
+    int pageSize = 20,
+  }) async {
+    try {
+      final response = await _client.googleUserList(
+        scopeId: scopeId,
+        // An empty filter is no filter: sending it would ask the API to match
+        // the empty string rather than to stop filtering.
+        name: _filter(name),
+        email: _filter(email),
+        includeDeleted: includeDeleted,
+        pageNumber: pageNumber,
+        pageSize: pageSize,
+      );
+
+      if (response.success != true) {
+        return FailureResult<Page<GoogleUser>>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: response.errors ?? const <String>[],
+          ),
+        );
+      }
+
+      final items = (response.data ?? const <GoogleUserOutput>[])
+          .map(googleUserFromOutput)
+          .toList(growable: false);
+
+      return Success<Page<GoogleUser>>(
+        Page<GoogleUser>(
+          items: items,
+          pageNumber: response.pageNumber ?? pageNumber,
+          pageSize: response.pageSize ?? pageSize,
+          totalItems: response.totalItems ?? items.length,
+          totalPages: response.totalPages ?? 1,
+        ),
+      );
+    } on DioException catch (error) {
+      // AF-28b and AF-28c depend on this: a transport failure and a `403` are
+      // different panels, and only the kind tells them apart.
+      return FailureResult<Page<GoogleUser>>(failureFromDioException(error));
+    }
+  }
+
+  @override
+  Future<Result<GoogleUser>> getById({
+    required String scopeId,
+    required String id,
+    bool includeDeleted = true,
+  }) async {
+    try {
+      final response = await _client.googleUserGetById(
+        scopeId: scopeId,
+        id: id,
+        includeDeleted: includeDeleted,
+      );
+
+      if (response.success != true) {
+        return FailureResult<GoogleUser>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: response.errors ?? const <String>[],
+          ),
+        );
+      }
+
+      final data = response.data;
+
+      if (data == null) {
+        return const FailureResult<GoogleUser>(
+          Failure(
+            kind: FailureKind.unknown,
+            errors: <String>['The API returned an incomplete response.'],
+          ),
+        );
+      }
+
+      return Success<GoogleUser>(googleUserFromOutput(data));
+    } on DioException catch (error) {
+      return FailureResult<GoogleUser>(failureFromDioException(error));
+    }
+  }
+
+  static String? _filter(String? value) =>
+      (value?.trim().isEmpty ?? true) ? null : value!.trim();
 }
+
+/// Maps the generated output onto the domain entity.
+GoogleUser googleUserFromOutput(GoogleUserOutput output) => GoogleUser(
+  id: output.id ?? '',
+  name: output.name ?? '',
+  email: output.email ?? '',
+  googleId: output.googleId,
+  emailVerified: output.emailVerified ?? true,
+  profilePictureUrl: output.profilePictureUrl,
+  isDeleted: output.isDeleted ?? false,
+  scopeId: output.scopeId,
+  createdAt: output.createdAt,
+  updatedAt: output.updatedAt,
+);

--- a/lib/features/google_users/domain/google_user.dart
+++ b/lib/features/google_users/domain/google_user.dart
@@ -1,0 +1,62 @@
+/// A Google User as the API describes one.
+///
+/// A Google User is not a Person: it is an account that reached a scope through
+/// Google's sign-in rather than through a password. Its fields come from
+/// Google, which is why AF-28e makes it read-only here.
+class GoogleUser {
+  const GoogleUser({
+    required this.id,
+    required this.name,
+    required this.email,
+    this.googleId,
+    this.emailVerified = true,
+    this.profilePictureUrl,
+    this.isDeleted = false,
+    this.scopeId,
+    this.createdAt,
+    this.updatedAt,
+  });
+
+  final String id;
+  final String name;
+  final String email;
+
+  /// Google's own identifier for the account.
+  final String? googleId;
+
+  /// Whether Google considers the address verified.
+  final bool emailVerified;
+
+  /// Where the account's picture lives, when Google reported one.
+  final String? profilePictureUrl;
+
+  final bool isDeleted;
+  final String? scopeId;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+
+  /// The letters shown when there is no picture to show (AF-28d, FR-GU-03).
+  ///
+  /// Runes rather than code units, so a name starting with an emoji or a
+  /// non-BMP character is not cut in half.
+  String get initials {
+    final words = name
+        .trim()
+        .split(RegExp(r'\s+'))
+        .where((word) => word.isNotEmpty)
+        .toList(growable: false);
+
+    if (words.isEmpty) {
+      return email.isEmpty ? '?' : _firstLetterOf(email);
+    }
+
+    if (words.length == 1) {
+      return _firstLetterOf(words.first);
+    }
+
+    return _firstLetterOf(words.first) + _firstLetterOf(words.last);
+  }
+
+  static String _firstLetterOf(String value) =>
+      String.fromCharCodes(value.runes.take(1)).toUpperCase();
+}

--- a/lib/features/google_users/domain/google_user_repository.dart
+++ b/lib/features/google_users/domain/google_user_repository.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/network/envelope.dart';
 import '../../../core/result/result.dart';
+import 'google_user.dart';
 
 /// The Google User operations the interface depends on.
 ///
@@ -13,6 +15,26 @@ abstract interface class GoogleUserRepository {
   /// Reads one page of one item and takes the API's own total, so the answer
   /// costs the same whether the scope holds none or thousands.
   Future<Result<int>> countIn(String scopeId);
+
+  /// Reads one page of a scope's Google Users.
+  Future<Result<Page<GoogleUser>>> list({
+    required String scopeId,
+    String? name,
+    String? email,
+    bool includeDeleted = false,
+    int pageNumber = 1,
+    int pageSize = 20,
+  });
+
+  /// Reads one Google User.
+  ///
+  /// [includeDeleted] is on by default for the detail screen, so a logically
+  /// deleted record can still be looked at.
+  Future<Result<GoogleUser>> getById({
+    required String scopeId,
+    required String id,
+    bool includeDeleted = true,
+  });
 }
 
 /// Overridden at start-up with the client-backed implementation, and in tests

--- a/lib/features/google_users/presentation/google_avatar.dart
+++ b/lib/features/google_users/presentation/google_avatar.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+import '../domain/google_user.dart';
+
+/// A Google User's picture, or their initials when there is none to show.
+///
+/// AF-28d and FR-GU-03: a missing picture and an unreachable one are the same
+/// thing to a reader, so both fall back to the initials rather than leaving a
+/// hole in the row. The fallback is also what renders first, so a slow image
+/// never leaves blank space behind it.
+class GoogleAvatar extends StatelessWidget {
+  const GoogleAvatar({required this.user, this.radius = 20, super.key});
+
+  final GoogleUser user;
+  final double radius;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final url = user.profilePictureUrl;
+    final picture = (url == null || url.isEmpty) ? null : NetworkImage(url);
+
+    return CircleAvatar(
+      radius: radius,
+      backgroundColor: scheme.secondaryContainer,
+      foregroundColor: scheme.onSecondaryContainer,
+      // The initials sit underneath: `foregroundImage` draws over them when it
+      // loads and leaves them alone when it fails, so an unreachable picture
+      // needs no error handling of its own.
+      foregroundImage: picture,
+      // An image that will not load is not worth reporting to the user; the
+      // initials already say who this is. The handler may only be given
+      // alongside an image, which is why it is conditional too.
+      onForegroundImageError: picture == null ? null : (_, _) {},
+      child: Text(user.initials),
+    );
+  }
+}

--- a/lib/features/google_users/presentation/google_user_detail_controller.dart
+++ b/lib/features/google_users/presentation/google_user_detail_controller.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/result/result.dart';
+import '../domain/google_user.dart';
+import '../domain/google_user_repository.dart';
+
+/// Which Google User a detail screen is showing.
+class GoogleUserRef {
+  const GoogleUserRef({required this.scopeId, required this.googleUserId});
+
+  final String scopeId;
+  final String googleUserId;
+
+  @override
+  bool operator ==(Object other) =>
+      other is GoogleUserRef &&
+      other.scopeId == scopeId &&
+      other.googleUserId == googleUserId;
+
+  @override
+  int get hashCode => Object.hash(scopeId, googleUserId);
+}
+
+/// How far the Google user detail has got.
+sealed class GoogleUserDetailState {
+  const GoogleUserDetailState();
+}
+
+/// The record is being read.
+final class GoogleUserDetailLoading extends GoogleUserDetailState {
+  const GoogleUserDetailLoading();
+}
+
+/// The record could not be read.
+final class GoogleUserDetailUnavailable extends GoogleUserDetailState {
+  const GoogleUserDetailUnavailable(this.failure);
+
+  final Failure failure;
+
+  bool get isNotFound => failure.kind == FailureKind.notFound;
+  bool get isForbidden => failure.kind == FailureKind.forbidden;
+}
+
+/// The record is on screen.
+///
+/// AF-28e: there is nothing to save here. Every field comes from Google, so
+/// the state carries no editing of any kind.
+final class GoogleUserDetailLoaded extends GoogleUserDetailState {
+  const GoogleUserDetailLoaded(this.user);
+
+  final GoogleUser user;
+}
+
+final NotifierProviderFamily<
+  GoogleUserDetailController,
+  GoogleUserDetailState,
+  GoogleUserRef
+>
+googleUserDetailControllerProvider =
+    NotifierProvider.family<
+      GoogleUserDetailController,
+      GoogleUserDetailState,
+      GoogleUserRef
+    >(GoogleUserDetailController.new);
+
+/// Owns one Google user's detail. Reading it is all there is to do.
+class GoogleUserDetailController
+    extends FamilyNotifier<GoogleUserDetailState, GoogleUserRef> {
+  @override
+  GoogleUserDetailState build(GoogleUserRef ref) =>
+      const GoogleUserDetailLoading();
+
+  Future<void> load() async {
+    state = const GoogleUserDetailLoading();
+
+    final result = await ref
+        .read(googleUserRepositoryProvider)
+        .getById(scopeId: arg.scopeId, id: arg.googleUserId);
+
+    state = result.fold(
+      onSuccess: GoogleUserDetailLoaded.new,
+      onFailure: GoogleUserDetailUnavailable.new,
+    );
+  }
+}

--- a/lib/features/google_users/presentation/google_user_detail_screen.dart
+++ b/lib/features/google_users/presentation/google_user_detail_screen.dart
@@ -1,0 +1,220 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../shared/layout/app_shell.dart';
+import '../../../shared/widgets/collection_states.dart';
+import '../domain/google_user.dart';
+import 'google_avatar.dart';
+import 'google_user_detail_controller.dart';
+
+/// UI-28 — one Google user, read-only.
+///
+/// AF-28e: every field comes from Google, so there is nothing here to edit.
+class GoogleUserDetailScreen extends ConsumerStatefulWidget {
+  const GoogleUserDetailScreen({
+    required this.scopeId,
+    required this.googleUserId,
+    super.key,
+  });
+
+  final String scopeId;
+  final String googleUserId;
+
+  @override
+  ConsumerState<GoogleUserDetailScreen> createState() =>
+      _GoogleUserDetailScreenState();
+}
+
+class _GoogleUserDetailScreenState
+    extends ConsumerState<GoogleUserDetailScreen> {
+  GoogleUserRef get _ref =>
+      GoogleUserRef(scopeId: widget.scopeId, googleUserId: widget.googleUserId);
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => ref.read(googleUserDetailControllerProvider(_ref).notifier).load(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(googleUserDetailControllerProvider(_ref));
+    final controller = ref.read(
+      googleUserDetailControllerProvider(_ref).notifier,
+    );
+    final backToListing = '/scopes/${widget.scopeId}/google-users';
+
+    return AppShell(
+      currentRoute: '/scopes',
+      title: Text(switch (state) {
+        GoogleUserDetailLoaded(:final user) => user.name,
+        _ => 'Google user',
+      }),
+      actions: <Widget>[
+        IconButton(
+          tooltip: 'Back to the listing',
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.go(backToListing),
+        ),
+      ],
+      body: switch (state) {
+        GoogleUserDetailLoading() => const Center(
+          child: CircularProgressIndicator(),
+        ),
+        GoogleUserDetailUnavailable(isNotFound: true) => CollectionEmpty(
+          title: 'Google user not found',
+          message:
+              'There is no Google user with that identifier. They may '
+              'have been permanently deleted.',
+          icon: Icons.search_off_outlined,
+          actionLabel: 'Back to the listing',
+          onAction: () => context.go(backToListing),
+        ),
+        GoogleUserDetailUnavailable(isForbidden: true) => CollectionEmpty(
+          title: 'Not available for your role',
+          message:
+              'This Google user is not one you administer. Nothing is '
+              'wrong with your session.',
+          icon: Icons.lock_person_outlined,
+          actionLabel: 'Back to the listing',
+          onAction: () => context.go(backToListing),
+        ),
+        GoogleUserDetailUnavailable(:final failure) => CollectionFailed(
+          failure: failure,
+          onRetry: controller.load,
+        ),
+        GoogleUserDetailLoaded(:final user) => _detail(user),
+      },
+    );
+  }
+
+  Widget _detail(GoogleUser user) {
+    final theme = Theme.of(context);
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(24),
+      child: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 640),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              if (user.isDeleted) ...<Widget>[
+                _DeletedNotice(),
+                const SizedBox(height: 16),
+              ],
+              Row(
+                children: <Widget>[
+                  // AF-28d: the picture, or the initials when there is none.
+                  GoogleAvatar(user: user, radius: 32),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Text(user.name, style: theme.textTheme.headlineSmall),
+                        const SizedBox(height: 4),
+                        Text(user.email, style: theme.textTheme.bodyMedium),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 24),
+              // AF-28e — read-only, and it says why rather than leaving the
+              // absence of controls to be puzzled over.
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: DefaultTextStyle.merge(
+                    style: theme.textTheme.bodyMedium,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Text(
+                          'These details come from Google and cannot be '
+                          'changed here.',
+                          style: theme.textTheme.bodySmall,
+                        ),
+                        const SizedBox(height: 12),
+                        _Fact(label: 'Identifier', value: user.id),
+                        _Fact(
+                          label: 'Google identifier',
+                          value: user.googleId ?? 'Not reported',
+                        ),
+                        _Fact(
+                          label: 'Verified by Google',
+                          value: user.emailVerified ? 'Yes' : 'No',
+                        ),
+                        _Fact(
+                          label: 'Scope',
+                          value: user.scopeId ?? widget.scopeId,
+                        ),
+                        _Fact(
+                          label: 'State',
+                          value: user.isDeleted ? 'Deleted' : 'Active',
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DeletedNotice extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: scheme.errorContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: <Widget>[
+          Icon(Icons.person_off_outlined, color: scheme.onErrorContainer),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              'This Google user is deleted. They are shown for reference.',
+              style: TextStyle(color: scheme.onErrorContainer),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Fact extends StatelessWidget {
+  const _Fact({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.symmetric(vertical: 4),
+    child: Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        SizedBox(
+          width: 160,
+          child: Text(label, style: Theme.of(context).textTheme.labelLarge),
+        ),
+        Expanded(child: Text(value)),
+      ],
+    ),
+  );
+}

--- a/lib/features/google_users/presentation/google_user_list_controller.dart
+++ b/lib/features/google_users/presentation/google_user_list_controller.dart
@@ -1,0 +1,138 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/network/envelope.dart';
+import '../../../core/result/result.dart';
+import '../domain/google_user.dart';
+import '../domain/google_user_repository.dart';
+
+/// What the listing is currently asking the API for.
+class GoogleUserQuery {
+  const GoogleUserQuery({
+    this.name = '',
+    this.email = '',
+    this.includeDeleted = false,
+    this.pageNumber = 1,
+  });
+
+  final String name;
+  final String email;
+  final bool includeDeleted;
+  final int pageNumber;
+
+  /// Whether the user has narrowed the listing at all, which is what tells an
+  /// empty result from a scope nobody has signed into (AF-28a).
+  bool get isFiltered =>
+      name.trim().isNotEmpty || email.trim().isNotEmpty || includeDeleted;
+
+  GoogleUserQuery copyWith({
+    String? name,
+    String? email,
+    bool? includeDeleted,
+    int? pageNumber,
+  }) => GoogleUserQuery(
+    name: name ?? this.name,
+    email: email ?? this.email,
+    includeDeleted: includeDeleted ?? this.includeDeleted,
+    pageNumber: pageNumber ?? this.pageNumber,
+  );
+}
+
+/// How far the listing has got.
+sealed class GoogleUserListState {
+  const GoogleUserListState(this.query);
+
+  final GoogleUserQuery query;
+}
+
+/// The first page is on its way and the list shows a placeholder.
+final class GoogleUserListLoading extends GoogleUserListState {
+  const GoogleUserListLoading(super.query);
+}
+
+/// A page arrived.
+final class GoogleUserListLoaded extends GoogleUserListState {
+  const GoogleUserListLoaded(super.query, this.page, {this.busy = false});
+
+  final Page<GoogleUser> page;
+  final bool busy;
+}
+
+/// AF-28b and AF-28c — the request failed, and the query that failed is kept.
+final class GoogleUserListFailed extends GoogleUserListState {
+  const GoogleUserListFailed(super.query, this.failure);
+
+  final Failure failure;
+
+  /// AF-28c — a scope this admin does not own.
+  bool get isForbidden => failure.kind == FailureKind.forbidden;
+}
+
+final NotifierProviderFamily<
+  GoogleUserListController,
+  GoogleUserListState,
+  String
+>
+googleUserListControllerProvider =
+    NotifierProvider.family<
+      GoogleUserListController,
+      GoogleUserListState,
+      String
+    >(GoogleUserListController.new);
+
+/// Owns one scope's Google user listing.
+class GoogleUserListController
+    extends FamilyNotifier<GoogleUserListState, String> {
+  bool _inFlight = false;
+
+  @override
+  GoogleUserListState build(String scopeId) =>
+      const GoogleUserListLoading(GoogleUserQuery());
+
+  Future<void> load() => _fetch(state.query);
+
+  /// A new search starts at the first page.
+  Future<void> search({String? name, String? email}) =>
+      _fetch(state.query.copyWith(name: name, email: email, pageNumber: 1));
+
+  Future<void> setIncludeDeleted(bool includeDeleted) => _fetch(
+    state.query.copyWith(includeDeleted: includeDeleted, pageNumber: 1),
+  );
+
+  Future<void> goToPage(int pageNumber) =>
+      _fetch(state.query.copyWith(pageNumber: pageNumber));
+
+  /// AF-28a — returns to the unfiltered listing from the empty-result panel.
+  Future<void> clearFilters() => _fetch(const GoogleUserQuery());
+
+  Future<void> _fetch(GoogleUserQuery query) async {
+    if (_inFlight) {
+      return;
+    }
+
+    final current = state;
+    _inFlight = true;
+
+    state = current is GoogleUserListLoaded
+        ? GoogleUserListLoaded(query, current.page, busy: true)
+        : GoogleUserListLoading(query);
+
+    try {
+      final result = await ref
+          .read(googleUserRepositoryProvider)
+          .list(
+            scopeId: arg,
+            name: query.name,
+            email: query.email,
+            includeDeleted: query.includeDeleted,
+            pageNumber: query.pageNumber,
+          );
+
+      state = result.fold(
+        onSuccess: (page) => GoogleUserListLoaded(query, page),
+        onFailure: (failure) => GoogleUserListFailed(query, failure),
+      );
+    } finally {
+      _inFlight = false;
+    }
+  }
+}

--- a/lib/features/google_users/presentation/google_user_list_screen.dart
+++ b/lib/features/google_users/presentation/google_user_list_screen.dart
@@ -1,0 +1,241 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../shared/layout/app_shell.dart';
+import '../../../shared/widgets/adaptive_collection.dart';
+import '../../../shared/widgets/collection_states.dart';
+import '../../scopes/presentation/scope_detail_controller.dart';
+import '../domain/google_user.dart';
+import 'google_avatar.dart';
+import 'google_user_list_controller.dart';
+
+/// UI-28 — the Google users of one scope.
+class GoogleUserListScreen extends ConsumerStatefulWidget {
+  const GoogleUserListScreen({required this.scopeId, super.key});
+
+  final String scopeId;
+
+  @override
+  ConsumerState<GoogleUserListScreen> createState() =>
+      _GoogleUserListScreenState();
+}
+
+class _GoogleUserListScreenState extends ConsumerState<GoogleUserListScreen> {
+  final _name = TextEditingController();
+  final _email = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref
+          .read(googleUserListControllerProvider(widget.scopeId).notifier)
+          .load();
+      // AF-28a needs to know whether the scope has Google Sign-In on, which is
+      // the scope's own record rather than anything in this listing.
+      ref.read(scopeDetailControllerProvider(widget.scopeId).notifier).load();
+    });
+  }
+
+  @override
+  void dispose() {
+    _name.dispose();
+    _email.dispose();
+    super.dispose();
+  }
+
+  GoogleUserListController get _controller =>
+      ref.read(googleUserListControllerProvider(widget.scopeId).notifier);
+
+  void _clearFilters() {
+    _name.clear();
+    _email.clear();
+    _controller.clearFilters();
+  }
+
+  /// Whether the scope has Google Sign-In switched off, which is why nobody
+  /// could have signed in. `null` while the scope is still being read.
+  bool? get _googleSignInOff =>
+      switch (ref.watch(scopeDetailControllerProvider(widget.scopeId))) {
+        ScopeDetailLoaded(:final scope) => !scope.googleSignInEnabled,
+        _ => null,
+      };
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(googleUserListControllerProvider(widget.scopeId));
+
+    return AppShell(
+      currentRoute: '/scopes',
+      title: const Text('Google users'),
+      actions: <Widget>[
+        IconButton(
+          tooltip: 'Back to the scope',
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.go('/scopes/${widget.scopeId}'),
+        ),
+      ],
+      body: Column(
+        children: <Widget>[
+          _Filters(
+            name: _name,
+            email: _email,
+            includeDeleted: state.query.includeDeleted,
+            onSearch: () =>
+                _controller.search(name: _name.text, email: _email.text),
+            onIncludeDeletedChanged: _controller.setIncludeDeleted,
+          ),
+          Expanded(
+            child: switch (state) {
+              GoogleUserListLoading() => const CollectionLoading(),
+              // AF-28c — the scope is not one this admin owns.
+              GoogleUserListFailed(isForbidden: true) => CollectionEmpty(
+                title: 'Not available for your role',
+                message:
+                    'This scope is not one you administer. Nothing is '
+                    'wrong with your session.',
+                icon: Icons.lock_person_outlined,
+                actionLabel: 'Back to scopes',
+                onAction: () => context.go('/scopes'),
+              ),
+              // AF-28b — the returned errors, with a retry.
+              GoogleUserListFailed(:final failure) => CollectionFailed(
+                failure: failure,
+                onRetry: _controller.load,
+              ),
+              GoogleUserListLoaded(:final page, :final query)
+                  when page.items.isEmpty =>
+                _empty(query),
+              final GoogleUserListLoaded loaded =>
+                AdaptiveCollection<GoogleUser>(
+                  items: loaded.page.items,
+                  busy: loaded.busy,
+                  pageNumber: loaded.page.pageNumber,
+                  totalPages: loaded.page.totalPages,
+                  totalItems: loaded.page.totalItems,
+                  onPageChanged: _controller.goToPage,
+                  onTap: (user) => context.go(
+                    '/scopes/${widget.scopeId}/google-users/${user.id}',
+                  ),
+                  title: (user) => user.name,
+                  subtitle: (user) => user.email,
+                  columns: <CollectionColumn<GoogleUser>>[
+                    CollectionColumn<GoogleUser>(
+                      label: 'Picture',
+                      // AF-28d: a missing or unreachable picture becomes
+                      // initials; the row never breaks.
+                      cell: (user) => GoogleAvatar(user: user, radius: 16),
+                    ),
+                    CollectionColumn<GoogleUser>(
+                      label: 'Verified by Google',
+                      cell: (user) => Text(user.emailVerified ? 'Yes' : 'No'),
+                    ),
+                    CollectionColumn<GoogleUser>(
+                      label: 'State',
+                      cell: (user) =>
+                          Text(user.isDeleted ? 'Deleted' : 'Active'),
+                    ),
+                  ],
+                ),
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// AF-28a — nobody has signed in with Google here, which is a different
+  /// thing from a search that matched nothing. When the scope has the feature
+  /// switched off, that is the reason, and UI-15 is where it is switched on.
+  Widget _empty(GoogleUserQuery query) {
+    if (query.isFiltered) {
+      return CollectionEmpty(
+        title: 'No Google users matched',
+        message:
+            'Nothing here matches what you searched for. Clearing the '
+            'filters shows them all again.',
+        icon: Icons.search_off_outlined,
+        actionLabel: 'Clear filters',
+        onAction: _clearFilters,
+      );
+    }
+
+    final signInOff = _googleSignInOff;
+
+    return CollectionEmpty(
+      title: 'No Google users yet',
+      message: signInOff ?? false
+          ? 'A Google user appears here the first time somebody signs in to '
+                'this scope with Google — and this scope has Google Sign-In '
+                'switched off, so nobody can.'
+          : 'A Google user appears here the first time somebody signs in to '
+                'this scope with Google. Nobody has yet.',
+      icon: Icons.account_circle_outlined,
+      actionLabel: (signInOff ?? false) ? 'Scope settings' : null,
+      onAction: (signInOff ?? false)
+          ? () => context.go('/scopes/${widget.scopeId}')
+          : null,
+    );
+  }
+}
+
+/// The two search fields and the include-deleted switch.
+class _Filters extends StatelessWidget {
+  const _Filters({
+    required this.name,
+    required this.email,
+    required this.includeDeleted,
+    required this.onSearch,
+    required this.onIncludeDeletedChanged,
+  });
+
+  final TextEditingController name;
+  final TextEditingController email;
+  final bool includeDeleted;
+  final VoidCallback onSearch;
+  final ValueChanged<bool> onIncludeDeletedChanged;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.fromLTRB(12, 12, 12, 0),
+    child: Wrap(
+      spacing: 16,
+      runSpacing: 8,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: <Widget>[
+        SizedBox(
+          width: 260,
+          child: TextField(
+            controller: name,
+            decoration: const InputDecoration(
+              labelText: 'Search by name',
+              prefixIcon: Icon(Icons.search),
+            ),
+            onSubmitted: (_) => onSearch(),
+          ),
+        ),
+        SizedBox(
+          width: 260,
+          child: TextField(
+            controller: email,
+            decoration: const InputDecoration(
+              labelText: 'Search by email',
+              prefixIcon: Icon(Icons.alternate_email),
+            ),
+            onSubmitted: (_) => onSearch(),
+          ),
+        ),
+        FilledButton.tonal(onPressed: onSearch, child: const Text('Search')),
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Switch(value: includeDeleted, onChanged: onIncludeDeletedChanged),
+            const SizedBox(width: 8),
+            const Text('Include deleted'),
+          ],
+        ),
+      ],
+    ),
+  );
+}

--- a/test/features/google_users/domain/google_user_test.dart
+++ b/test/features/google_users/domain/google_user_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdall_ui/features/google_users/domain/google_user.dart';
+
+GoogleUser _user({String name = '', String email = ''}) =>
+    GoogleUser(id: 'google-1', name: name, email: email);
+
+void main() {
+  // FR-GU-03 and AF-28d — the initials are what a missing picture falls back
+  // to, so they have to be right for every shape of name.
+  test('GivenAFullName_WhenInitialsRead_ThenTheFirstAndLastAreUsed', () {
+    // Given
+    final user = _user(name: 'Ada Lovelace');
+
+    // When
+    final initials = user.initials;
+
+    // Then
+    expect(initials, 'AL');
+  });
+
+  test('GivenThreeNames_WhenInitialsRead_ThenTheFirstAndLastAreUsed', () {
+    // Given
+    final user = _user(name: 'Ada Byron Lovelace');
+
+    // When
+    final initials = user.initials;
+
+    // Then
+    expect(initials, 'AL');
+  });
+
+  test('GivenOneName_WhenInitialsRead_ThenOneLetterIsUsed', () {
+    // Given
+    final user = _user(name: 'Ada');
+
+    // When
+    final initials = user.initials;
+
+    // Then
+    expect(initials, 'A');
+  });
+
+  test('GivenExtraSpaces_WhenInitialsRead_ThenTheyAreIgnored', () {
+    // Given
+    final user = _user(name: '  Ada   Lovelace  ');
+
+    // When
+    final initials = user.initials;
+
+    // Then
+    expect(initials, 'AL');
+  });
+
+  test('GivenALowercaseName_WhenInitialsRead_ThenTheyAreUppercased', () {
+    // Given
+    final user = _user(name: 'ada lovelace');
+
+    // When
+    final initials = user.initials;
+
+    // Then
+    expect(initials, 'AL');
+  });
+
+  test('GivenNoName_WhenInitialsRead_ThenTheEmailIsUsed', () {
+    // Given
+    final user = _user(email: 'ada@example.com');
+
+    // When
+    final initials = user.initials;
+
+    // Then
+    expect(initials, 'A');
+  });
+
+  test('GivenNothingAtAll_WhenInitialsRead_ThenAQuestionMarkIsUsed', () {
+    // Given
+    final user = _user();
+
+    // When
+    final initials = user.initials;
+
+    // Then
+    expect(initials, '?');
+  });
+
+  // Runes rather than code units: a name starting with a non-BMP character
+  // must not be cut in half.
+  test('GivenAnEmojiName_WhenInitialsRead_ThenTheCharacterSurvives', () {
+    // Given
+    final user = _user(name: '🌟 Star');
+
+    // When
+    final initials = user.initials;
+
+    // Then
+    expect(initials, '🌟S');
+  });
+}

--- a/test/features/google_users/presentation/google_user_detail_screen_test.dart
+++ b/test/features/google_users/presentation/google_user_detail_screen_test.dart
@@ -1,0 +1,303 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:heimdall_ui/app/theme.dart';
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/core/storage/token_store.dart';
+import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
+import 'package:heimdall_ui/features/google_users/domain/google_user.dart';
+import 'package:heimdall_ui/features/google_users/domain/google_user_repository.dart';
+import 'package:heimdall_ui/features/google_users/presentation/google_user_detail_screen.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockGoogleUserRepository extends Mock implements GoogleUserRepository {}
+
+String _jwt() {
+  final payload = base64Url.encode(
+    utf8.encode(
+      jsonEncode(<String, dynamic>{
+        'sub': 'person-9',
+        'email': 'admin@example.com',
+        'role': 1,
+      }),
+    ),
+  );
+
+  return 'header.$payload.signature';
+}
+
+const _ada = GoogleUser(
+  id: 'google-1',
+  name: 'Ada Lovelace',
+  email: 'ada@example.com',
+  googleId: '1234567890',
+  scopeId: 'scope-1',
+);
+
+const _deleted = GoogleUser(
+  id: 'google-1',
+  name: 'Ada Lovelace',
+  email: 'ada@example.com',
+  scopeId: 'scope-1',
+  isDeleted: true,
+);
+
+const Size _compact = Size(400, 900);
+const Size _medium = Size(800, 900);
+const Size _expanded = Size(1400, 900);
+
+void main() {
+  late _MockGoogleUserRepository repository;
+  late InMemoryTokenStore store;
+  late ProviderContainer container;
+  late GoRouter router;
+
+  Future<void> pump(
+    WidgetTester tester, {
+    Size size = _expanded,
+    ThemeData? theme,
+  }) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await store.write(AuthToken(value: _jwt(), expiresAt: DateTime.utc(2030)));
+
+    container = ProviderContainer(
+      overrides: <Override>[
+        googleUserRepositoryProvider.overrideWithValue(repository),
+        tokenStoreProvider.overrideWithValue(store),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(sessionControllerProvider.notifier).restore();
+
+    router = GoRouter(
+      initialLocation: '/scopes/scope-1/google-users/google-1',
+      routes: <RouteBase>[
+        GoRoute(
+          path: '/scopes/:scopeId/google-users',
+          builder: (context, state) => const Scaffold(body: Text('listing')),
+        ),
+        GoRoute(
+          path: '/scopes/:scopeId/google-users/:googleUserId',
+          builder: (context, state) => GoogleUserDetailScreen(
+            scopeId: state.pathParameters['scopeId']!,
+            googleUserId: state.pathParameters['googleUserId']!,
+          ),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(
+          theme: theme ?? buildLightTheme(),
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  void answerGetWith(Result<GoogleUser> result) {
+    when(
+      () => repository.getById(
+        scopeId: any(named: 'scopeId'),
+        id: any(named: 'id'),
+        includeDeleted: any(named: 'includeDeleted'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    repository = _MockGoogleUserRepository();
+    store = InMemoryTokenStore();
+  });
+
+  testWidgets('GivenAGoogleUser_WhenOpened_ThenTheRecordIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<GoogleUser>(_ada));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Ada Lovelace'), findsWidgets);
+    expect(find.text('1234567890'), findsOneWidget);
+  });
+
+  // AF-28e — nothing here is editable, and the screen says why.
+  testWidgets('GivenAGoogleUser_WhenOpened_ThenNothingIsEditable', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<GoogleUser>(_ada));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.byType(TextFormField), findsNothing);
+    expect(find.widgetWithText(FilledButton, 'Save changes'), findsNothing);
+  });
+
+  testWidgets('GivenAGoogleUser_WhenOpened_ThenTheReadOnlyReasonIsGiven', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<GoogleUser>(_ada));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(
+      find.textContaining('come from Google and cannot be changed here'),
+      findsOneWidget,
+    );
+  });
+
+  // AF-28d — no picture, so the initials stand in.
+  testWidgets('GivenNoPicture_WhenOpened_ThenInitialsAreShown', (tester) async {
+    // Given
+    answerGetWith(const Success<GoogleUser>(_ada));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('AL'), findsOneWidget);
+  });
+
+  testWidgets('GivenAMissingGoogleUser_WhenOpened_ThenNotFoundIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(
+      const FailureResult<GoogleUser>(
+        Failure(kind: FailureKind.notFound, errors: <String>[]),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Google user not found'), findsOneWidget);
+  });
+
+  testWidgets('GivenAMissingGoogleUser_WhenBackTapped_ThenTheListingOpens', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(
+      const FailureResult<GoogleUser>(
+        Failure(kind: FailureKind.notFound, errors: <String>[]),
+      ),
+    );
+    await pump(tester);
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Back to the listing'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('listing'), findsOneWidget);
+  });
+
+  testWidgets('GivenAForbiddenGoogleUser_WhenOpened_ThenTheRolePanelIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(
+      const FailureResult<GoogleUser>(
+        Failure(kind: FailureKind.forbidden, errors: <String>[]),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Not available for your role'), findsOneWidget);
+  });
+
+  testWidgets('GivenADeletedGoogleUser_WhenOpened_ThenItIsMarkedDeleted', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<GoogleUser>(_deleted));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.textContaining('This Google user is deleted'), findsOneWidget);
+  });
+
+  testWidgets('GivenATransportFailure_WhenOpened_ThenARetryIsOffered', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(
+      const FailureResult<GoogleUser>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.widgetWithText(TextButton, 'Retry'), findsOneWidget);
+  });
+
+  testWidgets('GivenACompactWindow_WhenRendered_ThenTheDetailIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<GoogleUser>(_ada));
+
+    // When
+    await pump(tester, size: _compact);
+
+    // Then
+    expect(find.text('ada@example.com'), findsWidgets);
+  });
+
+  testWidgets('GivenAMediumWindow_WhenRendered_ThenTheDetailIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<GoogleUser>(_ada));
+
+    // When
+    await pump(tester, size: _medium);
+
+    // Then
+    expect(find.text('ada@example.com'), findsWidgets);
+  });
+
+  testWidgets('GivenTheDarkTheme_WhenRendered_ThenTheDetailIsStillShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<GoogleUser>(_ada));
+
+    // When
+    await pump(tester, theme: buildDarkTheme());
+
+    // Then
+    expect(find.text('Ada Lovelace'), findsWidgets);
+  });
+}

--- a/test/features/google_users/presentation/google_user_list_screen_test.dart
+++ b/test/features/google_users/presentation/google_user_list_screen_test.dart
@@ -1,0 +1,454 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:heimdall_ui/app/theme.dart';
+import 'package:heimdall_ui/core/network/envelope.dart' as envelope;
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/core/storage/token_store.dart';
+import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
+import 'package:heimdall_ui/features/google_users/domain/google_user.dart';
+import 'package:heimdall_ui/features/google_users/domain/google_user_repository.dart';
+import 'package:heimdall_ui/features/google_users/presentation/google_user_list_screen.dart';
+import 'package:heimdall_ui/features/scopes/domain/scope.dart';
+import 'package:heimdall_ui/features/scopes/domain/scope_repository.dart';
+import 'package:heimdall_ui/features/scopes/presentation/scope_list_controller.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockGoogleUserRepository extends Mock implements GoogleUserRepository {}
+
+class _MockScopeRepository extends Mock implements ScopeRepository {}
+
+String _jwt() {
+  final payload = base64Url.encode(
+    utf8.encode(
+      jsonEncode(<String, dynamic>{
+        'sub': 'person-9',
+        'email': 'admin@example.com',
+        'role': 1,
+      }),
+    ),
+  );
+
+  return 'header.$payload.signature';
+}
+
+const _ada = GoogleUser(
+  id: 'google-1',
+  name: 'Ada Lovelace',
+  email: 'ada@example.com',
+  profilePictureUrl: 'https://example.invalid/ada.png',
+);
+
+const _withGoogle = Scope(
+  id: 'scope-1',
+  name: 'Acme',
+  description: 'The first tenant',
+  googleSignInEnabled: true,
+);
+
+const _withoutGoogle = Scope(
+  id: 'scope-1',
+  name: 'Acme',
+  description: 'The first tenant',
+);
+
+envelope.Page<GoogleUser> _page({
+  List<GoogleUser> items = const <GoogleUser>[_ada],
+  int pageNumber = 1,
+  int totalPages = 1,
+}) => envelope.Page<GoogleUser>(
+  items: items,
+  pageNumber: pageNumber,
+  pageSize: 20,
+  totalItems: items.length,
+  totalPages: totalPages,
+);
+
+const Size _compact = Size(400, 900);
+const Size _medium = Size(800, 900);
+const Size _expanded = Size(1400, 900);
+
+void main() {
+  late _MockGoogleUserRepository googleUsers;
+  late _MockScopeRepository scopes;
+  late InMemoryTokenStore store;
+  late ProviderContainer container;
+  late GoRouter router;
+
+  Future<void> pump(
+    WidgetTester tester, {
+    Size size = _expanded,
+    ThemeData? theme,
+  }) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await store.write(AuthToken(value: _jwt(), expiresAt: DateTime.utc(2030)));
+
+    container = ProviderContainer(
+      overrides: <Override>[
+        googleUserRepositoryProvider.overrideWithValue(googleUsers),
+        scopeRepositoryProvider.overrideWithValue(scopes),
+        tokenStoreProvider.overrideWithValue(store),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(sessionControllerProvider.notifier).restore();
+
+    router = GoRouter(
+      initialLocation: '/scopes/scope-1/google-users',
+      routes: <RouteBase>[
+        GoRoute(
+          path: '/scopes',
+          builder: (context, state) => const Scaffold(body: Text('scopes')),
+        ),
+        GoRoute(
+          path: '/scopes/:scopeId',
+          builder: (context, state) => const Scaffold(body: Text('scope')),
+        ),
+        GoRoute(
+          path: '/scopes/:scopeId/google-users',
+          builder: (context, state) =>
+              GoogleUserListScreen(scopeId: state.pathParameters['scopeId']!),
+        ),
+        GoRoute(
+          path: '/scopes/:scopeId/google-users/:googleUserId',
+          builder: (context, state) => Scaffold(
+            body: Text('detail ${state.pathParameters['googleUserId']}'),
+          ),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(
+          theme: theme ?? buildLightTheme(),
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  void answerListWith(Result<envelope.Page<GoogleUser>> result) {
+    when(
+      () => googleUsers.list(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  void answerScopeWith(Result<Scope> result) {
+    when(
+      () => scopes.getById(any(), includeDeleted: any(named: 'includeDeleted')),
+    ).thenAnswer((_) async => result);
+  }
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    googleUsers = _MockGoogleUserRepository();
+    scopes = _MockScopeRepository();
+    store = InMemoryTokenStore();
+    answerScopeWith(const Success<Scope>(_withGoogle));
+  });
+
+  testWidgets('GivenAPage_WhenOpened_ThenTheGoogleUsersAreListed', (
+    tester,
+  ) async {
+    // Given
+    answerListWith(Success<envelope.Page<GoogleUser>>(_page()));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Ada Lovelace'), findsOneWidget);
+  });
+
+  // AF-28d — a picture that cannot be fetched leaves the initials showing.
+  testWidgets('GivenAnUnreachablePicture_WhenListed_ThenInitialsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerListWith(Success<envelope.Page<GoogleUser>>(_page()));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('AL'), findsOneWidget);
+  });
+
+  testWidgets('GivenNoPicture_WhenListed_ThenInitialsAreShown', (tester) async {
+    // Given
+    answerListWith(
+      Success<envelope.Page<GoogleUser>>(
+        _page(
+          items: const <GoogleUser>[
+            GoogleUser(
+              id: 'google-1',
+              name: 'Ada Lovelace',
+              email: 'ada@example.com',
+            ),
+          ],
+        ),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('AL'), findsOneWidget);
+  });
+
+  // FR-UX-04 — a table when the window is wide, cards when it is not.
+  testWidgets('GivenAnExpandedWindow_WhenListed_ThenATableIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerListWith(Success<envelope.Page<GoogleUser>>(_page()));
+
+    // When
+    await pump(tester, size: _expanded);
+
+    // Then
+    expect(find.byType(DataTable), findsOneWidget);
+  });
+
+  testWidgets('GivenAMediumWindow_WhenListed_ThenATableIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerListWith(Success<envelope.Page<GoogleUser>>(_page()));
+
+    // When
+    await pump(tester, size: _medium);
+
+    // Then
+    expect(find.byType(DataTable), findsOneWidget);
+  });
+
+  testWidgets('GivenACompactWindow_WhenListed_ThenCardsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerListWith(Success<envelope.Page<GoogleUser>>(_page()));
+
+    // When
+    await pump(tester, size: _compact);
+
+    // Then
+    expect(find.byType(DataTable), findsNothing);
+    expect(find.byType(Card), findsOneWidget);
+  });
+
+  testWidgets('GivenAGoogleUser_WhenTapped_ThenTheirDetailOpens', (
+    tester,
+  ) async {
+    // Given
+    answerListWith(Success<envelope.Page<GoogleUser>>(_page()));
+    await pump(tester, size: _compact);
+
+    // When
+    await tester.tap(find.text('Ada Lovelace'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('detail google-1'), findsOneWidget);
+  });
+
+  // AF-28a — nobody has signed in yet, and the scope allows it.
+  testWidgets('GivenNoneAndGoogleOn_WhenListed_ThenTheReasonIsExplained', (
+    tester,
+  ) async {
+    // Given
+    answerListWith(
+      Success<envelope.Page<GoogleUser>>(_page(items: const <GoogleUser>[])),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('No Google users yet'), findsOneWidget);
+    expect(find.textContaining('Nobody has yet'), findsOneWidget);
+  });
+
+  // AF-28a — the scope has the feature off, which is why nobody could have.
+  testWidgets('GivenNoneAndGoogleOff_WhenListed_ThenTheScopeIsLinked', (
+    tester,
+  ) async {
+    // Given
+    answerListWith(
+      Success<envelope.Page<GoogleUser>>(_page(items: const <GoogleUser>[])),
+    );
+    answerScopeWith(const Success<Scope>(_withoutGoogle));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.textContaining('switched off, so nobody can'), findsOneWidget);
+    expect(find.widgetWithText(FilledButton, 'Scope settings'), findsOneWidget);
+  });
+
+  testWidgets('GivenGoogleOff_WhenScopeSettingsTapped_ThenTheScopeOpens', (
+    tester,
+  ) async {
+    // Given
+    answerListWith(
+      Success<envelope.Page<GoogleUser>>(_page(items: const <GoogleUser>[])),
+    );
+    answerScopeWith(const Success<Scope>(_withoutGoogle));
+    await pump(tester);
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Scope settings'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('scope'), findsOneWidget);
+  });
+
+  // AF-28a — a search that matched nothing is not the same thing.
+  testWidgets('GivenNoMatches_WhenSearched_ThenClearingIsOffered', (
+    tester,
+  ) async {
+    // Given
+    answerListWith(
+      Success<envelope.Page<GoogleUser>>(_page(items: const <GoogleUser>[])),
+    );
+    await pump(tester);
+
+    // When
+    await tester.enterText(
+      find.widgetWithText(TextField, 'Search by name'),
+      'nobody',
+    );
+    await tester.tap(find.widgetWithText(FilledButton, 'Search'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('No Google users matched'), findsOneWidget);
+  });
+
+  // AF-28b — the returned errors, with a retry.
+  testWidgets('GivenARefusedListing_WhenOpened_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerListWith(
+      const FailureResult<envelope.Page<GoogleUser>>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['Page size is too large.'],
+        ),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Page size is too large.'), findsOneWidget);
+  });
+
+  testWidgets('GivenATransportFailure_WhenOpened_ThenARetryIsOffered', (
+    tester,
+  ) async {
+    // Given
+    answerListWith(
+      const FailureResult<envelope.Page<GoogleUser>>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.widgetWithText(TextButton, 'Retry'), findsOneWidget);
+  });
+
+  // AF-28c — a scope this admin does not own.
+  testWidgets('GivenAForbiddenScope_WhenOpened_ThenTheRolePanelIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerListWith(
+      const FailureResult<envelope.Page<GoogleUser>>(
+        Failure(kind: FailureKind.forbidden, errors: <String>[]),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Not available for your role'), findsOneWidget);
+  });
+
+  testWidgets('GivenIncludeDeleted_WhenToggled_ThenTheFlagIsSent', (
+    tester,
+  ) async {
+    // Given
+    answerListWith(Success<envelope.Page<GoogleUser>>(_page()));
+    await pump(tester);
+
+    // When
+    await tester.tap(find.byType(Switch));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => googleUsers.list(
+        scopeId: 'scope-1',
+        name: '',
+        email: '',
+        includeDeleted: true,
+        pageNumber: 1,
+      ),
+    ).called(1);
+  });
+
+  // AF-28e — there is nothing to create here, so nothing offers to.
+  testWidgets('GivenTheListing_WhenRendered_ThenNoCreateControlIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerListWith(Success<envelope.Page<GoogleUser>>(_page()));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.byType(FloatingActionButton), findsNothing);
+  });
+
+  testWidgets('GivenTheDarkTheme_WhenListed_ThenTheGoogleUsersAreStillShown', (
+    tester,
+  ) async {
+    // Given
+    answerListWith(Success<envelope.Page<GoogleUser>>(_page()));
+
+    // When
+    await pump(tester, theme: buildDarkTheme());
+
+    // Then
+    expect(find.text('Ada Lovelace'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #28

Implements UI-28 — `/scopes/:scopeId/google-users` and its detail, over `GET /api/scopes/{scopeId}/google-users` (FR-GU-01) and `GET /api/scopes/{scopeId}/google-users/{id}` (FR-GU-02).

## Flows

| Flow | How it is handled |
| --- | --- |
| Main | The page is read on open; opening a row reads and shows the full record. |
| AF-28a | The empty state explains that a Google user appears only once somebody signs in — and when the scope has Google Sign-In off, says that is why and links to the scope. |
| AF-28b | The returned errors, or a retry for a transport failure. |
| AF-28c | A `403` shows the not-available-for-your-role panel. |
| AF-28d | A missing or unreachable picture falls back to an initials avatar. |
| AF-28e | Nothing is editable, and the detail says why. |

## `GoogleAvatar` (FR-GU-03)

The initials are drawn underneath and the picture covers them when it loads, so an image that never loads needs no error path of its own — a missing picture and an unreachable one look the same to the reader, which is what AF-28d asks for.

The initials read **runes**, not code units, so a name beginning with an emoji or any other non-BMP character is not cut in half. Its unit test covers that along with the empty, one-word, three-word, extra-whitespace, lowercase and no-name-at-all cases.

## Verification

`dart format --set-exit-if-changed .`, `flutter analyze`, and `flutter test` all pass — **828 tests**, 37 of them new. No presentation file imports `package:heimdall_api_client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)