### PR TITLE
feat(ui-29): delete a Google user, logically and permanently

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ the board is where an item's status changes as it moves.
 | Use case | Status | Issue |
 | --- | --- | --- |
 | UI-28: Browse and view Google users | ✅ | [#28](https://github.com/artur-rios/heimdall-ui/issues/28) |
-| UI-29: Delete a Google user, logically and permanently | ⬜ | [#29](https://github.com/artur-rios/heimdall-ui/issues/29) |
+| UI-29: Delete a Google user, logically and permanently | ✅ | [#29](https://github.com/artur-rios/heimdall-ui/issues/29) |
 
 ### Platform
 

--- a/lib/features/google_users/data/google_user_repository_impl.dart
+++ b/lib/features/google_users/data/google_user_repository_impl.dart
@@ -127,6 +127,50 @@ class ApiGoogleUserRepository implements GoogleUserRepository {
     }
   }
 
+  @override
+  Future<Result<void>> delete({
+    required String scopeId,
+    required String id,
+  }) async {
+    try {
+      final response = await _client.googleUserDelete(scopeId: scopeId, id: id);
+
+      // AF-29b: the API refuses a record it will not delete, and its own
+      // strings say why.
+      return _acknowledgement(response.success, response.errors);
+    } on DioException catch (error) {
+      return FailureResult<void>(failureFromDioException(error));
+    }
+  }
+
+  @override
+  Future<Result<void>> hardDelete({
+    required String scopeId,
+    required String id,
+  }) async {
+    try {
+      final response = await _client.googleUserHardDelete(
+        scopeId: scopeId,
+        id: id,
+      );
+
+      return _acknowledgement(response.success, response.errors);
+    } on DioException catch (error) {
+      return FailureResult<void>(failureFromDioException(error));
+    }
+  }
+
+  /// A command whose only interesting answer is whether it worked.
+  static Result<void> _acknowledgement(bool? success, List<String>? errors) =>
+      success == true
+      ? const Success<void>(null)
+      : FailureResult<void>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: errors ?? const <String>[],
+          ),
+        );
+
   static String? _filter(String? value) =>
       (value?.trim().isEmpty ?? true) ? null : value!.trim();
 }

--- a/lib/features/google_users/domain/google_user_repository.dart
+++ b/lib/features/google_users/domain/google_user_repository.dart
@@ -35,6 +35,17 @@ abstract interface class GoogleUserRepository {
     required String id,
     bool includeDeleted = true,
   });
+
+  /// Logically deletes a Google User. The record is kept and the API can
+  /// restore it.
+  Future<Result<void>> delete({required String scopeId, required String id});
+
+  /// Permanently deletes a Google User. Only a System Admin may, which is why
+  /// UI-29 shows the control to nobody else.
+  Future<Result<void>> hardDelete({
+    required String scopeId,
+    required String id,
+  });
 }
 
 /// Overridden at start-up with the client-backed implementation, and in tests

--- a/lib/features/google_users/presentation/google_user_detail_controller.dart
+++ b/lib/features/google_users/presentation/google_user_detail_controller.dart
@@ -41,14 +41,42 @@ final class GoogleUserDetailUnavailable extends GoogleUserDetailState {
   bool get isForbidden => failure.kind == FailureKind.forbidden;
 }
 
+/// The Google User is gone, and the screen returns to the listing.
+final class GoogleUserDeleted extends GoogleUserDetailState {
+  const GoogleUserDeleted();
+}
+
 /// The record is on screen.
 ///
 /// AF-28e: there is nothing to save here. Every field comes from Google, so
-/// the state carries no editing of any kind.
+/// the only thing this state carries beyond the record is the deletion.
 final class GoogleUserDetailLoaded extends GoogleUserDetailState {
-  const GoogleUserDetailLoaded(this.user);
+  const GoogleUserDetailLoaded(
+    this.user, {
+    this.deleting = false,
+    this.deleteFailure,
+  });
 
   final GoogleUser user;
+
+  /// A deletion is on its way. Both controls are disabled while it is.
+  final bool deleting;
+
+  /// AF-29b — the API refused to delete, and the record stays open.
+  final Failure? deleteFailure;
+
+  GoogleUserDetailLoaded copyWith({
+    GoogleUser? user,
+    bool? deleting,
+    Failure? deleteFailure,
+    bool clearDeleteFailure = false,
+  }) => GoogleUserDetailLoaded(
+    user ?? this.user,
+    deleting: deleting ?? this.deleting,
+    deleteFailure: clearDeleteFailure
+        ? null
+        : (deleteFailure ?? this.deleteFailure),
+  );
 }
 
 final NotifierProviderFamily<
@@ -81,5 +109,43 @@ class GoogleUserDetailController
       onSuccess: GoogleUserDetailLoaded.new,
       onFailure: GoogleUserDetailUnavailable.new,
     );
+  }
+
+  /// Logically deletes the Google User. The record is kept and the API can
+  /// restore it, which is what the confirmation says before this is called.
+  Future<void> delete() => _delete(
+    (repository) =>
+        repository.delete(scopeId: arg.scopeId, id: arg.googleUserId),
+  );
+
+  /// Permanently deletes the Google User.
+  Future<void> deletePermanently() => _delete(
+    (repository) =>
+        repository.hardDelete(scopeId: arg.scopeId, id: arg.googleUserId),
+  );
+
+  Future<void> _delete(
+    Future<Result<void>> Function(GoogleUserRepository repository) send,
+  ) async {
+    final current = state;
+
+    if (current is! GoogleUserDetailLoaded || current.deleting) {
+      return;
+    }
+
+    state = current.copyWith(deleting: true, clearDeleteFailure: true);
+
+    final result = await send(ref.read(googleUserRepositoryProvider));
+
+    switch (result) {
+      case Success<void>():
+        state = const GoogleUserDeleted();
+      case FailureResult<void>(:final failure):
+        // Somebody already deleted them, which is the outcome that was asked
+        // for.
+        state = failure.kind == FailureKind.notFound
+            ? const GoogleUserDeleted()
+            : current.copyWith(deleting: false, deleteFailure: failure);
+    }
   }
 }

--- a/lib/features/google_users/presentation/google_user_detail_screen.dart
+++ b/lib/features/google_users/presentation/google_user_detail_screen.dart
@@ -3,10 +3,16 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../shared/layout/app_shell.dart';
+import '../../../core/result/result.dart';
 import '../../../shared/widgets/collection_states.dart';
+import '../../../shared/widgets/confirm_dialog.dart';
+import '../../../shared/widgets/failure_banner.dart';
+import '../../auth/domain/session.dart';
+import '../../auth/presentation/session_controller.dart';
 import '../domain/google_user.dart';
 import 'google_avatar.dart';
 import 'google_user_detail_controller.dart';
+import 'google_user_list_controller.dart';
 
 /// UI-28 — one Google user, read-only.
 ///
@@ -47,6 +53,19 @@ class _GoogleUserDetailScreenState
     );
     final backToListing = '/scopes/${widget.scopeId}/google-users';
 
+    // A deleted Google user returns to the listing, which is now stale.
+    ref.listen<GoogleUserDetailState>(
+      googleUserDetailControllerProvider(_ref),
+      (previous, next) {
+        if (next is GoogleUserDeleted) {
+          ref
+              .read(googleUserListControllerProvider(widget.scopeId).notifier)
+              .load();
+          context.go(backToListing);
+        }
+      },
+    );
+
     return AppShell(
       currentRoute: '/scopes',
       title: Text(switch (state) {
@@ -86,13 +105,67 @@ class _GoogleUserDetailScreenState
           failure: failure,
           onRetry: controller.load,
         ),
-        GoogleUserDetailLoaded(:final user) => _detail(user),
+        // The listing is where a deleted record leaves the user; this is the
+        // frame in between.
+        GoogleUserDeleted() => const Center(child: CircularProgressIndicator()),
+        final GoogleUserDetailLoaded loaded => _detail(loaded),
       },
     );
   }
 
-  Widget _detail(GoogleUser user) {
+  /// AF-29d — only a System Admin erases a Google user permanently.
+  bool get _maySeeHardDelete {
+    final session = ref.watch(sessionControllerProvider);
+
+    return session is Authenticated && session.principal.isSystemAdmin;
+  }
+
+  /// AF-29a — a dialog the user closes sends nothing.
+  ///
+  /// AF-29e: deleting the record does not stop the person signing in again,
+  /// which the message says rather than letting it be assumed otherwise.
+  Future<void> _confirmDelete(GoogleUser user) async {
+    final confirmed = await showConfirm(
+      context: context,
+      title: 'Delete ${user.name}?',
+      message:
+          '${user.name} will be marked deleted. The record is kept and '
+          'the API can restore it. While this scope has Google Sign-In on, '
+          'they can sign in again and a new record will appear.',
+      confirmLabel: 'Delete',
+    );
+
+    if (confirmed && mounted) {
+      await ref
+          .read(googleUserDetailControllerProvider(_ref).notifier)
+          .delete();
+    }
+  }
+
+  /// AF-29c — the confirm control stays disabled until the address matches.
+  Future<void> _confirmDeletePermanently(GoogleUser user) async {
+    final confirmed = await showTypeToConfirm(
+      context: context,
+      title: 'Delete ${user.name} permanently?',
+      message:
+          'Their record is erased. This cannot be undone — though while '
+          'this scope has Google Sign-In on, they can sign in again and a new '
+          'record will appear. Type their email address to confirm:',
+      confirmationValue: user.email,
+      fieldLabel: 'Email address',
+      confirmLabel: 'Delete permanently',
+    );
+
+    if (confirmed && mounted) {
+      await ref
+          .read(googleUserDetailControllerProvider(_ref).notifier)
+          .deletePermanently();
+    }
+  }
+
+  Widget _detail(GoogleUserDetailLoaded state) {
     final theme = Theme.of(context);
+    final user = state.user;
 
     return SingleChildScrollView(
       padding: const EdgeInsets.all(24),
@@ -162,8 +235,100 @@ class _GoogleUserDetailScreenState
                   ),
                 ),
               ),
+              // A deleted record has nothing left to delete.
+              if (!user.isDeleted) ...<Widget>[
+                const SizedBox(height: 24),
+                _DangerZone(
+                  user: user,
+                  deleting: state.deleting,
+                  failure: state.deleteFailure,
+                  mayDeletePermanently: _maySeeHardDelete,
+                  onDelete: _confirmDelete,
+                  onDeletePermanently: _confirmDeletePermanently,
+                ),
+              ],
             ],
           ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The two deletions, kept apart from the rest of the screen because neither
+/// is an ordinary edit.
+class _DangerZone extends StatelessWidget {
+  const _DangerZone({
+    required this.user,
+    required this.deleting,
+    required this.failure,
+    required this.mayDeletePermanently,
+    required this.onDelete,
+    required this.onDeletePermanently,
+  });
+
+  final GoogleUser user;
+  final bool deleting;
+  final Failure? failure;
+
+  /// AF-29d — a Scope Admin never sees the permanent deletion.
+  final bool mayDeletePermanently;
+
+  final Future<void> Function(GoogleUser user) onDelete;
+  final Future<void> Function(GoogleUser user) onDeletePermanently;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Card(
+      color: theme.colorScheme.errorContainer,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              'Delete this Google user',
+              style: theme.textTheme.titleMedium?.copyWith(
+                color: theme.colorScheme.onErrorContainer,
+              ),
+            ),
+            const SizedBox(height: 8),
+            // AF-29e — deleting is not a way to keep somebody out, and saying
+            // so here is what stops it being used as one.
+            Text(
+              'Deleting keeps the record and can be undone by the API; '
+              'deleting permanently erases it. Neither stops them signing in '
+              'again while this scope has Google Sign-In on.',
+              style: TextStyle(color: theme.colorScheme.onErrorContainer),
+            ),
+            // AF-29b — the API refused, and the record is still open.
+            if (failure case final refusal?) ...<Widget>[
+              const SizedBox(height: 16),
+              ErrorBanner(failure: refusal),
+            ],
+            const SizedBox(height: 16),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: <Widget>[
+                OutlinedButton.icon(
+                  onPressed: deleting ? null : () => onDelete(user),
+                  icon: const Icon(Icons.delete_outline),
+                  label: const Text('Delete Google user'),
+                ),
+                if (mayDeletePermanently)
+                  FilledButton.icon(
+                    onPressed: deleting
+                        ? null
+                        : () => onDeletePermanently(user),
+                    icon: const Icon(Icons.delete_forever_outlined),
+                    label: const Text('Delete permanently'),
+                  ),
+              ],
+            ),
+          ],
         ),
       ),
     );

--- a/test/features/google_users/presentation/google_user_detail_screen_test.dart
+++ b/test/features/google_users/presentation/google_user_detail_screen_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:heimdall_ui/app/theme.dart';
+import 'package:heimdall_ui/core/network/envelope.dart' as envelope;
 import 'package:heimdall_ui/core/result/result.dart';
 import 'package:heimdall_ui/core/storage/token_store.dart';
 import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
@@ -16,13 +17,14 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockGoogleUserRepository extends Mock implements GoogleUserRepository {}
 
-String _jwt() {
+/// A token naming a person of [role]: 1 System Admin, 2 Scope Admin.
+String _jwt({int role = 1}) {
   final payload = base64Url.encode(
     utf8.encode(
       jsonEncode(<String, dynamic>{
         'sub': 'person-9',
         'email': 'admin@example.com',
-        'role': 1,
+        'role': role,
       }),
     ),
   );
@@ -60,12 +62,18 @@ void main() {
     WidgetTester tester, {
     Size size = _expanded,
     ThemeData? theme,
+    int role = 1,
   }) async {
     tester.view.physicalSize = size;
     tester.view.devicePixelRatio = 1;
     addTearDown(tester.view.reset);
 
-    await store.write(AuthToken(value: _jwt(), expiresAt: DateTime.utc(2030)));
+    await store.write(
+      AuthToken(
+        value: _jwt(role: role),
+        expiresAt: DateTime.utc(2030),
+      ),
+    );
 
     container = ProviderContainer(
       overrides: <Override>[
@@ -114,6 +122,52 @@ void main() {
         includeDeleted: any(named: 'includeDeleted'),
       ),
     ).thenAnswer((_) async => result);
+  }
+
+  /// The deletion controls sit at the bottom of a scrolling detail, so they
+  /// are not on screen until the view is brought to them.
+  Future<void> tapAfterScrolling(WidgetTester tester, Finder finder) async {
+    await tester.ensureVisible(finder);
+    await tester.pumpAndSettle();
+    await tester.tap(finder);
+    await tester.pumpAndSettle();
+  }
+
+  void answerDeleteWith(Result<void> result) {
+    when(
+      () => repository.delete(
+        scopeId: any(named: 'scopeId'),
+        id: any(named: 'id'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  void answerHardDeleteWith(Result<void> result) {
+    when(
+      () => repository.hardDelete(
+        scopeId: any(named: 'scopeId'),
+        id: any(named: 'id'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  /// The listing behind the detail is reloaded after a deletion; what it
+  /// answers does not matter here, only that it answers.
+  void answerListWith() {
+    when(
+      () => repository.list(
+        scopeId: any(named: 'scopeId'),
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        includeDeleted: any(named: 'includeDeleted'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer(
+      (_) async => const FailureResult<envelope.Page<GoogleUser>>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
   }
 
   setUp(() {
@@ -299,5 +353,291 @@ void main() {
 
     // Then
     expect(find.text('Ada Lovelace'), findsWidgets);
+  });
+
+  testWidgets('GivenASystemAdmin_WhenOpened_ThenBothDeletionsAreOffered', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<GoogleUser>(_ada));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(
+      find.widgetWithText(OutlinedButton, 'Delete Google user'),
+      findsOneWidget,
+    );
+    expect(
+      find.widgetWithText(FilledButton, 'Delete permanently'),
+      findsOneWidget,
+    );
+  });
+
+  // AF-29d — a Scope Admin never sees the permanent deletion.
+  testWidgets('GivenAScopeAdmin_WhenOpened_ThenOnlyTheLogicalOneIsOffered', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<GoogleUser>(_ada));
+
+    // When
+    await pump(tester, role: 2);
+
+    // Then
+    expect(
+      find.widgetWithText(OutlinedButton, 'Delete Google user'),
+      findsOneWidget,
+    );
+    expect(
+      find.widgetWithText(FilledButton, 'Delete permanently'),
+      findsNothing,
+    );
+  });
+
+  testWidgets('GivenADeletedGoogleUser_WhenOpened_ThenDeletionIsNotOffered', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<GoogleUser>(_deleted));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(
+      find.widgetWithText(OutlinedButton, 'Delete Google user'),
+      findsNothing,
+    );
+  });
+
+  // AF-29e — deleting is not a way to keep somebody out, and the screen says
+  // so before the dialog is even opened.
+  testWidgets('GivenTheDangerZone_WhenRendered_ThenSignInAgainIsExplained', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<GoogleUser>(_ada));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(
+      find.textContaining('Neither stops them signing in again'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('GivenTheDeleteControl_WhenTapped_ThenConfirmationIsAsked', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<GoogleUser>(_ada));
+    await pump(tester);
+
+    // When
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(OutlinedButton, 'Delete Google user'),
+    );
+
+    // Then
+    expect(find.text('Delete Ada Lovelace?'), findsOneWidget);
+  });
+
+  // AF-29e — and again in the dialog itself.
+  testWidgets('GivenTheDeleteDialog_WhenOpened_ThenSignInAgainIsExplained', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<GoogleUser>(_ada));
+    await pump(tester);
+
+    // When
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(OutlinedButton, 'Delete Google user'),
+    );
+
+    // Then
+    expect(find.textContaining('they can sign in again'), findsOneWidget);
+  });
+
+  testWidgets('GivenAConfirmedDeletion_WhenConfirmed_ThenTheyAreDeleted', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<GoogleUser>(_ada));
+    answerDeleteWith(const Success<void>(null));
+    answerListWith();
+    await pump(tester);
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(OutlinedButton, 'Delete Google user'),
+    );
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => repository.delete(scopeId: 'scope-1', id: 'google-1'),
+    ).called(1);
+  });
+
+  testWidgets('GivenADeletedGoogleUser_WhenDeleted_ThenTheListingOpens', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<GoogleUser>(_ada));
+    answerDeleteWith(const Success<void>(null));
+    answerListWith();
+    await pump(tester);
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(OutlinedButton, 'Delete Google user'),
+    );
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('listing'), findsOneWidget);
+  });
+
+  // AF-29a — the dialog closes and nothing is sent.
+  testWidgets('GivenTheDeleteDialog_WhenCancelled_ThenNothingIsSent', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<GoogleUser>(_ada));
+    answerDeleteWith(const Success<void>(null));
+    await pump(tester);
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(OutlinedButton, 'Delete Google user'),
+    );
+
+    // When
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verifyNever(
+      () => repository.delete(
+        scopeId: any(named: 'scopeId'),
+        id: any(named: 'id'),
+      ),
+    );
+  });
+
+  // AF-29b — the API refused, and the record stays open.
+  testWidgets('GivenARefusedDeletion_WhenConfirmed_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<GoogleUser>(_ada));
+    answerDeleteWith(
+      const FailureResult<void>(
+        Failure(
+          kind: FailureKind.validation,
+          errors: <String>['That Google user cannot be deleted.'],
+        ),
+      ),
+    );
+    await pump(tester);
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(OutlinedButton, 'Delete Google user'),
+    );
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.text('That Google user cannot be deleted.'), findsOneWidget);
+  });
+
+  // AF-29c — the confirm control stays disabled until the address matches.
+  testWidgets('GivenTheHardDeleteDialog_WhenOpened_ThenConfirmIsDisabled', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<GoogleUser>(_ada));
+    await pump(tester);
+
+    // When
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(FilledButton, 'Delete permanently'),
+    );
+
+    // Then
+    expect(
+      tester
+          .widget<FilledButton>(
+            find.widgetWithText(FilledButton, 'Delete permanently').last,
+          )
+          .onPressed,
+      isNull,
+    );
+  });
+
+  testWidgets('GivenAMistypedEmail_WhenTyped_ThenConfirmStaysDisabled', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<GoogleUser>(_ada));
+    await pump(tester);
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(FilledButton, 'Delete permanently'),
+    );
+
+    // When
+    await tester.enterText(find.byType(TextField).last, 'ADA@example.com');
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(
+      tester
+          .widget<FilledButton>(
+            find.widgetWithText(FilledButton, 'Delete permanently').last,
+          )
+          .onPressed,
+      isNull,
+    );
+  });
+
+  testWidgets('GivenTheTypedEmail_WhenItMatches_ThenTheyAreErased', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<GoogleUser>(_ada));
+    answerHardDeleteWith(const Success<void>(null));
+    answerListWith();
+    await pump(tester);
+    await tapAfterScrolling(
+      tester,
+      find.widgetWithText(FilledButton, 'Delete permanently'),
+    );
+    await tester.enterText(find.byType(TextField).last, 'ada@example.com');
+    await tester.pumpAndSettle();
+
+    // When
+    await tester.tap(
+      find.widgetWithText(FilledButton, 'Delete permanently').last,
+    );
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => repository.hardDelete(scopeId: 'scope-1', id: 'google-1'),
+    ).called(1);
   });
 }


### PR DESCRIPTION
Closes #29

Implements UI-29 — both deletions from the Google user detail, over `DELETE /api/scopes/{scopeId}/google-users/{id}` (FR-GU-04) and its `/hard` counterpart (FR-GU-05).

## Flows

| Flow | How it is handled |
| --- | --- |
| Main — logical | A dialog names them and says the record is kept; on success the listing reopens. |
| Main — permanent | A dialog requires their email address to be typed. |
| AF-29a | Closing either dialog sends nothing. |
| AF-29b | A refusal shows the API's strings and leaves the record open. |
| AF-29c | The confirm control stays disabled until the address matches exactly. |
| AF-29d | Only a System Admin is shown the permanent deletion. |
| AF-29e | Both dialogs, and the section itself, say they can sign in again. |

**On AF-29e:** deleting a Google user is not a way to keep somebody out — while the scope has Google Sign-In on they can sign in again and a new record appears. That is stated in the section before either dialog opens, and again inside each dialog, because it is the one thing about this action that is easy to get wrong. It is also why UI-15's toggle sits on the scope this screen came from.

## Verification

`dart format --set-exit-if-changed .`, `flutter analyze`, and `flutter test` all pass — **841 tests**, 13 of them new. No presentation file imports `package:heimdall_api_client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)