### PR TITLE
feat(p-04): API health and diagnostics screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ Not use cases, tracked separately.
 | P-01: Project scaffolding and initial infrastructure | ✅ | [#30](https://github.com/artur-rios/heimdall-ui/issues/30) |
 | P-02: Generated API client and specification drift check | ✅ | [#31](https://github.com/artur-rios/heimdall-ui/issues/31) |
 | P-03: Multi-platform build and release pipelines | ✅ | [#32](https://github.com/artur-rios/heimdall-ui/issues/32) |
-| P-04: API health and diagnostics screen | ⬜ | [#33](https://github.com/artur-rios/heimdall-ui/issues/33) |
+| P-04: API health and diagnostics screen | ✅ | [#33](https://github.com/artur-rios/heimdall-ui/issues/33) |
 
 The sign-in and home screens exist as part of P-01, so the shell is reachable at all. UI-01 and UI-07
 complete them with their alternative flows; every other screen arrives with its own use case, and

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -12,6 +12,7 @@ import '../features/auth/presentation/password_reset_screen.dart';
 import '../features/auth/presentation/session_controller.dart';
 import '../features/auth/presentation/two_factor_screen.dart';
 import '../features/auth/presentation/verify_email_screen.dart';
+import '../features/health/presentation/health_screen.dart';
 import '../features/home/presentation/home_screen.dart';
 import '../features/google_users/presentation/google_user_detail_screen.dart';
 import '../features/google_users/presentation/google_user_list_screen.dart';
@@ -209,6 +210,10 @@ final Provider<GoRouter> routerProvider = Provider<GoRouter>((ref) {
           scopeId: state.pathParameters['scopeId']!,
           personId: state.pathParameters['personId']!,
         ),
+      ),
+      GoRoute(
+        path: '/health',
+        builder: (context, state) => const HealthScreen(),
       ),
       GoRoute(
         path: '/not-available',

--- a/lib/features/health/data/health_repository_impl.dart
+++ b/lib/features/health/data/health_repository_impl.dart
@@ -1,0 +1,86 @@
+import 'package:dio/dio.dart';
+import 'package:heimdall_api_client/export.dart';
+
+import '../../../core/network/envelope.dart';
+import '../../../core/result/result.dart';
+import '../domain/health.dart';
+import '../domain/health_repository.dart';
+
+/// [HealthRepository] over the generated client.
+class ApiHealthRepository implements HealthRepository {
+  const ApiHealthRepository(this._client);
+
+  final HealthCheckClient _client;
+
+  @override
+  Future<Result<String>> ping() async {
+    try {
+      final response = await _client.healthCheckHelloWorld();
+
+      if (response.success != true) {
+        return FailureResult<String>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: response.errors ?? const <String>[],
+          ),
+        );
+      }
+
+      // Whatever it said is the answer; that it answered is the point.
+      return Success<String>(response.data ?? 'The API answered.');
+    } on DioException catch (error) {
+      return FailureResult<String>(failureFromDioException(error));
+    }
+  }
+
+  @override
+  Future<Result<Health>> detailed() async {
+    try {
+      final response = await _client.healthCheckDetailed();
+
+      return _healthFrom(response);
+    } on DioException catch (error) {
+      // A `503` is the API reporting itself unhealthy rather than failing to
+      // answer, and its body carries the report — so it is read rather than
+      // turned into a bare failure.
+      if (error.response?.statusCode == 503) {
+        final body = error.response?.data;
+
+        if (body is Map<String, dynamic>) {
+          return _healthFrom(HealthCheckOutputDataOutput.fromJson(body));
+        }
+      }
+
+      // A `403` for a Scope Admin arrives here, and its kind is what lets the
+      // screen call it an expected refusal rather than a fault.
+      return FailureResult<Health>(failureFromDioException(error));
+    }
+  }
+
+  Result<Health> _healthFrom(HealthCheckOutputDataOutput response) {
+    final data = response.data;
+
+    if (data == null) {
+      return FailureResult<Health>(
+        Failure(
+          kind: FailureKind.unknown,
+          errors: response.errors ?? const <String>[],
+        ),
+      );
+    }
+
+    return Success<Health>(
+      Health(
+        status: data.status ?? 'Unknown',
+        services: (data.services ?? const <ServiceHealthOutput>[])
+            .map(
+              (service) => ServiceHealth(
+                name: service.name ?? 'Unnamed service',
+                status: service.status ?? 'Unknown',
+              ),
+            )
+            .toList(growable: false),
+      ),
+    );
+  }
+}

--- a/lib/features/health/domain/health.dart
+++ b/lib/features/health/domain/health.dart
@@ -1,0 +1,35 @@
+/// One service the API checks, and what it reported.
+class ServiceHealth {
+  const ServiceHealth({required this.name, required this.status});
+
+  final String name;
+
+  /// The API's own word for the state. It is not an enum here on purpose: the
+  /// API may add a state, and a screen that renders whatever it was told stays
+  /// truthful when it does.
+  final String status;
+
+  /// Whether the status reads as healthy.
+  ///
+  /// Only the display leans on this — the colour of a chip — so a word this
+  /// does not recognise is shown as it came rather than being called a
+  /// failure.
+  bool get isHealthy => status.toLowerCase() == 'healthy';
+}
+
+/// The API's detailed health report.
+class Health {
+  const Health({required this.status, this.services = const <ServiceHealth>[]});
+
+  /// The aggregate the API computed across its services.
+  final String status;
+
+  final List<ServiceHealth> services;
+
+  bool get isHealthy => status.toLowerCase() == 'healthy';
+
+  /// The services the API reported as anything other than healthy, which is
+  /// what an operator is looking for first.
+  List<ServiceHealth> get unhealthy =>
+      services.where((service) => !service.isHealthy).toList(growable: false);
+}

--- a/lib/features/health/domain/health_repository.dart
+++ b/lib/features/health/domain/health_repository.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/result/result.dart';
+import 'health.dart';
+
+/// The health operations the interface depends on.
+abstract interface class HealthRepository {
+  /// The liveness check, which anyone may call.
+  ///
+  /// Returns whatever the API answered with, because the point of a liveness
+  /// check is that it answered at all.
+  Future<Result<String>> ping();
+
+  /// The detailed report, which only a System Admin may read.
+  ///
+  /// A `403` for a Scope Admin is the expected answer rather than a fault, and
+  /// the screen says so.
+  Future<Result<Health>> detailed();
+}
+
+/// Overridden at start-up with the client-backed implementation, and in tests
+/// with a fake.
+final Provider<HealthRepository> healthRepositoryProvider =
+    Provider<HealthRepository>(
+      (ref) => throw UnimplementedError(
+        'healthRepositoryProvider must be overridden',
+      ),
+    );

--- a/lib/features/health/presentation/health_controller.dart
+++ b/lib/features/health/presentation/health_controller.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/result/result.dart';
+import '../domain/health.dart';
+import '../domain/health_repository.dart';
+
+/// What the health screen knows.
+///
+/// The two checks are independent: the liveness one anybody may call, the
+/// detailed one only a System Admin may. Either can answer while the other
+/// does not, and the screen shows whichever it has.
+class HealthState {
+  const HealthState({
+    this.checking = false,
+    this.liveness,
+    this.livenessFailure,
+    this.detailed,
+    this.detailedFailure,
+  });
+
+  /// Both checks are in flight. The refresh control is disabled while they
+  /// are, so a fast second tap cannot double the requests.
+  final bool checking;
+
+  /// What the liveness check answered with.
+  final String? liveness;
+  final Failure? livenessFailure;
+
+  final Health? detailed;
+  final Failure? detailedFailure;
+
+  /// Whether the detailed report was refused because of who is asking, which
+  /// is the expected answer for a Scope Admin rather than a fault.
+  bool get detailedForbidden =>
+      detailedFailure?.kind == FailureKind.forbidden ||
+      detailedFailure?.kind == FailureKind.unauthorized;
+
+  /// Whether anything has been asked for yet.
+  bool get isEmpty =>
+      liveness == null &&
+      livenessFailure == null &&
+      detailed == null &&
+      detailedFailure == null;
+}
+
+final NotifierProvider<HealthController, HealthState> healthControllerProvider =
+    NotifierProvider<HealthController, HealthState>(HealthController.new);
+
+/// Owns the two health checks and the refresh that repeats them.
+class HealthController extends Notifier<HealthState> {
+  @override
+  HealthState build() => const HealthState();
+
+  /// Runs both checks.
+  ///
+  /// They go together rather than in sequence: neither depends on the other,
+  /// and an operator asking "is it up" wants both answers at once.
+  Future<void> check() async {
+    if (state.checking) {
+      return;
+    }
+
+    state = HealthState(checking: true, liveness: state.liveness);
+
+    final repository = ref.read(healthRepositoryProvider);
+    final results = await Future.wait<Object>(<Future<Object>>[
+      repository.ping(),
+      repository.detailed(),
+    ]);
+
+    final liveness = results[0] as Result<String>;
+    final detailed = results[1] as Result<Health>;
+
+    state = HealthState(
+      liveness: liveness.valueOrNull,
+      livenessFailure: liveness.failureOrNull,
+      detailed: detailed.valueOrNull,
+      detailedFailure: detailed.failureOrNull,
+    );
+  }
+}

--- a/lib/features/health/presentation/health_screen.dart
+++ b/lib/features/health/presentation/health_screen.dart
@@ -1,0 +1,235 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/result/result.dart';
+import '../../../shared/layout/app_shell.dart';
+import '../../../shared/widgets/failure_banner.dart';
+import 'health_controller.dart';
+
+/// P-04 — whether the API is up, and what it says about itself.
+class HealthScreen extends ConsumerStatefulWidget {
+  const HealthScreen({super.key});
+
+  @override
+  ConsumerState<HealthScreen> createState() => _HealthScreenState();
+}
+
+class _HealthScreenState extends ConsumerState<HealthScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => ref.read(healthControllerProvider.notifier).check(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final state = ref.watch(healthControllerProvider);
+
+    return AppShell(
+      currentRoute: '/health',
+      title: const Text('Health'),
+      actions: <Widget>[
+        IconButton(
+          tooltip: 'Check again',
+          icon: const Icon(Icons.refresh),
+          onPressed: state.checking
+              ? null
+              : () => ref.read(healthControllerProvider.notifier).check(),
+        ),
+      ],
+      body: ListView(
+        padding: const EdgeInsets.all(24),
+        children: <Widget>[
+          if (state.checking && state.isEmpty)
+            const LinearProgressIndicator()
+          else ...<Widget>[
+            _LivenessCard(
+              answer: state.liveness,
+              failure: state.livenessFailure,
+            ),
+            const SizedBox(height: 16),
+            Text('Services', style: theme.textTheme.titleLarge),
+            const SizedBox(height: 8),
+            _DetailedSection(state: state),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+/// The check anybody may make: did the API answer at all.
+class _LivenessCard extends StatelessWidget {
+  const _LivenessCard({required this.answer, required this.failure});
+
+  final String? answer;
+  final Failure? failure;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final reachable = answer != null;
+
+    return Card(
+      color: reachable
+          ? theme.colorScheme.secondaryContainer
+          : theme.colorScheme.errorContainer,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          children: <Widget>[
+            Icon(
+              reachable ? Icons.check_circle_outline : Icons.cloud_off_outlined,
+              color: reachable
+                  ? theme.colorScheme.onSecondaryContainer
+                  : theme.colorScheme.onErrorContainer,
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(
+                    reachable
+                        ? 'The API is reachable'
+                        : 'The API did not answer',
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      color: reachable
+                          ? theme.colorScheme.onSecondaryContainer
+                          : theme.colorScheme.onErrorContainer,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    answer ?? failure?.displayMessage ?? 'No answer.',
+                    style: TextStyle(
+                      color: reachable
+                          ? theme.colorScheme.onSecondaryContainer
+                          : theme.colorScheme.onErrorContainer,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// The detailed report, which the API gives only to a System Admin.
+class _DetailedSection extends StatelessWidget {
+  const _DetailedSection({required this.state});
+
+  final HealthState state;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    // A Scope Admin is offered this screen read-only, and the API's refusal of
+    // the detailed report is the expected answer rather than a fault.
+    if (state.detailedForbidden) {
+      return Card(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Text(
+            'The per-service report is only shown to a System Admin. The '
+            'reachability check above is what your role is given.',
+            style: theme.textTheme.bodyMedium,
+          ),
+        ),
+      );
+    }
+
+    if (state.detailedFailure case final failure?) {
+      return ErrorBanner(failure: failure);
+    }
+
+    final health = state.detailed;
+
+    if (health == null) {
+      return Card(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Text('No report yet.', style: theme.textTheme.bodyMedium),
+        ),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        Card(
+          child: ListTile(
+            leading: _StatusChip(status: health.status),
+            title: const Text('Overall'),
+            subtitle: Text(
+              health.unhealthy.isEmpty
+                  ? 'Every checked service reported healthy.'
+                  : '${health.unhealthy.length} of ${health.services.length} '
+                        'services are not healthy.',
+            ),
+          ),
+        ),
+        const SizedBox(height: 8),
+        if (health.services.isEmpty)
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Text(
+                'The API reported no individual services.',
+                style: theme.textTheme.bodyMedium,
+              ),
+            ),
+          )
+        else
+          Card(
+            child: Column(
+              children: <Widget>[
+                for (final service in health.services)
+                  ListTile(
+                    leading: _StatusChip(status: service.status),
+                    title: Text(service.name),
+                  ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+/// A status as the API worded it, coloured by whether it reads as healthy.
+///
+/// The word is never rewritten: a state this does not recognise is shown as it
+/// came rather than being called a failure.
+class _StatusChip extends StatelessWidget {
+  const _StatusChip({required this.status});
+
+  final String status;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final healthy = status.toLowerCase() == 'healthy';
+
+    return Chip(
+      avatar: Icon(
+        healthy ? Icons.check_circle_outline : Icons.error_outline,
+        color: healthy ? scheme.onSecondaryContainer : scheme.onErrorContainer,
+      ),
+      label: Text(status),
+      backgroundColor: healthy
+          ? scheme.secondaryContainer
+          : scheme.errorContainer,
+      labelStyle: TextStyle(
+        color: healthy ? scheme.onSecondaryContainer : scheme.onErrorContainer,
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,8 @@ import 'features/auth/data/google_sign_in_gateway_impl.dart';
 import 'features/auth/presentation/session_controller.dart';
 import 'features/google_users/data/google_user_repository_impl.dart';
 import 'features/google_users/domain/google_user_repository.dart';
+import 'features/health/data/health_repository_impl.dart';
+import 'features/health/domain/health_repository.dart';
 import 'features/permissions/data/scope_permission_repository_impl.dart';
 import 'features/permissions/domain/scope_permission_repository.dart';
 import 'features/persons/data/person_repository_impl.dart';
@@ -56,6 +58,10 @@ void main() {
         googleUserRepositoryProvider.overrideWith(
           (ref) =>
               ApiGoogleUserRepository(GoogleUserClient(ref.watch(dioProvider))),
+        ),
+        healthRepositoryProvider.overrideWith(
+          (ref) =>
+              ApiHealthRepository(HealthCheckClient(ref.watch(dioProvider))),
         ),
         scopePermissionRepositoryProvider.overrideWith(
           (ref) => ApiScopePermissionRepository(

--- a/test/features/health/data/health_repository_impl_test.dart
+++ b/test/features/health/data/health_repository_impl_test.dart
@@ -1,0 +1,202 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdall_api_client/export.dart';
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/features/health/data/health_repository_impl.dart';
+
+void main() {
+  late Dio dio;
+
+  ApiHealthRepository repositoryAnswering(_Answer answer) {
+    dio.httpClientAdapter = _StubAdapter(answer);
+
+    return ApiHealthRepository(HealthCheckClient(dio));
+  }
+
+  setUp(() {
+    dio = Dio(BaseOptions(baseUrl: 'https://example.invalid'));
+  });
+
+  test('GivenAReachableApi_WhenPinged_ThenItsAnswerIsReturned', () async {
+    // Given
+    final repository = repositoryAnswering(
+      const _Answer(
+        status: 200,
+        body: <String, dynamic>{
+          'success': true,
+          'errors': <String>[],
+          'data': 'Hello, world!',
+        },
+      ),
+    );
+
+    // When
+    final result = await repository.ping();
+
+    // Then
+    expect(result.valueOrNull, 'Hello, world!');
+  });
+
+  test('GivenNoConnection_WhenPinged_ThenNetworkFailureIsReturned', () async {
+    // Given
+    final repository = repositoryAnswering(const _Answer(status: 0));
+
+    // When
+    final result = await repository.ping();
+
+    // Then
+    expect(result.failureOrNull?.kind, FailureKind.network);
+  });
+
+  test('GivenAHealthyApi_WhenDetailed_ThenEveryServiceIsReturned', () async {
+    // Given
+    final repository = repositoryAnswering(
+      const _Answer(
+        status: 200,
+        body: <String, dynamic>{
+          'success': true,
+          'errors': <String>[],
+          'data': <String, dynamic>{
+            'status': 'Healthy',
+            'services': <Map<String, dynamic>>[
+              <String, dynamic>{'name': 'Database', 'status': 'Healthy'},
+              <String, dynamic>{'name': 'Mail', 'status': 'Healthy'},
+            ],
+          },
+        },
+      ),
+    );
+
+    // When
+    final result = await repository.detailed();
+
+    // Then
+    expect(result.valueOrNull?.status, 'Healthy');
+    expect(result.valueOrNull?.services, hasLength(2));
+    expect(result.valueOrNull?.unhealthy, isEmpty);
+  });
+
+  // A 503 is the API reporting itself unhealthy, not failing to answer — the
+  // report is in the body and is what an operator came for.
+  test('GivenAnUnhealthyApi_WhenDetailed_ThenTheReportIsStillRead', () async {
+    // Given
+    final repository = repositoryAnswering(
+      const _Answer(
+        status: 503,
+        body: <String, dynamic>{
+          'success': false,
+          'errors': <String>[],
+          'data': <String, dynamic>{
+            'status': 'Unhealthy',
+            'services': <Map<String, dynamic>>[
+              <String, dynamic>{'name': 'Database', 'status': 'Healthy'},
+              <String, dynamic>{'name': 'Mail', 'status': 'Unhealthy'},
+            ],
+          },
+        },
+      ),
+    );
+
+    // When
+    final result = await repository.detailed();
+
+    // Then
+    expect(result.valueOrNull?.status, 'Unhealthy');
+    expect(result.valueOrNull?.unhealthy.single.name, 'Mail');
+  });
+
+  // A Scope Admin is refused the detailed report, which the screen treats as
+  // an expected answer rather than a fault.
+  test('GivenAScopeAdmin_WhenDetailed_ThenForbiddenIsReturned', () async {
+    // Given
+    final repository = repositoryAnswering(
+      const _Answer(
+        status: 403,
+        body: <String, dynamic>{'success': false, 'errors': <String>[]},
+      ),
+    );
+
+    // When
+    final result = await repository.detailed();
+
+    // Then
+    expect(result.failureOrNull?.kind, FailureKind.forbidden);
+  });
+
+  test('GivenNoConnection_WhenDetailed_ThenNetworkFailureIsReturned', () async {
+    // Given
+    final repository = repositoryAnswering(const _Answer(status: 0));
+
+    // When
+    final result = await repository.detailed();
+
+    // Then
+    expect(result.failureOrNull?.kind, FailureKind.network);
+  });
+
+  test('GivenAnUnnamedService_WhenDetailed_ThenItStillHasALabel', () async {
+    // Given
+    final repository = repositoryAnswering(
+      const _Answer(
+        status: 200,
+        body: <String, dynamic>{
+          'success': true,
+          'errors': <String>[],
+          'data': <String, dynamic>{
+            'status': 'Healthy',
+            'services': <Map<String, dynamic>>[<String, dynamic>{}],
+          },
+        },
+      ),
+    );
+
+    // When
+    final result = await repository.detailed();
+
+    // Then
+    expect(result.valueOrNull?.services.single.name, 'Unnamed service');
+    expect(result.valueOrNull?.services.single.status, 'Unknown');
+  });
+}
+
+class _Answer {
+  const _Answer({required this.status, this.body});
+
+  final int status;
+  final Map<String, dynamic>? body;
+}
+
+/// Answers from memory, so no test reaches the network.
+class _StubAdapter implements HttpClientAdapter {
+  _StubAdapter(this._answer);
+
+  final _Answer _answer;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    if (_answer.status == 0) {
+      throw DioException.connectionError(
+        requestOptions: options,
+        reason: 'No route to host',
+      );
+    }
+
+    return ResponseBody.fromString(
+      jsonEncode(_answer.body),
+      _answer.status,
+      headers: <String, List<String>>{
+        Headers.contentTypeHeader: <String>[Headers.jsonContentType],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}

--- a/test/features/health/presentation/health_screen_test.dart
+++ b/test/features/health/presentation/health_screen_test.dart
@@ -1,0 +1,313 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdall_ui/app/theme.dart';
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/core/storage/token_store.dart';
+import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
+import 'package:heimdall_ui/features/health/domain/health.dart';
+import 'package:heimdall_ui/features/health/domain/health_repository.dart';
+import 'package:heimdall_ui/features/health/presentation/health_screen.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockHealthRepository extends Mock implements HealthRepository {}
+
+/// A token naming a person of [role]: 1 System Admin, 2 Scope Admin.
+String _jwt({int role = 1}) {
+  final payload = base64Url.encode(
+    utf8.encode(
+      jsonEncode(<String, dynamic>{
+        'sub': 'person-9',
+        'email': 'admin@example.com',
+        'role': role,
+      }),
+    ),
+  );
+
+  return 'header.$payload.signature';
+}
+
+const _healthy = Health(
+  status: 'Healthy',
+  services: <ServiceHealth>[
+    ServiceHealth(name: 'Database', status: 'Healthy'),
+    ServiceHealth(name: 'Mail', status: 'Healthy'),
+  ],
+);
+
+const _unhealthy = Health(
+  status: 'Unhealthy',
+  services: <ServiceHealth>[
+    ServiceHealth(name: 'Database', status: 'Healthy'),
+    ServiceHealth(name: 'Mail', status: 'Unhealthy'),
+  ],
+);
+
+const Size _compact = Size(400, 900);
+const Size _medium = Size(800, 900);
+const Size _expanded = Size(1400, 900);
+
+void main() {
+  late _MockHealthRepository repository;
+  late InMemoryTokenStore store;
+  late ProviderContainer container;
+
+  Future<void> pump(
+    WidgetTester tester, {
+    Size size = _expanded,
+    ThemeData? theme,
+    int role = 1,
+  }) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await store.write(
+      AuthToken(
+        value: _jwt(role: role),
+        expiresAt: DateTime.utc(2030),
+      ),
+    );
+
+    container = ProviderContainer(
+      overrides: <Override>[
+        healthRepositoryProvider.overrideWithValue(repository),
+        tokenStoreProvider.overrideWithValue(store),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(sessionControllerProvider.notifier).restore();
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          theme: theme ?? buildLightTheme(),
+          home: const HealthScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  void answerPingWith(Result<String> result) {
+    when(() => repository.ping()).thenAnswer((_) async => result);
+  }
+
+  void answerDetailedWith(Result<Health> result) {
+    when(() => repository.detailed()).thenAnswer((_) async => result);
+  }
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    repository = _MockHealthRepository();
+    store = InMemoryTokenStore();
+    answerPingWith(const Success<String>('Hello, world!'));
+    answerDetailedWith(const Success<Health>(_healthy));
+  });
+
+  testWidgets('GivenAReachableApi_WhenOpened_ThenItSaysSo', (tester) async {
+    // Given / When
+    await pump(tester);
+
+    // Then
+    expect(find.text('The API is reachable'), findsOneWidget);
+    expect(find.text('Hello, world!'), findsOneWidget);
+  });
+
+  testWidgets('GivenAnUnreachableApi_WhenOpened_ThenItSaysSo', (tester) async {
+    // Given
+    answerPingWith(
+      const FailureResult<String>(
+        Failure(
+          kind: FailureKind.network,
+          errors: <String>[],
+          message: 'Connection refused',
+        ),
+      ),
+    );
+    answerDetailedWith(
+      const FailureResult<Health>(
+        Failure(kind: FailureKind.network, errors: <String>[]),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('The API did not answer'), findsOneWidget);
+    expect(find.text('Connection refused'), findsOneWidget);
+  });
+
+  testWidgets('GivenAHealthyApi_WhenOpened_ThenEveryServiceIsListed', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Database'), findsOneWidget);
+    expect(find.text('Mail'), findsOneWidget);
+    expect(find.textContaining('Every checked service'), findsOneWidget);
+  });
+
+  testWidgets('GivenAnUnhealthyService_WhenOpened_ThenTheCountIsGiven', (
+    tester,
+  ) async {
+    // Given
+    answerDetailedWith(const Success<Health>(_unhealthy));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(
+      find.textContaining('1 of 2 services are not healthy'),
+      findsOneWidget,
+    );
+  });
+
+  // The API's own word is what is shown, whatever it is.
+  testWidgets('GivenAnUnfamiliarStatus_WhenOpened_ThenItIsShownAsGiven', (
+    tester,
+  ) async {
+    // Given
+    answerDetailedWith(
+      const Success<Health>(
+        Health(
+          status: 'Degraded',
+          services: <ServiceHealth>[
+            ServiceHealth(name: 'Mail', status: 'Degraded'),
+          ],
+        ),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Degraded'), findsNWidgets(2));
+  });
+
+  // A Scope Admin is offered the screen but refused the detailed report, and
+  // that is the expected answer rather than a fault.
+  testWidgets('GivenAScopeAdmin_WhenRefused_ThenTheReasonIsExplained', (
+    tester,
+  ) async {
+    // Given
+    answerDetailedWith(
+      const FailureResult<Health>(
+        Failure(kind: FailureKind.forbidden, errors: <String>[]),
+      ),
+    );
+
+    // When
+    await pump(tester, role: 2);
+
+    // Then
+    expect(find.textContaining('only shown to a System Admin'), findsOneWidget);
+  });
+
+  testWidgets('GivenAScopeAdmin_WhenRefused_ThenTheLivenessStillShows', (
+    tester,
+  ) async {
+    // Given
+    answerDetailedWith(
+      const FailureResult<Health>(
+        Failure(kind: FailureKind.forbidden, errors: <String>[]),
+      ),
+    );
+
+    // When
+    await pump(tester, role: 2);
+
+    // Then
+    expect(find.text('The API is reachable'), findsOneWidget);
+  });
+
+  testWidgets('GivenARefusedReport_WhenOpened_ThenApiErrorsAreShown', (
+    tester,
+  ) async {
+    // Given
+    answerDetailedWith(
+      const FailureResult<Health>(
+        Failure(
+          kind: FailureKind.server,
+          errors: <String>['The health check itself failed.'],
+        ),
+      ),
+    );
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('The health check itself failed.'), findsOneWidget);
+  });
+
+  testWidgets('GivenTheScreen_WhenRefreshTapped_ThenBothChecksRunAgain', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+
+    // When
+    await tester.tap(find.byTooltip('Check again'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(() => repository.ping()).called(2);
+    verify(() => repository.detailed()).called(2);
+  });
+
+  testWidgets('GivenNoServices_WhenOpened_ThenItSaysNoneWereReported', (
+    tester,
+  ) async {
+    // Given
+    answerDetailedWith(const Success<Health>(Health(status: 'Healthy')));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(
+      find.text('The API reported no individual services.'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('GivenACompactWindow_WhenRendered_ThenTheReportIsShown', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, size: _compact);
+
+    // Then
+    expect(find.text('The API is reachable'), findsOneWidget);
+  });
+
+  testWidgets('GivenAMediumWindow_WhenRendered_ThenTheReportIsShown', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, size: _medium);
+
+    // Then
+    expect(find.text('The API is reachable'), findsOneWidget);
+  });
+
+  testWidgets('GivenTheDarkTheme_WhenRendered_ThenTheReportIsStillShown', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, theme: buildDarkTheme());
+
+    // Then
+    expect(find.text('The API is reachable'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #33

Implements P-04 — `/health` over `GET /HealthCheck` and `GET /HealthCheck/detailed`, the last screen in the inventory.

## What it does

The two checks run **together** rather than in sequence: neither depends on the other, and somebody asking "is it up" wants both answers at once.

- **Liveness** — what anybody signed in may call. Its card says whether the API answered and what it said.
- **Per-service report** — a System Admin's. A Scope Admin is offered this screen read-only per the authorization matrix, so the API's `403` is the *expected* answer rather than a fault; the section says which, and the reachability check stays visible above it.

## Two decisions worth naming

- **A `503` is read, not discarded.** It is the API reporting itself unhealthy rather than failing to answer, and the report an operator came for is in its body. A repository test covers it.
- **Statuses are shown in the API's own words.** Only the chip's colour depends on recognising `Healthy`, so a state the API adds later renders as it came instead of being called a failure. A widget test covers an unfamiliar status.

## Verification

`dart format --set-exit-if-changed .`, `flutter analyze`, and `flutter test` all pass — **861 tests**, 20 of them new. No presentation file imports `package:heimdall_api_client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)