### PR TITLE
feat(ui-11, ui-14, ui-18): owner pickers, and the second-factor state

### DIFF
--- a/docs/requirements/System Requirements Document.md
+++ b/docs/requirements/System Requirements Document.md
@@ -83,10 +83,11 @@ describes the flows that satisfy these requirements; the
 | FR-PE-02 | The client shall filter the person listing and shall let the user include logically deleted persons. | UI-16 |
 | FR-PE-03 | The client shall create a person within a scope through `POST /api/scopes/{scopeId}/persons`. | UI-17 |
 | FR-PE-04 | The client shall let a System Admin create a person belonging to no scope through `POST /api/persons`. | UI-17 |
-| FR-PE-05 | The client shall show a person through `GET /api/persons/{id}`, including role, scope membership, owned scopes, and verification state. | UI-18 |
+| FR-PE-05 | The client shall show a person through `GET /api/persons/{id}`, including role, scope membership, owned scopes, verification state, and whether a second factor is configured. | UI-18 |
 | FR-PE-06 | The client shall update a person's name and email through `PUT /api/persons/{id}`. | UI-18 |
 | FR-PE-07 | The client shall logically delete a person through `DELETE /api/persons/{id}` after confirmation. | UI-19 |
 | FR-PE-08 | The client shall permanently delete a person through `DELETE /api/persons/{id}/hard` after a confirmation requiring the person's email to be typed. | UI-19 |
+| FR-PE-09 | The client shall offer the owners a scope may be given from `GET /api/persons/scope-admins`, leaving out the persons who already own the scope being managed. | UI-11, UI-14 |
 
 ### 2.4 Application management (`FR-AP`)
 

--- a/lib/features/persons/data/person_repository_impl.dart
+++ b/lib/features/persons/data/person_repository_impl.dart
@@ -251,6 +251,58 @@ class ApiPersonRepository implements PersonRepository {
   );
 
   @override
+  Future<Result<Page<PersonSummary>>> listScopeAdmins({
+    String? name,
+    String? email,
+    String? excludeOwnersOfScopeId,
+    int pageNumber = 1,
+    int pageSize = 20,
+  }) async {
+    try {
+      final response = await _client.personListScopeAdmins(
+        name: _filter(name),
+        email: _filter(email),
+        excludeOwnersOfScopeId: _filter(excludeOwnersOfScopeId),
+        pageNumber: pageNumber,
+        pageSize: pageSize,
+      );
+
+      if (response.success != true) {
+        return FailureResult<Page<PersonSummary>>(
+          Failure(
+            kind: FailureKind.validation,
+            errors: response.errors ?? const <String>[],
+          ),
+        );
+      }
+
+      final items = (response.data ?? const <PersonSummaryOutput>[])
+          .map(
+            (output) => PersonSummary(
+              id: output.id ?? '',
+              name: output.name ?? '',
+              email: output.email ?? '',
+            ),
+          )
+          .toList(growable: false);
+
+      return Success<Page<PersonSummary>>(
+        Page<PersonSummary>(
+          items: items,
+          pageNumber: response.pageNumber ?? pageNumber,
+          pageSize: response.pageSize ?? pageSize,
+          totalItems: response.totalItems ?? items.length,
+          totalPages: response.totalPages ?? 1,
+        ),
+      );
+    } on DioException catch (error) {
+      // A Scope Admin who may not manage the named scope is refused here, and
+      // the picker falls back to an identifier rather than to nothing.
+      return FailureResult<Page<PersonSummary>>(failureFromDioException(error));
+    }
+  }
+
+  @override
   Future<Result<void>> addScopeOwner({
     required String scopeId,
     required String personId,
@@ -417,6 +469,7 @@ Person personFromOutput(PersonOutput output) => Person(
   email: output.email ?? '',
   role: roleFromValue(output.role ?? Role.user.value),
   emailVerified: output.emailVerified ?? true,
+  twoFactorEnabled: output.twoFactorEnabled ?? false,
   isDeleted: output.isDeleted ?? false,
   scopeId: output.scopeId,
   ownedScopeIds: output.ownedScopeIds ?? const <String>[],

--- a/lib/features/persons/domain/person.dart
+++ b/lib/features/persons/domain/person.dart
@@ -13,6 +13,7 @@ class Person {
     required this.email,
     required this.role,
     this.emailVerified = true,
+    this.twoFactorEnabled = false,
     this.isDeleted = false,
     this.scopeId,
     this.ownedScopeIds = const <String>[],
@@ -30,6 +31,11 @@ class Person {
   /// an unverified address.
   final bool emailVerified;
 
+  /// Whether the person has a second factor configured. Defaults to `false`:
+  /// the endpoints that do not report it are the ones where nobody could have
+  /// configured one yet.
+  final bool twoFactorEnabled;
+
   /// Whether the person has been logically deleted. The listings show these
   /// only when the user asks for them.
   final bool isDeleted;
@@ -42,4 +48,42 @@ class Person {
 
   final DateTime? createdAt;
   final DateTime? updatedAt;
+
+  /// The same person carrying a second-factor state read elsewhere.
+  ///
+  /// The update endpoint answers with a shape that does not report one, and an
+  /// edit to a name and an address cannot have turned anybody's second factor
+  /// on or off — so what was already read still holds, and `false` would be a
+  /// guess rather than a fact.
+  Person withTwoFactorEnabled(bool enabled) => Person(
+    id: id,
+    name: name,
+    email: email,
+    role: role,
+    emailVerified: emailVerified,
+    twoFactorEnabled: enabled,
+    isDeleted: isDeleted,
+    scopeId: scopeId,
+    ownedScopeIds: ownedScopeIds,
+    createdAt: createdAt,
+    updatedAt: updatedAt,
+  );
+}
+
+/// A Scope Admin as the owner listing projects one: enough to recognise and to
+/// name, and nothing else.
+///
+/// The endpoint behind it answers with its own shape rather than with a person,
+/// because choosing an owner needs a name and an address, not a role, a scope,
+/// or a deletion state.
+class PersonSummary {
+  const PersonSummary({
+    required this.id,
+    required this.name,
+    required this.email,
+  });
+
+  final String id;
+  final String name;
+  final String email;
 }

--- a/lib/features/persons/domain/person_repository.dart
+++ b/lib/features/persons/domain/person_repository.dart
@@ -72,6 +72,20 @@ abstract interface class PersonRepository {
     int pageSize = 20,
   });
 
+  /// Lists the system's Scope Admins, projected to what an owner picker shows.
+  ///
+  /// [excludeOwnersOfScopeId] leaves out the people who already own that
+  /// scope, which is what makes UI-14's AF-14c true of the selector rather
+  /// than only of the API's answer afterwards. UI-11 has no scope to exclude
+  /// from — it is creating one.
+  Future<Result<Page<PersonSummary>>> listScopeAdmins({
+    String? name,
+    String? email,
+    String? excludeOwnersOfScopeId,
+    int pageNumber = 1,
+    int pageSize = 20,
+  });
+
   /// Adds an existing Scope Admin as a co-owner of a scope.
   ///
   /// Whether that person is a usable Scope Admin, and whether they already own

--- a/lib/features/persons/presentation/person_detail_controller.dart
+++ b/lib/features/persons/presentation/person_detail_controller.dart
@@ -136,7 +136,13 @@ class PersonDetailController extends FamilyNotifier<PersonDetailState, String> {
         .update(id: arg, name: name, email: email);
 
     state = result.fold(
-      onSuccess: (person) => PersonDetailLoaded(person, saved: true),
+      // The update endpoint does not report a second factor, and this edit
+      // cannot have changed one — so the state already read is carried over
+      // rather than being replaced by a default.
+      onSuccess: (person) => PersonDetailLoaded(
+        person.withTwoFactorEnabled(current.person.twoFactorEnabled),
+        saved: true,
+      ),
       // AF-18c: the refusal is kept as it came back, and the record on screen
       // is still the one the API last confirmed.
       onFailure: (failure) =>

--- a/lib/features/persons/presentation/person_detail_screen.dart
+++ b/lib/features/persons/presentation/person_detail_screen.dart
@@ -337,6 +337,10 @@ class _PersonDetailScreenState extends ConsumerState<PersonDetailScreen> {
                           value: person.emailVerified ? 'Yes' : 'No',
                         ),
                         _Fact(
+                          label: 'Two-factor authentication',
+                          value: person.twoFactorEnabled ? 'On' : 'Off',
+                        ),
+                        _Fact(
                           label: 'Scope',
                           value: person.scopeId ?? 'Not a member of a scope',
                         ),

--- a/lib/features/persons/presentation/scope_admin_picker.dart
+++ b/lib/features/persons/presentation/scope_admin_picker.dart
@@ -1,0 +1,230 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/result/result.dart';
+import '../../../shared/widgets/collection_states.dart';
+import '../../../shared/widgets/failure_banner.dart';
+import '../domain/person.dart';
+import 'scope_admin_picker_controller.dart';
+
+/// Asks for a Scope Admin, and answers with the one chosen.
+///
+/// [excludeOwnersOfScopeId] leaves out the people who already own that scope,
+/// which is UI-14's AF-14c. [excludeIds] leaves out the ones the calling screen
+/// has already collected but not yet sent — UI-11's chips, which the API cannot
+/// know about because the scope does not exist yet.
+Future<PersonSummary?> showScopeAdminPicker({
+  required BuildContext context,
+  String? excludeOwnersOfScopeId,
+  Set<String> excludeIds = const <String>{},
+}) => showDialog<PersonSummary>(
+  context: context,
+  builder: (context) => ScopeAdminPicker(
+    excludeOwnersOfScopeId: excludeOwnersOfScopeId,
+    excludeIds: excludeIds,
+  ),
+);
+
+/// The picker itself, public so a widget test can pump it on its own.
+class ScopeAdminPicker extends ConsumerStatefulWidget {
+  const ScopeAdminPicker({
+    super.key,
+    this.excludeOwnersOfScopeId,
+    this.excludeIds = const <String>{},
+  });
+
+  final String? excludeOwnersOfScopeId;
+  final Set<String> excludeIds;
+
+  @override
+  ConsumerState<ScopeAdminPicker> createState() => _ScopeAdminPickerState();
+}
+
+class _ScopeAdminPickerState extends ConsumerState<ScopeAdminPicker> {
+  final _search = TextEditingController();
+  final _identifier = TextEditingController();
+
+  String get _key => widget.excludeOwnersOfScopeId ?? '';
+
+  ScopeAdminPickerController get _controller =>
+      ref.read(scopeAdminPickerControllerProvider(_key).notifier);
+
+  @override
+  void initState() {
+    super.initState();
+    // The exclusion changes as owners are added, so the listing is read afresh
+    // each time the picker opens rather than trusted from the last one.
+    WidgetsBinding.instance.addPostFrameCallback((_) => _controller.search());
+  }
+
+  @override
+  void dispose() {
+    _search.dispose();
+    _identifier.dispose();
+    super.dispose();
+  }
+
+  void _choose(PersonSummary admin) => Navigator.of(context).pop(admin);
+
+  /// The escape hatch: an identifier stands in for a person the listing could
+  /// not offer. The API judges it exactly as it judged the typed identifiers
+  /// this picker replaced (AF-11c, AF-14b).
+  void _chooseTyped() {
+    final id = _identifier.text.trim();
+
+    if (id.isNotEmpty) {
+      Navigator.of(context).pop(PersonSummary(id: id, name: id, email: ''));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(scopeAdminPickerControllerProvider(_key));
+
+    return AlertDialog(
+      title: const Text('Choose a Scope Admin'),
+      content: SizedBox(
+        width: 420,
+        height: 360,
+        child: switch (state) {
+          ScopeAdminsLoading() => const CollectionLoading(rows: 4),
+          ScopeAdminsUnavailable(:final failure) => _Unavailable(
+            failure: failure,
+            identifier: _identifier,
+            onRetry: () => _controller.search(_search.text),
+            onSubmit: _chooseTyped,
+          ),
+          final ScopeAdminsLoaded loaded => _Candidates(
+            state: loaded,
+            search: _search,
+            excludeIds: widget.excludeIds,
+            onSearch: _controller.search,
+            onChoose: _choose,
+          ),
+        },
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+      ],
+    );
+  }
+}
+
+class _Candidates extends StatelessWidget {
+  const _Candidates({
+    required this.state,
+    required this.search,
+    required this.excludeIds,
+    required this.onSearch,
+    required this.onChoose,
+  });
+
+  final ScopeAdminsLoaded state;
+  final TextEditingController search;
+  final Set<String> excludeIds;
+  final ValueChanged<String> onSearch;
+  final ValueChanged<PersonSummary> onChoose;
+
+  @override
+  Widget build(BuildContext context) {
+    final offered = state.candidates
+        .where((admin) => !excludeIds.contains(admin.id))
+        .toList(growable: false);
+
+    return Column(
+      children: <Widget>[
+        TextField(
+          controller: search,
+          autofocus: true,
+          decoration: const InputDecoration(
+            labelText: 'Search',
+            helperText: 'By name, or by email address.',
+            prefixIcon: Icon(Icons.search),
+          ),
+          onSubmitted: onSearch,
+        ),
+        const SizedBox(height: 8),
+        if (state.searching) const LinearProgressIndicator(),
+        Expanded(
+          child: offered.isEmpty
+              ? const CollectionEmpty(
+                  title: 'No Scope Admins to offer',
+                  message:
+                      'Nobody matches, or everybody who does already owns '
+                      'this scope.',
+                  icon: Icons.shield_outlined,
+                )
+              : ListView(
+                  children: <Widget>[
+                    for (final admin in offered)
+                      ListTile(
+                        leading: const Icon(Icons.shield_outlined),
+                        title: Text(admin.name),
+                        subtitle: Text(admin.email),
+                        onTap: () => onChoose(admin),
+                      ),
+                  ],
+                ),
+        ),
+      ],
+    );
+  }
+}
+
+class _Unavailable extends StatelessWidget {
+  const _Unavailable({
+    required this.failure,
+    required this.identifier,
+    required this.onRetry,
+    required this.onSubmit,
+  });
+
+  final Failure failure;
+  final TextEditingController identifier;
+  final VoidCallback onRetry;
+  final VoidCallback onSubmit;
+
+  @override
+  Widget build(BuildContext context) => ListView(
+    children: <Widget>[
+      // The banners rather than `CollectionFailed`: this is a panel inside a
+      // dialog, and a centred full-height failure would push the identifier
+      // out of reach.
+      if (failure.kind == FailureKind.network)
+        RetryBanner(onRetry: onRetry)
+      else ...<Widget>[
+        ErrorBanner(failure: failure),
+        const SizedBox(height: 12),
+        Align(
+          alignment: Alignment.centerRight,
+          child: FilledButton(onPressed: onRetry, child: const Text('Retry')),
+        ),
+      ],
+      const SizedBox(height: 16),
+      Text(
+        'You can still name someone by their identifier.',
+        style: Theme.of(context).textTheme.bodyMedium,
+      ),
+      const SizedBox(height: 8),
+      TextField(
+        controller: identifier,
+        decoration: const InputDecoration(
+          labelText: 'Person identifier',
+          helperText: 'The person id of an existing Scope Admin.',
+        ),
+        onSubmitted: (_) => onSubmit(),
+      ),
+      const SizedBox(height: 8),
+      Align(
+        alignment: Alignment.centerRight,
+        child: FilledButton(
+          onPressed: onSubmit,
+          child: const Text('Use this identifier'),
+        ),
+      ),
+    ],
+  );
+}

--- a/lib/features/persons/presentation/scope_admin_picker_controller.dart
+++ b/lib/features/persons/presentation/scope_admin_picker_controller.dart
@@ -1,0 +1,102 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/network/envelope.dart';
+import '../../../core/result/result.dart';
+import '../../profile/presentation/profile_controller.dart';
+import '../domain/person.dart';
+
+/// How far the Scope Admin listing behind an owner picker has got.
+sealed class ScopeAdminsState {
+  const ScopeAdminsState();
+}
+
+/// The candidates are being read.
+final class ScopeAdminsLoading extends ScopeAdminsState {
+  const ScopeAdminsLoading();
+}
+
+/// The candidates could not be read, so the picker offers a typed identifier
+/// instead of nothing — naming an owner was possible before this listing
+/// existed and stays possible without it.
+final class ScopeAdminsUnavailable extends ScopeAdminsState {
+  const ScopeAdminsUnavailable(this.failure);
+
+  final Failure failure;
+}
+
+/// The candidates are on screen.
+final class ScopeAdminsLoaded extends ScopeAdminsState {
+  const ScopeAdminsLoaded({
+    required this.candidates,
+    this.query = '',
+    this.searching = false,
+  });
+
+  final List<PersonSummary> candidates;
+
+  /// What the search field was asked for, kept so a reread repeats it.
+  final String query;
+
+  /// A narrowed listing is on its way. The list stays on screen while it is.
+  final bool searching;
+}
+
+final NotifierProviderFamily<
+  ScopeAdminPickerController,
+  ScopeAdminsState,
+  String
+>
+scopeAdminPickerControllerProvider =
+    NotifierProvider.family<
+      ScopeAdminPickerController,
+      ScopeAdminsState,
+      String
+    >(ScopeAdminPickerController.new);
+
+/// Owns the Scope Admin candidates one picker offers.
+///
+/// The family argument is the scope whose current owners are left out, or the
+/// empty string when there is none to leave out — UI-11 is creating the scope,
+/// so nobody owns it yet.
+class ScopeAdminPickerController
+    extends FamilyNotifier<ScopeAdminsState, String> {
+  @override
+  ScopeAdminsState build(String excludeOwnersOfScopeId) =>
+      const ScopeAdminsLoading();
+
+  /// Reads the candidates, optionally narrowed by what was typed.
+  ///
+  /// A query containing an `@` is an address and anything else is a name: one
+  /// field is what a picker wants, and two would ask the user to classify what
+  /// they typed before typing it.
+  Future<void> search([String query = '']) async {
+    final trimmed = query.trim();
+    final current = state;
+
+    state = current is ScopeAdminsLoaded
+        ? ScopeAdminsLoaded(
+            candidates: current.candidates,
+            query: trimmed,
+            searching: true,
+          )
+        : const ScopeAdminsLoading();
+
+    final result = await ref
+        .read(personRepositoryProvider)
+        .listScopeAdmins(
+          name: trimmed.contains('@') ? null : trimmed,
+          email: trimmed.contains('@') ? trimmed : null,
+          excludeOwnersOfScopeId: arg.isEmpty ? null : arg,
+          pageSize: 50,
+        );
+
+    state = switch (result) {
+      Success<Page<PersonSummary>>(:final value) => ScopeAdminsLoaded(
+        candidates: value.items,
+        query: trimmed,
+      ),
+      FailureResult<Page<PersonSummary>>(:final failure) =>
+        ScopeAdminsUnavailable(failure),
+    };
+  }
+}

--- a/lib/features/scopes/presentation/scope_create_screen.dart
+++ b/lib/features/scopes/presentation/scope_create_screen.dart
@@ -5,14 +5,16 @@ import 'package:go_router/go_router.dart';
 import '../../../core/result/result.dart';
 import '../../../shared/layout/app_shell.dart';
 import '../../../shared/widgets/failure_banner.dart';
+import '../../persons/domain/person.dart';
+import '../../persons/presentation/scope_admin_picker.dart';
 import 'scope_create_controller.dart';
 import 'scope_list_controller.dart';
 
 /// UI-11 — the create-scope form.
 ///
-/// Owners are named by their person identifier. The API has no endpoint that
-/// lists the Scope Admins an anonymous new scope could choose from, so the
-/// identifiers are typed and the API judges them (AF-11c).
+/// Owners are chosen from the Scope Admins the API lists. Whether each one is
+/// still usable by the time the scope is created remains the API's to say, so
+/// AF-11c is still what its refusal looks like.
 class ScopeCreateScreen extends ConsumerStatefulWidget {
   const ScopeCreateScreen({super.key});
 
@@ -24,14 +26,12 @@ class _ScopeCreateScreenState extends ConsumerState<ScopeCreateScreen> {
   final _formKey = GlobalKey<FormState>();
   final _name = TextEditingController();
   final _description = TextEditingController();
-  final _owner = TextEditingController();
-  final List<String> _ownerIds = <String>[];
+  final List<PersonSummary> _owners = <PersonSummary>[];
 
   @override
   void dispose() {
     _name.dispose();
     _description.dispose();
-    _owner.dispose();
     super.dispose();
   }
 
@@ -40,20 +40,19 @@ class _ScopeCreateScreenState extends ConsumerState<ScopeCreateScreen> {
   bool get _isDirty =>
       _name.text.trim().isNotEmpty ||
       _description.text.trim().isNotEmpty ||
-      _owner.text.trim().isNotEmpty ||
-      _ownerIds.isNotEmpty;
+      _owners.isNotEmpty;
 
-  void _addOwner() {
-    final id = _owner.text.trim();
+  /// The scope does not exist yet, so there are no owners for the API to leave
+  /// out — only the ones already chosen here, which it cannot know about.
+  Future<void> _addOwner() async {
+    final chosen = await showScopeAdminPicker(
+      context: context,
+      excludeIds: _owners.map((owner) => owner.id).toSet(),
+    );
 
-    if (id.isEmpty || _ownerIds.contains(id)) {
-      return;
+    if (chosen != null && mounted) {
+      setState(() => _owners.add(chosen));
     }
-
-    setState(() {
-      _ownerIds.add(id);
-      _owner.clear();
-    });
   }
 
   Future<void> _submit() async {
@@ -62,12 +61,8 @@ class _ScopeCreateScreenState extends ConsumerState<ScopeCreateScreen> {
       return;
     }
 
-    // AF-11a: neither does a scope with nobody to own it. The unadded text in
-    // the owner field counts, so a user who typed one and did not press add is
-    // not told they forgot.
-    _addOwner();
-
-    if (_ownerIds.isEmpty) {
+    // AF-11a: neither does a scope with nobody to own it.
+    if (_owners.isEmpty) {
       setState(() {});
 
       return;
@@ -78,7 +73,7 @@ class _ScopeCreateScreenState extends ConsumerState<ScopeCreateScreen> {
         .create(
           name: _name.text.trim(),
           description: _description.text.trim(),
-          ownerIds: List<String>.unmodifiable(_ownerIds),
+          ownerIds: _owners.map((owner) => owner.id).toList(growable: false),
         );
   }
 
@@ -185,30 +180,16 @@ class _ScopeCreateScreenState extends ConsumerState<ScopeCreateScreen> {
                   const SizedBox(height: 24),
                   Text('Owners', style: theme.textTheme.titleMedium),
                   const SizedBox(height: 8),
-                  Row(
-                    children: <Widget>[
-                      Expanded(
-                        child: TextField(
-                          controller: _owner,
-                          decoration: const InputDecoration(
-                            labelText: 'Scope Admin identifier',
-                            helperText:
-                                'The person id of an existing Scope '
-                                'Admin.',
-                          ),
-                          onSubmitted: (_) => _addOwner(),
-                        ),
-                      ),
-                      const SizedBox(width: 8),
-                      IconButton.filledTonal(
-                        tooltip: 'Add owner',
-                        icon: const Icon(Icons.add),
-                        onPressed: sending ? null : _addOwner,
-                      ),
-                    ],
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: OutlinedButton.icon(
+                      onPressed: sending ? null : _addOwner,
+                      icon: const Icon(Icons.person_add_alt),
+                      label: const Text('Add owner'),
+                    ),
                   ),
                   const SizedBox(height: 12),
-                  if (_ownerIds.isEmpty)
+                  if (_owners.isEmpty)
                     Text(
                       'No owners added yet.',
                       style: theme.textTheme.bodySmall,
@@ -218,14 +199,14 @@ class _ScopeCreateScreenState extends ConsumerState<ScopeCreateScreen> {
                       spacing: 8,
                       runSpacing: 8,
                       children: <Widget>[
-                        for (final id in _ownerIds)
+                        for (final owner in _owners)
                           InputChip(
-                            label: Text(id),
+                            label: Text(owner.name),
                             deleteIcon: const Icon(Icons.close),
                             deleteButtonTooltipMessage: 'Remove owner',
                             onDeleted: sending
                                 ? null
-                                : () => setState(() => _ownerIds.remove(id)),
+                                : () => setState(() => _owners.remove(owner)),
                           ),
                       ],
                     ),

--- a/lib/features/scopes/presentation/scope_owners_screen.dart
+++ b/lib/features/scopes/presentation/scope_owners_screen.dart
@@ -9,6 +9,7 @@ import '../../../shared/widgets/failure_banner.dart';
 import '../../auth/domain/session.dart';
 import '../../auth/presentation/session_controller.dart';
 import '../../persons/domain/person.dart';
+import '../../persons/presentation/scope_admin_picker.dart';
 import 'scope_owners_controller.dart';
 
 /// UI-14 — the owners of one scope, and the four ways the list changes.
@@ -43,14 +44,16 @@ class _ScopeOwnersScreenState extends ConsumerState<ScopeOwnersScreen> {
     return session is Authenticated ? session.principal.id : null;
   }
 
+  /// AF-14c — the API leaves this scope's current owners out of the listing,
+  /// so somebody who already owns it is never offered in the first place.
   Future<void> _addExisting() async {
-    final personId = await showDialog<String>(
+    final chosen = await showScopeAdminPicker(
       context: context,
-      builder: (context) => const _AddOwnerDialog(),
+      excludeOwnersOfScopeId: widget.scopeId,
     );
 
-    if (personId != null && personId.isNotEmpty && mounted) {
-      await _controller.addOwner(personId);
+    if (chosen != null && mounted) {
+      await _controller.addOwner(chosen.id);
     }
   }
 
@@ -228,54 +231,6 @@ class _ScopeOwnersScreenState extends ConsumerState<ScopeOwnersScreen> {
       ],
     );
   }
-}
-
-/// Names an existing Scope Admin to add.
-///
-/// As in UI-11, the API publishes no listing of Scope Admins outside a scope,
-/// so the identifier is typed and the API judges it (AF-14b, AF-14c).
-class _AddOwnerDialog extends StatefulWidget {
-  const _AddOwnerDialog();
-
-  @override
-  State<_AddOwnerDialog> createState() => _AddOwnerDialogState();
-}
-
-class _AddOwnerDialogState extends State<_AddOwnerDialog> {
-  final _personId = TextEditingController();
-
-  @override
-  void dispose() {
-    _personId.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) => AlertDialog(
-    title: const Text('Add an existing Scope Admin'),
-    content: TextField(
-      controller: _personId,
-      autofocus: true,
-      decoration: const InputDecoration(
-        labelText: 'Person identifier',
-        helperText: 'The person id of an existing Scope Admin.',
-      ),
-      onChanged: (_) => setState(() {}),
-      onSubmitted: (value) => Navigator.of(context).pop(value.trim()),
-    ),
-    actions: <Widget>[
-      TextButton(
-        onPressed: () => Navigator.of(context).pop(),
-        child: const Text('Cancel'),
-      ),
-      FilledButton(
-        onPressed: _personId.text.trim().isEmpty
-            ? null
-            : () => Navigator.of(context).pop(_personId.text.trim()),
-        child: const Text('Add owner'),
-      ),
-    ],
-  );
 }
 
 /// What the create-a-co-owner dialog collects.

--- a/test/features/persons/data/person_repository_impl_test.dart
+++ b/test/features/persons/data/person_repository_impl_test.dart
@@ -184,6 +184,125 @@ void main() {
     // Then
     expect(result.failureOrNull?.kind, FailureKind.network);
   });
+
+  test(
+    'GivenAScopeAdminListing_WhenRead_ThenTheSummariesAreReturned',
+    () async {
+      // Given
+      final repository = repositoryAnswering(
+        const _Answer(
+          status: 200,
+          body: <String, dynamic>{
+            'success': true,
+            'errors': <String>[],
+            'data': <Map<String, dynamic>>[
+              <String, dynamic>{
+                'id': 'person-1',
+                'name': 'Ada',
+                'email': 'ada@example.com',
+              },
+            ],
+            'pageNumber': 1,
+            'pageSize': 50,
+            'totalItems': 1,
+            'totalPages': 1,
+          },
+        ),
+      );
+
+      // When
+      final result = await repository.listScopeAdmins(pageSize: 50);
+
+      // Then
+      expect(result.valueOrNull?.items.single.name, 'Ada');
+      expect(result.valueOrNull?.items.single.email, 'ada@example.com');
+    },
+  );
+
+  // AF-14c depends on this filter reaching the API, because the exclusion is
+  // the API's to apply — the client does not know who owns what.
+  test('GivenAnExcludedScope_WhenListed_ThenTheFilterIsSent', () async {
+    // Given
+    final repository = repositoryAnswering(
+      const _Answer(
+        status: 200,
+        body: <String, dynamic>{
+          'success': true,
+          'errors': <String>[],
+          'data': <Map<String, dynamic>>[],
+        },
+      ),
+    );
+
+    // When
+    await repository.listScopeAdmins(excludeOwnersOfScopeId: 'scope-1');
+
+    // Then
+    expect(adapter.queries.single['ExcludeOwnersOfScopeId'], 'scope-1');
+  });
+
+  // An empty filter is no filter: sent, it would ask the API to match the
+  // empty string rather than to stop narrowing.
+  test('GivenABlankQuery_WhenListed_ThenNoFilterIsSent', () async {
+    // Given
+    final repository = repositoryAnswering(
+      const _Answer(
+        status: 200,
+        body: <String, dynamic>{
+          'success': true,
+          'errors': <String>[],
+          'data': <Map<String, dynamic>>[],
+        },
+      ),
+    );
+
+    // When
+    await repository.listScopeAdmins(name: '   ', excludeOwnersOfScopeId: '');
+
+    // Then
+    expect(adapter.queries.single.containsKey('Name'), isFalse);
+    expect(
+      adapter.queries.single.containsKey('ExcludeOwnersOfScopeId'),
+      isFalse,
+    );
+  });
+
+  test('GivenNoConnection_WhenListed_ThenNetworkFailureIsReturned', () async {
+    // Given
+    final repository = repositoryAnswering(const _Answer(status: 0));
+
+    // When
+    final result = await repository.listScopeAdmins();
+
+    // Then
+    expect(result.failureOrNull?.kind, FailureKind.network);
+  });
+
+  test('GivenASecondFactor_WhenReadById_ThenItIsCarried', () async {
+    // Given
+    final repository = repositoryAnswering(
+      const _Answer(
+        status: 200,
+        body: <String, dynamic>{
+          'success': true,
+          'errors': <String>[],
+          'data': <String, dynamic>{
+            'id': 'person-1',
+            'name': 'Ada',
+            'email': 'ada@example.com',
+            'role': 2,
+            'twoFactorEnabled': true,
+          },
+        },
+      ),
+    );
+
+    // When
+    final result = await repository.getById('person-1');
+
+    // Then
+    expect(result.valueOrNull?.twoFactorEnabled, isTrue);
+  });
 }
 
 /// What the stub answers with. A [status] of zero stands for a connection that
@@ -205,12 +324,18 @@ class _StubAdapter implements HttpClientAdapter {
   /// travelled in.
   final List<Map<String, dynamic>> requests = <Map<String, dynamic>>[];
 
+  /// The query strings it was asked for, so a test can assert which filters
+  /// reached the API and which were left off.
+  final List<Map<String, String>> queries = <Map<String, String>>[];
+
   @override
   Future<ResponseBody> fetch(
     RequestOptions options,
     Stream<Uint8List>? requestStream,
     Future<void>? cancelFuture,
   ) async {
+    queries.add(options.uri.queryParameters);
+
     if (requestStream != null) {
       final bytes = <int>[];
 

--- a/test/features/persons/presentation/person_detail_controller_test.dart
+++ b/test/features/persons/presentation/person_detail_controller_test.dart
@@ -168,6 +168,43 @@ void main() {
     ).called(1);
   });
 
+  // The update endpoint reports no second factor, and renaming somebody cannot
+  // have turned theirs off.
+  test('GivenASecondFactor_WhenSaved_ThenItSurvivesTheEdit', () async {
+    // Given
+    answerGetWith(
+      const Success<Person>(
+        Person(
+          id: 'person-1',
+          name: 'Ada',
+          email: 'ada@example.com',
+          role: Role.user,
+          twoFactorEnabled: true,
+        ),
+      ),
+    );
+    answerUpdateWith(
+      const Success<Person>(
+        Person(
+          id: 'person-1',
+          name: 'Ada L',
+          email: 'ada@example.com',
+          role: Role.user,
+        ),
+      ),
+    );
+    final controller = controllerUnderTest();
+    await controller.load();
+
+    // When
+    await controller.save(name: 'Ada L', email: 'ada@example.com');
+
+    // Then
+    final state = currentState() as PersonDetailLoaded;
+    expect(state.person.name, 'Ada L');
+    expect(state.person.twoFactorEnabled, isTrue);
+  });
+
   // AF-18e — the role is never part of what this screen sends.
   test('GivenAnEdit_WhenSaved_ThenNoRoleIsSent', () async {
     // Given

--- a/test/features/persons/presentation/person_detail_screen_test.dart
+++ b/test/features/persons/presentation/person_detail_screen_test.dart
@@ -42,6 +42,15 @@ const _ada = Person(
   scopeId: 'scope-1',
 );
 
+const _protected = Person(
+  id: 'person-1',
+  name: 'Ada',
+  email: 'ada@example.com',
+  role: Role.user,
+  scopeId: 'scope-1',
+  twoFactorEnabled: true,
+);
+
 const _deleted = Person(
   id: 'person-1',
   name: 'Ada',
@@ -200,6 +209,31 @@ void main() {
     // Then
     expect(find.text('User'), findsOneWidget);
     expect(find.text('scope-1'), findsOneWidget);
+  });
+
+  testWidgets('GivenASecondFactor_WhenOpened_ThenItIsReported', (tester) async {
+    // Given
+    answerGetWith(const Success<Person>(_protected));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Two-factor authentication'), findsOneWidget);
+    expect(find.text('On'), findsOneWidget);
+  });
+
+  testWidgets('GivenNoSecondFactor_WhenOpened_ThenItIsReportedAsOff', (
+    tester,
+  ) async {
+    // Given
+    answerGetWith(const Success<Person>(_ada));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Off'), findsOneWidget);
   });
 
   testWidgets('GivenAnEdit_WhenSaved_ThenTheNewValuesAreSent', (tester) async {

--- a/test/features/persons/presentation/scope_admin_picker_test.dart
+++ b/test/features/persons/presentation/scope_admin_picker_test.dart
@@ -1,0 +1,383 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:heimdall_ui/app/theme.dart';
+import 'package:heimdall_ui/core/network/envelope.dart' as envelope;
+import 'package:heimdall_ui/core/result/result.dart';
+import 'package:heimdall_ui/features/persons/domain/person.dart';
+import 'package:heimdall_ui/features/persons/domain/person_repository.dart';
+import 'package:heimdall_ui/features/persons/presentation/scope_admin_picker.dart';
+import 'package:heimdall_ui/features/persons/presentation/scope_admin_picker_controller.dart';
+import 'package:heimdall_ui/features/profile/presentation/profile_controller.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockPersonRepository extends Mock implements PersonRepository {}
+
+const _ada = PersonSummary(
+  id: 'person-1',
+  name: 'Ada',
+  email: 'ada@example.com',
+);
+
+const _grace = PersonSummary(
+  id: 'person-2',
+  name: 'Grace',
+  email: 'grace@example.com',
+);
+
+const _offline = FailureResult<envelope.Page<PersonSummary>>(
+  Failure(kind: FailureKind.network, errors: <String>[]),
+);
+
+Result<envelope.Page<PersonSummary>> _listing(List<PersonSummary> items) =>
+    Success<envelope.Page<PersonSummary>>(
+      envelope.Page<PersonSummary>(
+        items: items,
+        pageNumber: 1,
+        pageSize: 50,
+        totalItems: items.length,
+        totalPages: 1,
+      ),
+    );
+
+const Size _compact = Size(400, 900);
+const Size _expanded = Size(1400, 900);
+
+void main() {
+  late _MockPersonRepository repository;
+  late ProviderContainer container;
+
+  void answerWith(Result<envelope.Page<PersonSummary>> result) {
+    when(
+      () => repository.listScopeAdmins(
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        excludeOwnersOfScopeId: any(named: 'excludeOwnersOfScopeId'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  ProviderContainer containerUnderTest() {
+    container = ProviderContainer(
+      overrides: <Override>[
+        personRepositoryProvider.overrideWithValue(repository),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    return container;
+  }
+
+  /// Pumps a screen whose one control opens the picker, so a test can assert
+  /// what the picker answered with as well as what it showed.
+  Future<void> pump(
+    WidgetTester tester, {
+    Size size = _expanded,
+    ThemeData? theme,
+    String? excludeOwnersOfScopeId,
+    Set<String> excludeIds = const <String>{},
+    void Function(PersonSummary?)? onChosen,
+  }) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: containerUnderTest(),
+        child: MaterialApp(
+          theme: theme ?? buildLightTheme(),
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => TextButton(
+                onPressed: () async {
+                  final chosen = await showScopeAdminPicker(
+                    context: context,
+                    excludeOwnersOfScopeId: excludeOwnersOfScopeId,
+                    excludeIds: excludeIds,
+                  );
+                  onChosen?.call(chosen);
+                },
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+  }
+
+  setUp(() {
+    repository = _MockPersonRepository();
+    answerWith(_listing(<PersonSummary>[_ada, _grace]));
+  });
+
+  test('GivenAListing_WhenRead_ThenTheCandidatesAreOffered', () async {
+    // Given
+    final container = containerUnderTest();
+
+    // When
+    await container
+        .read(scopeAdminPickerControllerProvider('').notifier)
+        .search();
+
+    // Then
+    final state =
+        container.read(scopeAdminPickerControllerProvider(''))
+            as ScopeAdminsLoaded;
+    expect(state.candidates, hasLength(2));
+  });
+
+  // One field is what a picker wants; which filter it becomes is this
+  // controller's decision, not the user's.
+  test('GivenAnAddress_WhenSearched_ThenItTravelsAsTheEmailFilter', () async {
+    // Given
+    final container = containerUnderTest();
+
+    // When
+    await container
+        .read(scopeAdminPickerControllerProvider('').notifier)
+        .search('ada@example.com');
+
+    // Then
+    verify(
+      () => repository.listScopeAdmins(
+        name: null,
+        email: 'ada@example.com',
+        excludeOwnersOfScopeId: any(named: 'excludeOwnersOfScopeId'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).called(1);
+  });
+
+  test('GivenAName_WhenSearched_ThenItTravelsAsTheNameFilter', () async {
+    // Given
+    final container = containerUnderTest();
+
+    // When
+    await container
+        .read(scopeAdminPickerControllerProvider('').notifier)
+        .search('Ada');
+
+    // Then
+    verify(
+      () => repository.listScopeAdmins(
+        name: 'Ada',
+        email: null,
+        excludeOwnersOfScopeId: any(named: 'excludeOwnersOfScopeId'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).called(1);
+  });
+
+  // AF-14c — the exclusion is the API's to apply, so it has to reach it.
+  test('GivenAScopeToExclude_WhenSearched_ThenItIsSent', () async {
+    // Given
+    final container = containerUnderTest();
+
+    // When
+    await container
+        .read(scopeAdminPickerControllerProvider('scope-1').notifier)
+        .search();
+
+    // Then
+    verify(
+      () => repository.listScopeAdmins(
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        excludeOwnersOfScopeId: 'scope-1',
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).called(1);
+  });
+
+  test('GivenNoScopeToExclude_WhenSearched_ThenNoExclusionIsSent', () async {
+    // Given
+    final container = containerUnderTest();
+
+    // When
+    await container
+        .read(scopeAdminPickerControllerProvider('').notifier)
+        .search();
+
+    // Then
+    verify(
+      () => repository.listScopeAdmins(
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        excludeOwnersOfScopeId: null,
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).called(1);
+  });
+
+  test('GivenAFailedListing_WhenRead_ThenItIsUnavailable', () async {
+    // Given
+    answerWith(_offline);
+    final container = containerUnderTest();
+
+    // When
+    await container
+        .read(scopeAdminPickerControllerProvider('').notifier)
+        .search();
+
+    // Then
+    expect(
+      container.read(scopeAdminPickerControllerProvider('')),
+      isA<ScopeAdminsUnavailable>(),
+    );
+  });
+
+  testWidgets('GivenCandidates_WhenOpened_ThenTheyAreListed', (tester) async {
+    // Given / When
+    await pump(tester);
+
+    // Then
+    expect(find.text('Ada'), findsOneWidget);
+    expect(find.text('grace@example.com'), findsOneWidget);
+  });
+
+  testWidgets('GivenACandidate_WhenChosen_ThenTheyAreAnsweredWith', (
+    tester,
+  ) async {
+    // Given
+    PersonSummary? chosen;
+    await pump(tester, onChosen: (value) => chosen = value);
+
+    // When
+    await tester.tap(find.widgetWithText(ListTile, 'Ada'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(chosen?.id, 'person-1');
+  });
+
+  testWidgets('GivenThePicker_WhenCancelled_ThenNobodyIsAnsweredWith', (
+    tester,
+  ) async {
+    // Given
+    PersonSummary? chosen;
+    var answered = false;
+    await pump(
+      tester,
+      onChosen: (value) {
+        chosen = value;
+        answered = true;
+      },
+    );
+
+    // When
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(answered, isTrue);
+    expect(chosen, isNull);
+  });
+
+  // What the calling screen has already collected is not the API's to know.
+  testWidgets('GivenAnExcludedIdentifier_WhenOpened_ThenItIsNotOffered', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, excludeIds: <String>{'person-1'});
+
+    // Then
+    expect(find.widgetWithText(ListTile, 'Ada'), findsNothing);
+    expect(find.widgetWithText(ListTile, 'Grace'), findsOneWidget);
+  });
+
+  testWidgets('GivenNobodyToOffer_WhenOpened_ThenTheEmptyStateIsShown', (
+    tester,
+  ) async {
+    // Given
+    answerWith(_listing(<PersonSummary>[]));
+
+    // When
+    await pump(tester);
+
+    // Then
+    expect(find.text('No Scope Admins to offer'), findsOneWidget);
+  });
+
+  testWidgets('GivenAQuery_WhenSubmitted_ThenTheListingIsNarrowed', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+    answerWith(_listing(<PersonSummary>[_ada]));
+
+    // When
+    await tester.enterText(find.byType(TextField), 'Ada');
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.widgetWithText(ListTile, 'Grace'), findsNothing);
+  });
+
+  // Naming an owner was possible before this listing existed, and a listing
+  // that cannot be read must not take that away.
+  testWidgets('GivenAFailedListing_WhenOpened_ThenAnIdentifierIsAccepted', (
+    tester,
+  ) async {
+    // Given
+    answerWith(_offline);
+    PersonSummary? chosen;
+    await pump(tester, onChosen: (value) => chosen = value);
+
+    // When
+    await tester.enterText(find.byType(TextField), 'person-7');
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, 'Use this identifier'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(chosen?.id, 'person-7');
+  });
+
+  testWidgets('GivenAFailedListing_WhenRetried_ThenTheCandidatesArrive', (
+    tester,
+  ) async {
+    // Given
+    answerWith(_offline);
+    await pump(tester);
+    answerWith(_listing(<PersonSummary>[_ada]));
+
+    // When
+    await tester.tap(find.widgetWithText(TextButton, 'Retry'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.widgetWithText(ListTile, 'Ada'), findsOneWidget);
+  });
+
+  testWidgets('GivenACompactWindow_WhenOpened_ThenTheCandidatesAreListed', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, size: _compact);
+
+    // Then
+    expect(find.widgetWithText(ListTile, 'Ada'), findsOneWidget);
+  });
+
+  testWidgets('GivenTheDarkTheme_WhenOpened_ThenTheCandidatesAreListed', (
+    tester,
+  ) async {
+    // Given / When
+    await pump(tester, theme: buildDarkTheme());
+
+    // Then
+    expect(find.widgetWithText(ListTile, 'Ada'), findsOneWidget);
+  });
+}

--- a/test/features/scopes/presentation/scope_create_screen_test.dart
+++ b/test/features/scopes/presentation/scope_create_screen_test.dart
@@ -9,6 +9,9 @@ import 'package:heimdall_ui/core/network/envelope.dart' as envelope;
 import 'package:heimdall_ui/core/result/result.dart';
 import 'package:heimdall_ui/core/storage/token_store.dart';
 import 'package:heimdall_ui/features/auth/presentation/session_controller.dart';
+import 'package:heimdall_ui/features/persons/domain/person.dart';
+import 'package:heimdall_ui/features/persons/domain/person_repository.dart';
+import 'package:heimdall_ui/features/profile/presentation/profile_controller.dart';
 import 'package:heimdall_ui/features/scopes/domain/scope.dart';
 import 'package:heimdall_ui/features/scopes/domain/scope_repository.dart';
 import 'package:heimdall_ui/features/scopes/presentation/scope_create_screen.dart';
@@ -17,6 +20,8 @@ import 'package:mocktail/mocktail.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockScopeRepository extends Mock implements ScopeRepository {}
+
+class _MockPersonRepository extends Mock implements PersonRepository {}
 
 String _jwt() {
   final payload = base64Url.encode(
@@ -39,12 +44,26 @@ const _created = Scope(
   ownerIds: <String>['person-1'],
 );
 
+/// The Scope Admins the picker offers.
+const _ada = PersonSummary(
+  id: 'person-1',
+  name: 'Ada',
+  email: 'ada@example.com',
+);
+
+const _grace = PersonSummary(
+  id: 'person-2',
+  name: 'Grace',
+  email: 'grace@example.com',
+);
+
 const Size _compact = Size(400, 900);
 const Size _medium = Size(800, 900);
 const Size _expanded = Size(1400, 900);
 
 void main() {
   late _MockScopeRepository repository;
+  late _MockPersonRepository persons;
   late InMemoryTokenStore store;
   late ProviderContainer container;
   late GoRouter router;
@@ -63,6 +82,7 @@ void main() {
     container = ProviderContainer(
       overrides: <Override>[
         scopeRepositoryProvider.overrideWithValue(repository),
+        personRepositoryProvider.overrideWithValue(persons),
         tokenStoreProvider.overrideWithValue(store),
       ],
     );
@@ -111,23 +131,51 @@ void main() {
     ).thenAnswer((_) async => result);
   }
 
+  /// Opens the picker and chooses [who] from it.
+  Future<void> addOwner(WidgetTester tester, String who) async {
+    await tester.tap(find.widgetWithText(OutlinedButton, 'Add owner'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(ListTile, who));
+    await tester.pumpAndSettle();
+  }
+
   Future<void> fillIn(
     WidgetTester tester, {
     String name = 'Acme',
-    String owner = 'person-1',
+    bool withOwner = true,
   }) async {
     await tester.enterText(find.widgetWithText(TextFormField, 'Name'), name);
-    await tester.enterText(
-      find.widgetWithText(TextField, 'Scope Admin identifier'),
-      owner,
-    );
     await tester.pumpAndSettle();
+
+    if (withOwner) {
+      await addOwner(tester, 'Ada');
+    }
   }
 
   setUp(() {
     SharedPreferences.setMockInitialValues(<String, Object>{});
     repository = _MockScopeRepository();
+    persons = _MockPersonRepository();
     store = InMemoryTokenStore();
+    when(
+      () => persons.listScopeAdmins(
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        excludeOwnersOfScopeId: any(named: 'excludeOwnersOfScopeId'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer(
+      (_) async => const Success<envelope.Page<PersonSummary>>(
+        envelope.Page<PersonSummary>(
+          items: <PersonSummary>[_ada, _grace],
+          pageNumber: 1,
+          pageSize: 50,
+          totalItems: 2,
+          totalPages: 1,
+        ),
+      ),
+    );
     when(
       () => repository.list(
         name: any(named: 'name'),
@@ -212,7 +260,7 @@ void main() {
     // Given
     answerCreateWith(const Success<Scope>(_created));
     await pump(tester);
-    await fillIn(tester, owner: '');
+    await fillIn(tester, withOwner: false);
 
     // When
     await tester.tap(find.widgetWithText(FilledButton, 'Create scope'));
@@ -232,7 +280,7 @@ void main() {
     // Given
     answerCreateWith(const Success<Scope>(_created));
     await pump(tester);
-    await fillIn(tester, owner: '');
+    await fillIn(tester, withOwner: false);
 
     // When
     await tester.tap(find.widgetWithText(FilledButton, 'Create scope'));
@@ -242,36 +290,74 @@ void main() {
     expect(find.text('No owners added yet.'), findsOneWidget);
   });
 
-  testWidgets('GivenAnOwnerIdentifier_WhenAdded_ThenAChipIsShown', (
+  testWidgets('GivenAChosenScopeAdmin_WhenAdded_ThenAChipNamesThem', (
     tester,
   ) async {
     // Given
     answerCreateWith(const Success<Scope>(_created));
     await pump(tester);
-    await fillIn(tester, owner: 'person-7');
 
     // When
-    await tester.tap(find.byTooltip('Add owner'));
-    await tester.pumpAndSettle();
+    await addOwner(tester, 'Ada');
 
     // Then
-    expect(find.widgetWithText(InputChip, 'person-7'), findsOneWidget);
+    expect(find.widgetWithText(InputChip, 'Ada'), findsOneWidget);
   });
 
   testWidgets('GivenAnAddedOwner_WhenRemoved_ThenTheChipGoes', (tester) async {
     // Given
     answerCreateWith(const Success<Scope>(_created));
     await pump(tester);
-    await fillIn(tester, owner: 'person-7');
-    await tester.tap(find.byTooltip('Add owner'));
-    await tester.pumpAndSettle();
+    await addOwner(tester, 'Ada');
 
     // When
     await tester.tap(find.byTooltip('Remove owner'));
     await tester.pumpAndSettle();
 
     // Then
-    expect(find.widgetWithText(InputChip, 'person-7'), findsNothing);
+    expect(find.widgetWithText(InputChip, 'Ada'), findsNothing);
+  });
+
+  // The scope does not exist yet, so the API cannot leave out the owners
+  // already chosen here — the form does it.
+  testWidgets('GivenAnAddedOwner_WhenPickingAgain_ThenTheyAreNotOffered', (
+    tester,
+  ) async {
+    // Given
+    answerCreateWith(const Success<Scope>(_created));
+    await pump(tester);
+    await addOwner(tester, 'Ada');
+
+    // When
+    await tester.tap(find.widgetWithText(OutlinedButton, 'Add owner'));
+    await tester.pumpAndSettle();
+
+    // Then
+    expect(find.widgetWithText(ListTile, 'Ada'), findsNothing);
+    expect(find.widgetWithText(ListTile, 'Grace'), findsOneWidget);
+  });
+
+  testWidgets('GivenTwoChosenOwners_WhenSubmitted_ThenBothAreSent', (
+    tester,
+  ) async {
+    // Given
+    answerCreateWith(const Success<Scope>(_created));
+    await pump(tester);
+    await fillIn(tester);
+    await addOwner(tester, 'Grace');
+
+    // When
+    await tester.tap(find.widgetWithText(FilledButton, 'Create scope'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => repository.create(
+        name: 'Acme',
+        description: '',
+        ownerIds: <String>['person-1', 'person-2'],
+      ),
+    ).called(1);
   });
 
   // AF-11b — the API's own errors, with the form left as it was.

--- a/test/features/scopes/presentation/scope_owners_screen_test.dart
+++ b/test/features/scopes/presentation/scope_owners_screen_test.dart
@@ -55,6 +55,13 @@ const _alan = Person(
   role: Role.user,
 );
 
+/// A Scope Admin the picker offers, who does not already own the scope.
+const _hedy = PersonSummary(
+  id: 'person-7',
+  name: 'Hedy',
+  email: 'hedy@example.com',
+);
+
 envelope.Page<Person> _page(List<Person> items) => envelope.Page<Person>(
   items: items,
   pageNumber: 1,
@@ -62,6 +69,15 @@ envelope.Page<Person> _page(List<Person> items) => envelope.Page<Person>(
   totalItems: items.length,
   totalPages: 1,
 );
+
+envelope.Page<PersonSummary> _candidates(List<PersonSummary> items) =>
+    envelope.Page<PersonSummary>(
+      items: items,
+      pageNumber: 1,
+      pageSize: 50,
+      totalItems: items.length,
+      totalPages: 1,
+    );
 
 const Size _compact = Size(400, 900);
 const Size _medium = Size(800, 900);
@@ -153,6 +169,26 @@ void main() {
     ).thenAnswer((_) async => result);
   }
 
+  void answerAdminsWith(Result<envelope.Page<PersonSummary>> result) {
+    when(
+      () => repository.listScopeAdmins(
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        excludeOwnersOfScopeId: any(named: 'excludeOwnersOfScopeId'),
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
+    ).thenAnswer((_) async => result);
+  }
+
+  /// Opens the picker and chooses [name] from it.
+  Future<void> choose(WidgetTester tester, String name) async {
+    await tester.tap(find.widgetWithText(TextButton, 'Add existing'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(ListTile, name));
+    await tester.pumpAndSettle();
+  }
+
   setUp(() {
     SharedPreferences.setMockInitialValues(<String, Object>{});
     repository = _MockPersonRepository();
@@ -161,6 +197,11 @@ void main() {
       Success<envelope.Page<Person>>(_page(<Person>[_ada, _grace])),
     );
     answerUsersWith(Success<envelope.Page<Person>>(_page(<Person>[_alan])));
+    answerAdminsWith(
+      Success<envelope.Page<PersonSummary>>(
+        _candidates(<PersonSummary>[_hedy]),
+      ),
+    );
     when(
       () => repository.addScopeOwner(
         scopeId: any(named: 'scopeId'),
@@ -209,21 +250,42 @@ void main() {
     expect(find.widgetWithText(TextButton, 'Promote'), findsOneWidget);
   });
 
-  testWidgets('GivenAnIdentifier_WhenAdded_ThenTheApiIsAsked', (tester) async {
+  testWidgets('GivenAChosenScopeAdmin_WhenAdded_ThenTheApiIsAsked', (
+    tester,
+  ) async {
     // Given
     await pump(tester);
-    await tester.tap(find.widgetWithText(TextButton, 'Add existing'));
-    await tester.pumpAndSettle();
 
     // When
-    await tester.enterText(find.byType(TextField), 'person-7');
-    await tester.pumpAndSettle();
-    await tester.tap(find.widgetWithText(FilledButton, 'Add owner'));
-    await tester.pumpAndSettle();
+    await choose(tester, 'Hedy');
 
     // Then
     verify(
       () => repository.addScopeOwner(scopeId: 'scope-1', personId: 'person-7'),
+    ).called(1);
+  });
+
+  // AF-14c — the people who already own the scope are left out of the listing
+  // by the API, so the picker cannot offer one of them.
+  testWidgets('GivenThePicker_WhenOpened_ThenCurrentOwnersAreExcluded', (
+    tester,
+  ) async {
+    // Given
+    await pump(tester);
+
+    // When
+    await tester.tap(find.widgetWithText(TextButton, 'Add existing'));
+    await tester.pumpAndSettle();
+
+    // Then
+    verify(
+      () => repository.listScopeAdmins(
+        name: any(named: 'name'),
+        email: any(named: 'email'),
+        excludeOwnersOfScopeId: 'scope-1',
+        pageNumber: any(named: 'pageNumber'),
+        pageSize: any(named: 'pageSize'),
+      ),
     ).called(1);
   });
 
@@ -267,14 +329,9 @@ void main() {
       ),
     );
     await pump(tester);
-    await tester.tap(find.widgetWithText(TextButton, 'Add existing'));
-    await tester.pumpAndSettle();
-    await tester.enterText(find.byType(TextField), 'person-7');
-    await tester.pumpAndSettle();
 
     // When
-    await tester.tap(find.widgetWithText(FilledButton, 'Add owner'));
-    await tester.pumpAndSettle();
+    await choose(tester, 'Hedy');
 
     // Then
     expect(find.text('person-7 is not a Scope Admin.'), findsOneWidget);


### PR DESCRIPTION
Closes #68.

Consumes the two things the specification refresh in #67 added and nothing used.

## The owner picker

UI-11 and UI-14 asked for owners by *typed person identifier*, because no listing existed to choose from. `GET /api/persons/scope-admins` is that listing, so both now choose from one — a shared picker in [scope_admin_picker.dart](lib/features/persons/presentation/scope_admin_picker.dart).

One search field narrows the listing, sent as the name filter or the email filter depending on whether what was typed contains an `@`. One field is what a picker wants; two would ask the user to classify their own input before entering it.

**AF-14c** becomes true of the selector rather than only of the refusal afterwards: `ExcludeOwnersOfScopeId` means someone who already owns the scope is never offered. UI-11 has no scope to exclude from — it is creating one — so the owners already collected in the form are left out client-side instead, which the API could not do because the scope does not exist yet.

A listing that cannot be read still accepts an identifier. Naming an owner was possible before this endpoint existed and a failed picker must not take that away; the API judges what is typed exactly as it judged it before (AF-11c, AF-14b).

## The second-factor state

UI-18's facts panel now reports whether the person has a second factor, beside the role and the verification state.

The update endpoint answers with a shape that does not report one. Rather than let a rename read as "Off", `Person.withTwoFactorEnabled` carries the value already read across a save — the same reasoning the impl already applies to `isDeleted`, except that here `false` would be a guess rather than a fact.

## Specification

`FR-PE-05` gains the second-factor state; a new `FR-PE-09` records where owner candidates come from. The Use Case Specification already said "selector" for both flows and "already-listed owners are excluded from the selector" for AF-14c, so it needed no change — the implementation now matches what it always said.

## Tests

956 total, up from 929. Sixteen cover the picker on its own (both filters, the exclusion, choosing, cancelling, the empty state, the failure fallback and its retry, compact and dark). The rest update UI-11's and UI-14's screen tests to choose from the picker instead of typing, and add UI-18's fact plus the carry-across-a-save.

`dart format --set-exit-if-changed .`, `flutter analyze` and `flutter test` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
